### PR TITLE
Token-based access for Azure resources

### DIFF
--- a/cloudbridge/cloud/providers/azure/azure_client.py
+++ b/cloudbridge/cloud/providers/azure/azure_client.py
@@ -158,7 +158,7 @@ class AzureClient(object):
             tenant=config.get('azure_tenant')
         )
 
-        self._access_token = config.get('access_token')
+        self._access_token = config.get('azure_access_token')
         self._resource_client = None
         self._storage_client = None
         self._network_management_client = None

--- a/cloudbridge/cloud/providers/azure/azure_client.py
+++ b/cloudbridge/cloud/providers/azure/azure_client.py
@@ -158,7 +158,7 @@ class AzureClient(object):
             tenant=config.get('azure_tenant')
         )
 
-        self._resource_client = None
+        self._access_token = config.get('access_token')
         self._resource_client = None
         self._storage_client = None
         self._network_management_client = None

--- a/cloudbridge/cloud/providers/azure/azure_client.py
+++ b/cloudbridge/cloud/providers/azure/azure_client.py
@@ -255,8 +255,8 @@ class AzureClient(object):
                     token_credential=token_credential)
             else:
                 self._block_blob_service = BlockBlobService(
-                    self.storage_account,
-                    self.access_key_result.keys[0].value)
+                    account_name=self.storage_account,
+                    account_key=self.access_key_result.keys[0].value)
         return self._block_blob_service
 
     @property

--- a/cloudbridge/cloud/providers/azure/azure_client.py
+++ b/cloudbridge/cloud/providers/azure/azure_client.py
@@ -12,6 +12,7 @@ from azure.mgmt.resource.subscriptions import SubscriptionClient
 from azure.mgmt.storage import StorageManagementClient
 from azure.storage.blob import BlobPermissions
 from azure.storage.blob import BlockBlobService
+from azure.storage.common import TokenCredential
 
 from cloudbridge.cloud.interfaces.exceptions import WaitStateException
 
@@ -158,6 +159,7 @@ class AzureClient(object):
         )
 
         self._resource_client = None
+        self._resource_client = None
         self._storage_client = None
         self._network_management_client = None
         self._subscription_client = None
@@ -246,9 +248,15 @@ class AzureClient(object):
     @property
     def blob_service(self):
         if not self._block_blob_service:
-            self._block_blob_service = BlockBlobService(
-                self.storage_account,
-                self.access_key_result.keys[0].value)
+            if self._access_token:
+                token_credential = TokenCredential(self._access_token)
+                self._block_blob_service = BlockBlobService(
+                    account_name=self.storage_account,
+                    token_credential=token_credential)
+            else:
+                self._block_blob_service = BlockBlobService(
+                    self.storage_account,
+                    self.access_key_result.keys[0].value)
         return self._block_blob_service
 
     @property

--- a/cloudbridge/cloud/providers/azure/provider.py
+++ b/cloudbridge/cloud/providers/azure/provider.py
@@ -32,6 +32,8 @@ class AzureCloudProvider(BaseCloudProvider):
             'azure_tenant', os.environ.get('AZURE_TENANT', None))
 
         # optional config values
+        self.access_token = self._get_config_value(
+            'azure_access_token', os.environ.get('AZURE_ACCESS_TOKEN', None))
         self.region_name = self._get_config_value(
             'azure_region_name', os.environ.get('AZURE_REGION_NAME',
                                                 'eastus'))
@@ -98,7 +100,8 @@ class AzureCloudProvider(BaseCloudProvider):
                 'azure_resource_group': self.resource_group,
                 'azure_storage_account': self.storage_account,
                 'azure_public_key_storage_table_name':
-                    self.public_key_storage_table_name
+                    self.public_key_storage_table_name,
+                'azure_access_token': self.access_token
             }
 
             self._azure_client = AzureClient(provider_config)


### PR DESCRIPTION
If user provides an optional `access_token`, an instance of `BlockBlobService` is created using this token. The `ServicePrincipalCredentials` automatically creates an access token (`self._credentials.token`), and it follows a very similar logic to `CloudAuthz` to create this token: 

https://github.com/Azure/msrestazure-for-python/blob/2ab56d8f24042fe4d5511ba05550ac004e685d3d/msrestazure/azure_active_directory.py#L362-L368

https://github.com/galaxyproject/cloudauthz/blob/2ee68ab187661136e3f0640e1bc1225b201e6441/cloudauthz/providers/azure.py#L20-L26

However, `ServicePrincipalCredentials` makes some changes to the generated token (see [these lines](https://github.com/Azure/msrestazure-for-python/blob/2ab56d8f24042fe4d5511ba05550ac004e685d3d/msrestazure/azure_active_directory.py#L171-L174)), and CloudAuthz does not change generated token. Hence, I have not been able to use the token generate by `ServicePrincipalCredentials` to read/write to Azure blob storage. Therefore, in this PR I'm relying on the token user passes to cloudbridge. 

An example of a payload with `access_token` is as the following:
```python
config = {
    'azure_subscription_id': "...", 
    'azure_client_id': "...",
    'azure_secret': "...",
    'azure_tenant': "...",
    'azure_storage_account': '...',
    'azure_resource_group': '...',
    'azure_access_token': '...'}
```