### PR TITLE
Azure updates

### DIFF
--- a/cloudbridge/cloud/providers/azure/azure_client.py
+++ b/cloudbridge/cloud/providers/azure/azure_client.py
@@ -80,6 +80,7 @@ VOLUME_RESOURCE_ID = ['/subscriptions/{subscriptionId}/resourceGroups/'
                       'disks/{diskName}',
                       '{diskName}']
 
+RES_GROUP_NAME = 'resourceGroupName'
 IMAGE_NAME = 'imageName'
 NETWORK_NAME = 'virtualNetworkName'
 NETWORK_INTERFACE_NAME = 'networkInterfaceName'
@@ -577,7 +578,8 @@ class AzureClient(object):
                                          version=url_params['version'])
         else:
             name = url_params.get(IMAGE_NAME)
-            return self.compute_client.images.get(self.resource_group, name)
+            res_group = url_params.get(RES_GROUP_NAME, self.resource_group)
+            return self.compute_client.images.get(res_group, name)
 
     def update_image_tags(self, image_id, tags):
         url_params = azure_helpers.parse_url(IMAGE_RESOURCE_ID,

--- a/cloudbridge/cloud/providers/azure/resources.py
+++ b/cloudbridge/cloud/providers/azure/resources.py
@@ -1247,6 +1247,7 @@ class AzureSubnet(BaseSubnet):
 
     def delete(self):
         self._provider.azure_client.delete_subnet(self.id)
+        self._network._remove_sn_label(self._subnet.name)
 
     @property
     def state(self):

--- a/cloudbridge/cloud/providers/azure/services.py
+++ b/cloudbridge/cloud/providers/azure/services.py
@@ -1035,8 +1035,9 @@ class AzureSubnetService(BaseSubnetService):
         return subnet
 
     def delete(self, subnet):
-        subnet_id = subnet.id if isinstance(subnet, Subnet) else subnet
-        self.provider.azure_client.delete_subnet(subnet_id)
+        cb_subnet = subnet if isinstance(subnet, Subnet) else \
+            self._provider.networking.subnets.get(subnet)
+        cb_subnet.delete()
 
 
 class AzureRouterService(BaseRouterService):


### PR DESCRIPTION
-Unlike other resources, images can be shared between resource groups, thus I changed the image get method to parse both resource group name and image name, in case the ID points to a different resource group.
-Subnet labels are stored in Network tags because subnets don't support tags themselves. In order to avoid reaching the 15 tag limit per resource, subnet labels now share the same tag, up to the character limit, after which they start using a new tag.