### PR TITLE
Label exception message (Sentry bugs 293976-9)

### DIFF
--- a/cloudbridge/cloud/base/resources.py
+++ b/cloudbridge/cloud/base/resources.py
@@ -86,8 +86,8 @@ class BaseCloudResource(CloudResource):
             raise InvalidLabelException(
                 u"Invalid label: %s. Label must be at least 3 characters long"
                 " and at most 63 characters. It must consist of lowercase"
-                " letters, numbers, or dashes. The label must not start or"
-                " end with a dash." % name)
+                " letters, numbers, or dashes. The label must start with a "
+                "letter and not end with a dash." % name)
 
     @staticmethod
     def assert_valid_resource_name(name):


### PR DESCRIPTION
Changing error message to reflect current regex (^[a-z][-a-z0-9]{1,61}[a-z0-9]$).
Related to Sentry bugs [293976](https://sentry.galaxyproject.org/sentry/cloudlaunch/issues/293976/)-[7](https://sentry.galaxyproject.org/sentry/cloudlaunch/issues/293977/)-[8](https://sentry.galaxyproject.org/sentry/cloudlaunch/issues/293978/)-[9](https://sentry.galaxyproject.org/sentry/cloudlaunch/issues/293979/).