### PR TITLE
Remove Bunch requirement

### DIFF
--- a/cloudbridge/cloud/factory.py
+++ b/cloudbridge/cloud/factory.py
@@ -124,9 +124,9 @@ class CloudProviderFactory(object):
         :param name: Cloud provider name: one of ``aws``, ``openstack``,
         ``azure``.
 
-        :type config: an object with required fields
-        :param config: This can be a Bunch or any other object whose fields can
-                       be accessed using dot notation. See specific provider
+        :type config: :class:`dict`
+        :param config: A dictionary or an iterable of key/value pairs (as tuples
+                       or other iterables of length two). See specific provider
                        implementation for the required fields.
 
         :return:  a concrete provider instance

--- a/cloudbridge/cloud/interfaces/provider.py
+++ b/cloudbridge/cloud/interfaces/provider.py
@@ -18,10 +18,10 @@ class CloudProvider(object):
 
         :type config: :class:`dict`
         :param config: A dictionary object containing provider initialization
-                       values. Alternatively, this can be a Bunch or any other
-                       object whose fields can be accessed as members. See
-                       specific provider implementation for the required
-                       fields.
+                       values. Alternatively, this can be an iterable of
+                       key/value pairs (as tuples or other iterables of length
+                       two). See specific provider implementation for the
+                       required fields.
 
         :rtype: :class:`.CloudProvider`
         :return:  a concrete provider instance

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,6 @@ with open(os.path.join('cloudbridge', '__init__.py')) as f:
             break
 
 REQS_BASE = [
-    'bunch>=1.0.1',
     'six>=1.11',
     'tenacity>=4.12.0,<=5.0',
     'cachetools>=2.1.0',


### PR DESCRIPTION
The `Bunch` package is unmaintained and not Python3-compatible, and is not used any more by CloudBridge.

Also, `config` needs to be any object accepted by `dict.update()`, fix the
documentation.