### PR TITLE
Adding optional tag to provider creation

### DIFF
--- a/cloudbridge/cloud/base/provider.py
+++ b/cloudbridge/cloud/base/provider.py
@@ -83,12 +83,13 @@ class BaseConfiguration(Configuration):
 
 
 class BaseCloudProvider(CloudProvider):
-    def __init__(self, config):
+    def __init__(self, config, tag):
         self._config = BaseConfiguration(config)
         self._config_parser = ConfigParser()
         self._config_parser.read(CloudBridgeConfigLocations)
         self._middleware = SimpleMiddlewareManager()
         self.add_required_middleware()
+        self.tag = tag
 
     @property
     def config(self):
@@ -165,6 +166,9 @@ class BaseCloudProvider(CloudProvider):
 
         :return: a configuration value for the supplied ``key``
         """
+        prov_id = self.PROVIDER_ID
+        if self.tag:
+            prov_id = "-".join((prov_id, self.tag))
         log.debug("Getting config key %s, with supplied default value: %s",
                   key, default_value)
         value = default_value
@@ -172,9 +176,9 @@ class BaseCloudProvider(CloudProvider):
             value = self.config.get(key, default_value)
         elif hasattr(self.config, key) and getattr(self.config, key):
             value = getattr(self.config, key)
-        elif (self._config_parser.has_option(self.PROVIDER_ID, key) and
-              self._config_parser.get(self.PROVIDER_ID, key)):
-            value = self._config_parser.get(self.PROVIDER_ID, key)
+        elif (self._config_parser.has_option(prov_id, key) and
+              self._config_parser.get(prov_id, key)):
+            value = self._config_parser.get(prov_id, key)
         if isinstance(value, six.string_types) and not isinstance(
                 value, six.text_type):
             return six.u(value)

--- a/cloudbridge/cloud/factory.py
+++ b/cloudbridge/cloud/factory.py
@@ -108,7 +108,7 @@ class CloudProviderFactory(object):
         log.debug("List of available providers: %s", self.provider_list)
         return self.provider_list
 
-    def create_provider(self, name, config):
+    def create_provider(self, name, config, tag=None):
         """
         Searches all available providers for a CloudProvider interface with the
         given name, and instantiates it based on the given config dictionary,
@@ -127,7 +127,10 @@ class CloudProviderFactory(object):
         :return:  a concrete provider instance
         :rtype: ``object`` of :class:`.CloudProvider`
         """
-        log.info("Creating '%s' provider", name)
+        if not tag:
+            log.info("Creating default '%s' provider", name)
+        else:
+            log.info("Creating '%s' provider with tag '%s'", name, tag)
         provider_class = self.get_provider_class(name)
         if provider_class is None:
             log.exception("A provider with the name %s could not "
@@ -136,7 +139,7 @@ class CloudProviderFactory(object):
                 'A provider with name {0} could not be'
                 ' found'.format(name))
         log.debug("Created '%s' provider", name)
-        return provider_class(config)
+        return provider_class(config, tag)
 
     def get_provider_class(self, name):
         """

--- a/cloudbridge/cloud/providers/aws/provider.py
+++ b/cloudbridge/cloud/providers/aws/provider.py
@@ -17,8 +17,8 @@ class AWSCloudProvider(BaseCloudProvider):
     PROVIDER_ID = 'aws'
     AWS_INSTANCE_DATA_DEFAULT_URL = "http://cloudve.org/cb-aws-vmtypes.json"
 
-    def __init__(self, config):
-        super(AWSCloudProvider, self).__init__(config)
+    def __init__(self, config, tag):
+        super(AWSCloudProvider, self).__init__(config, tag)
 
         # Initialize cloud connection fields
         # These are passed as-is to Boto

--- a/cloudbridge/cloud/providers/azure/provider.py
+++ b/cloudbridge/cloud/providers/azure/provider.py
@@ -23,8 +23,8 @@ log = logging.getLogger(__name__)
 class AzureCloudProvider(BaseCloudProvider):
     PROVIDER_ID = 'azure'
 
-    def __init__(self, config):
-        super(AzureCloudProvider, self).__init__(config)
+    def __init__(self, config, tag):
+        super(AzureCloudProvider, self).__init__(config, tag)
 
         # mandatory config values
         self.subscription_id = self._get_config_value(

--- a/cloudbridge/cloud/providers/gce/provider.py
+++ b/cloudbridge/cloud/providers/gce/provider.py
@@ -196,8 +196,8 @@ class GCECloudProvider(BaseCloudProvider):
 
     PROVIDER_ID = 'gce'
 
-    def __init__(self, config):
-        super(GCECloudProvider, self).__init__(config)
+    def __init__(self, config, tag):
+        super(GCECloudProvider, self).__init__(config, tag)
 
         # Disable warnings about file_cache not being available when using
         # oauth2client >= 4.0.0.

--- a/cloudbridge/cloud/providers/openstack/provider.py
+++ b/cloudbridge/cloud/providers/openstack/provider.py
@@ -31,8 +31,8 @@ class OpenStackCloudProvider(BaseCloudProvider):
 
     PROVIDER_ID = 'openstack'
 
-    def __init__(self, config):
-        super(OpenStackCloudProvider, self).__init__(config)
+    def __init__(self, config, tag):
+        super(OpenStackCloudProvider, self).__init__(config, tag)
 
         # Initialize cloud connection fields
         self.username = self._get_config_value(


### PR DESCRIPTION
The idea behind this is to add support for multiple configurations of the same provider.
This simple implementation allows tagging of configurations, and then uses that tag, when available, to parse from the config file. This would solve the multi-regionality/zone issues, as we can fix each provider to one region/zone and mandate the configuration (xref: https://github.com/CloudVE/cloudbridge/issues/54), and also allows to have multiple providers for multiple RG's on Azure, as well as using multiple openstack clouds:

Example config file:
```
[azure]
azure_subscription_id: mysub
azure_tenant: mytenant
azure_client_id: myclient
azure_secret: mysecret
azure_resource_group: GALAXY-MAHMOUD
azure_storage_account: gxymahmoud

[azure-dev]
azure_subscription_id: mysub
azure_tenant: mytenant
azure_client_id: myclient
azure_secret: mysecret
azure_resource_group: GALAXY-DEV
azure_storage_account: gxymahmoud
```
Example code:
```
az_mahmoud = CloudProviderFactory().create_provider(ProviderList.AZURE, {})
az_dev = CloudProviderFactory().create_provider(ProviderList.AZURE, {}, tag='dev')
```
P.S.: Only tested on Azure so far, and it works with this simple change, can make sure all other configs get parsed by the helper and it should work everywhere, and can pursue this more seriously over the weekend if people believe it's a good thing to do

Some of the things I thought would also be good to add, if people think this is a good idea to pursue:
- [ ] Automatic inheritance (i.e. only set the `azure_resource_group` in the second in this example, and inherit the rest from either main, or the previous found in the same provider for mandatory variables, depending on how we want to do it)
- [ ] Tagging ENV variables as well

A related idea:
- Allow for adding middleware/event handlers in the provider factory, that would get inherited by each provider. This would allow a user to create a factory, extend it as they wish, then create multiple provider instances holding those changes rather than having to apply it to each provider.