### PR TITLE
[WIP] Move zone to provider

### DIFF
--- a/cloudbridge/cloud/base/provider.py
+++ b/cloudbridge/cloud/base/provider.py
@@ -89,6 +89,19 @@ class BaseCloudProvider(CloudProvider):
         self._config_parser.read(CloudBridgeConfigLocations)
         self._middleware = SimpleMiddlewareManager()
         self.add_required_middleware()
+        self._region_name = None
+        self._zone_name = None
+
+    @property
+    def region_name(self):
+        return self._region_name
+
+    @property
+    def zone_name(self):
+        if not self._zone_name:
+            region = self.compute.regions.get(self.region_name)
+            self._zone_name = next(region.zones)
+        return self._zone_name
 
     @property
     def config(self):
@@ -152,7 +165,7 @@ class BaseCloudProvider(CloudProvider):
                  service_type)
         return False
 
-    def _get_config_value(self, key, default_value):
+    def _get_config_value(self, key, default_value=None):
         """
         A convenience method to extract a configuration value.
 

--- a/cloudbridge/cloud/base/provider.py
+++ b/cloudbridge/cloud/base/provider.py
@@ -101,7 +101,8 @@ class BaseCloudProvider(CloudProvider):
         if not self._zone_name:
             region = self.compute.regions.get(self.region_name)
             # TODO: Default zone
-            self._zone_name = next(iter(region.zones))
+            zone = next(iter(region.zones))
+            self._zone_name = zone.name if zone else None
         return self._zone_name
 
     @property

--- a/cloudbridge/cloud/base/provider.py
+++ b/cloudbridge/cloud/base/provider.py
@@ -100,7 +100,8 @@ class BaseCloudProvider(CloudProvider):
     def zone_name(self):
         if not self._zone_name:
             region = self.compute.regions.get(self.region_name)
-            self._zone_name = next(region.zones)
+            # TODO: Default zone
+            self._zone_name = next(iter(region.zones))
         return self._zone_name
 
     @property

--- a/cloudbridge/cloud/base/services.py
+++ b/cloudbridge/cloud/base/services.py
@@ -307,7 +307,7 @@ class BaseSubnetService(
         matches = cb_helpers.generic_find(filters, kwargs, obj_list)
         return ClientPagedResultList(self._provider, list(matches))
 
-    def get_or_create_default(self, zone):
+    def get_or_create_default(self):
         # Look for a CB-default subnet
         matches = self.find(label=BaseSubnet.CB_DEFAULT_SUBNET_LABEL)
         if matches:
@@ -316,7 +316,7 @@ class BaseSubnetService(
         # No provider-default Subnet exists, try to create it (net + subnets)
         network = self.provider.networking.networks.get_or_create_default()
         subnet = self.create(BaseSubnet.CB_DEFAULT_SUBNET_LABEL, network,
-                             BaseSubnet.CB_DEFAULT_SUBNET_IPV4RANGE, zone)
+                             BaseSubnet.CB_DEFAULT_SUBNET_IPV4RANGE)
         return subnet
 
 

--- a/cloudbridge/cloud/base/subservices.py
+++ b/cloudbridge/cloud/base/subservices.py
@@ -159,10 +159,10 @@ class BaseSubnetSubService(SubnetSubService, BasePageableObjectMixin):
         return self._provider.networking.subnets.find(network=self.network,
                                                       **kwargs)
 
-    def create(self, label, cidr_block, zone):
+    def create(self, label, cidr_block):
         return self._provider.networking.subnets.create(label,
                                                         self.network,
-                                                        cidr_block, zone)
+                                                        cidr_block)
 
     def delete(self, subnet):
         return self._provider.networking.subnets.delete(subnet)

--- a/cloudbridge/cloud/interfaces/provider.py
+++ b/cloudbridge/cloud/interfaces/provider.py
@@ -119,6 +119,29 @@ class CloudProvider(object):
         """
         pass
 
+    @abstractproperty
+    def region_name(self):
+        """
+        Returns the region that this provider is connected to.
+        All provider operations will take place within this region.
+
+        :rtype: ``str``
+        :return:  a zone id
+        """
+        pass
+
+    @abstractproperty
+    def zone_name(self):
+        """
+        Returns the placement zone that this provider is connected to.
+        All provider operations will take place within this zone. Placement
+        zone must be within the provider default region.
+
+        :rtype: ``str``
+        :return:  a zone id
+        """
+        pass
+
 #     @abstractproperty
 #     def account(self):
 #         """

--- a/cloudbridge/cloud/interfaces/resources.py
+++ b/cloudbridge/cloud/interfaces/resources.py
@@ -740,7 +740,7 @@ class LaunchConfig(object):
         lc.add_block_device(...)
 
         inst = provider.compute.instances.create(
-            'MyVM', image, vm_type, subnet, zone, launch_config=lc)
+            'MyVM', image, vm_type, subnet, launch_config=lc)
     """
 
     @abstractmethod
@@ -1623,12 +1623,9 @@ class Snapshot(ObjectLifeCycleMixin, LabeledCloudResource):
         pass
 
     @abstractmethod
-    def create_volume(self, placement, size=None, volume_type=None, iops=None):
+    def create_volume(self, size=None, volume_type=None, iops=None):
         """
         Create a new Volume from this Snapshot.
-
-        :type placement: ``str``
-        :param placement: The availability zone where to create the Volume.
 
         :type size: ``int``
         :param size: The size of the new volume, in GiB (optional). Defaults to

--- a/cloudbridge/cloud/interfaces/services.py
+++ b/cloudbridge/cloud/interfaces/services.py
@@ -215,9 +215,8 @@ class InstanceService(PageableObjectMixin, CloudService):
         pass
 
     @abstractmethod
-    def create(self, label, image, vm_type, subnet, zone=None,
-               key_pair=None, vm_firewalls=None, user_data=None,
-               launch_config=None,
+    def create(self, label, image, vm_type, subnet, key_pair=None,
+               vm_firewalls=None, user_data=None, launch_config=None,
                **kwargs):
         """
         Creates a new virtual machine instance.
@@ -244,14 +243,6 @@ class InstanceService(PageableObjectMixin, CloudService):
                        have proper subnet support and are not guaranteed to
                        work. Some providers (e.g. OpenStack) support a null
                        value but the behaviour is implementation specific.
-
-        :type  zone: ``Zone`` or ``str``
-        :param zone: The Zone or its id, where the instance should be placed.
-                     This parameter is provided for legacy compatibility (with
-                     classic networks).
-
-                     The subnet's placement zone will take precedence over this
-                     parameter, but in its absence, this value will be used.
 
         :type  key_pair: ``KeyPair`` or ``str``
         :param key_pair: The KeyPair object or its id, to set for the
@@ -335,7 +326,7 @@ class VolumeService(PageableObjectMixin, CloudService):
         pass
 
     @abstractmethod
-    def create(self, label, size, zone, snapshot=None, description=None):
+    def create(self, label, size, snapshot=None, description=None):
         """
         Creates a new volume.
 
@@ -344,9 +335,6 @@ class VolumeService(PageableObjectMixin, CloudService):
 
         :type  size: ``int``
         :param size: The size of the volume (in GB).
-
-        :type  zone: ``str`` or :class:`.PlacementZone` object
-        :param zone: The availability zone in which the Volume will be created.
 
         :type  snapshot: ``str`` or :class:`.Snapshot` object
         :param snapshot: An optional reference to a snapshot from which this
@@ -772,7 +760,7 @@ class SubnetService(PageableObjectMixin, CloudService):
         pass
 
     @abstractmethod
-    def create(self, label, network, cidr_block, zone):
+    def create(self, label, network, cidr_block):
         """
         Create a new subnet within the supplied network.
 
@@ -786,17 +774,13 @@ class SubnetService(PageableObjectMixin, CloudService):
         :param cidr_block: CIDR block within the Network to assign to the
                            subnet.
 
-        :type zone: ``str``
-        :param zone: A placement zone for the subnet. Some providers
-                     may not support this, in which case the value is ignored.
-
         :rtype: ``object`` of :class:`.Subnet`
         :return:  A Subnet object
         """
         pass
 
     @abstractmethod
-    def get_or_create_default(self, zone):
+    def get_or_create_default(self):
         """
         Return a default subnet for the account or create one if not found.
         This provides a convenience method for obtaining a network if you
@@ -804,9 +788,6 @@ class SubnetService(PageableObjectMixin, CloudService):
 
         A default network is one marked as such by the provider or matches the
         default label used by this library (e.g., cloudbridge-net).
-
-        :type zone: :class:`.PlacementZone` object ``str``
-        :param zone: Placement zone where to look for the subnet.
 
         :rtype: ``object`` of :class:`.Subnet`
         :return: A Subnet object

--- a/cloudbridge/cloud/interfaces/subservices.py
+++ b/cloudbridge/cloud/interfaces/subservices.py
@@ -370,7 +370,7 @@ class SubnetSubService(PageableObjectMixin):
         pass
 
     @abstractmethod
-    def create(self, label, cidr_block, zone):
+    def create(self, label, cidr_block):
         """
         Create a new subnet within the network holding this subservice.
 
@@ -380,10 +380,6 @@ class SubnetSubService(PageableObjectMixin):
         :type cidr_block: ``str``
         :param cidr_block: CIDR block within the Network to assign to the
                            subnet.
-
-        :type zone: ``str``
-        :param zone: A placement zone for the subnet. Some providers
-                     may not support this, in which case the value is ignored.
 
         :rtype: ``object`` of :class:`.Subnet`
         :return:  A Subnet object

--- a/cloudbridge/cloud/providers/aws/provider.py
+++ b/cloudbridge/cloud/providers/aws/provider.py
@@ -22,25 +22,26 @@ class AWSCloudProvider(BaseCloudProvider):
 
         # Initialize cloud connection fields
         # These are passed as-is to Boto
-        self.region_name = self._get_config_value('aws_region_name',
-                                                  'us-east-1')
+        self._region_name = self._get_config_value('aws_region_name',
+                                                   'us-east-1')
+        self._zone_name = self._get_config_value('aws_zone_name')
         self.session_cfg = {
             'aws_access_key_id': self._get_config_value(
-                'aws_access_key', get_env('AWS_ACCESS_KEY', None)),
+                'aws_access_key', get_env('AWS_ACCESS_KEY')),
             'aws_secret_access_key': self._get_config_value(
-                'aws_secret_key', get_env('AWS_SECRET_KEY', None)),
+                'aws_secret_key', get_env('AWS_SECRET_KEY')),
             'aws_session_token': self._get_config_value(
                 'aws_session_token', None)
         }
         self.ec2_cfg = {
             'use_ssl': self._get_config_value('ec2_is_secure', True),
             'verify': self._get_config_value('ec2_validate_certs', True),
-            'endpoint_url': self._get_config_value('ec2_endpoint_url', None)
+            'endpoint_url': self._get_config_value('ec2_endpoint_url')
         }
         self.s3_cfg = {
             'use_ssl': self._get_config_value('s3_is_secure', True),
             'verify': self._get_config_value('s3_validate_certs', True),
-            'endpoint_url': self._get_config_value('s3_endpoint_url', None)
+            'endpoint_url': self._get_config_value('s3_endpoint_url')
         }
 
         # service connections, lazily initialized

--- a/cloudbridge/cloud/providers/aws/resources.py
+++ b/cloudbridge/cloud/providers/aws/resources.py
@@ -590,12 +590,11 @@ class AWSSnapshot(BaseSnapshot):
             # set the status to unknown
             self._unknown_state = True
 
-    def create_volume(self, placement, size=None, volume_type=None, iops=None):
+    def create_volume(self, size=None, volume_type=None, iops=None):
         label = "from-snap-{0}".format(self.label or self.id)
         cb_vol = self._provider.storage.volumes.create(
             label=label,
             size=size,
-            zone=placement,
             snapshot=self.id)
         cb_vol.wait_till_ready()
         return cb_vol

--- a/cloudbridge/cloud/providers/aws/services.py
+++ b/cloudbridge/cloud/providers/aws/services.py
@@ -124,7 +124,7 @@ class AWSKeyPairService(BaseKeyPairService):
                 "attributes: %s" % (kwargs, 'name'))
 
         log.debug("Searching for Key Pair %s", name)
-        return self.svc.find(filter_name='key-name', filter_value=name)
+        return self.svc.find(filters={'key-name': name})
 
     @dispatch(event="provider.security.key_pairs.create",
               priority=BaseKeyPairService.STANDARD_EVENT_PRIORITY)
@@ -199,8 +199,7 @@ class AWSVMFirewallService(BaseVMFirewallService):
             raise InvalidParamException(
                 "Unrecognised parameters for search: %s. Supported "
                 "attributes: %s" % (kwargs, 'label'))
-        return self.svc.find(filter_name='tag:Name',
-                             filter_value=label)
+        return self.svc.find(filters={'tag:Name': label})
 
     @dispatch(event="provider.security.vm_firewalls.delete",
               priority=BaseVMFirewallService.STANDARD_EVENT_PRIORITY)
@@ -341,16 +340,16 @@ class AWSVolumeService(BaseVolumeService):
                 "attributes: %s" % (kwargs, 'label'))
 
         log.debug("Searching for AWS Volume Service %s", label)
-        return self.svc.find(filter_names=['tag:Name', 'availability-zone'],
-                             filter_values=[label,
-                                            self.provider.zone_name.name])
+        return self.svc.find(
+            filters={'tag:Name': label,
+                     'availability-zone': self.provider.zone_name})
 
     @dispatch(event="provider.storage.volumes.list",
               priority=BaseVolumeService.STANDARD_EVENT_PRIORITY)
     def list(self, limit=None, marker=None):
-        return self.svc.find(filter_names='availability-zone',
-                             filter_values=self.provider.zone_name.name,
-                             limit=limit, marker=marker)
+        return self.svc.find(
+            filters={'availability-zone': self.provider.zone_name},
+            limit=limit, marker=marker)
 
     @dispatch(event="provider.storage.volumes.create",
               priority=BaseVolumeService.STANDARD_EVENT_PRIORITY)
@@ -401,8 +400,7 @@ class AWSSnapshotService(BaseSnapshotService):
         obj_list = []
         if label:
             log.debug("Searching for AWS Snapshot with label %s", label)
-            obj_list.extend(self.svc.find(filter_name='tag:Name',
-                                          filter_value=label,
+            obj_list.extend(self.svc.find(filters={'tag:Name': label},
                                           OwnerIds=['self']))
         else:
             obj_list = list(self)
@@ -626,10 +624,10 @@ class AWSImageService(BaseImageService):
         if label:
             log.debug("Searching for AWS Image Service %s", label)
             obj_list = []
-            obj_list.extend(self.svc.find(filter_name='name',
-                                          filter_value=label, **extra_args))
-            obj_list.extend(self.svc.find(filter_name='tag:Name',
-                                          filter_value=label, **extra_args))
+            obj_list.extend(
+                self.svc.find(filters={'name': label}, **extra_args))
+            obj_list.extend(
+                self.svc.find(filters={'tag:Name': label}, **extra_args))
             return obj_list
         else:
             return []
@@ -795,16 +793,16 @@ class AWSInstanceService(BaseInstanceService):
                 "Unrecognised parameters for search: %s. Supported "
                 "attributes: %s" % (kwargs, 'label'))
 
-        return self.svc.find(filter_names=['tag:Name', 'availability-zone'],
-                             filter_values=[label,
-                                            self.provider.zone_name.name])
+        return self.svc.find(
+            filters={'tag:Name': label,
+                     'availability-zone': self.provider.zone_name})
 
     @dispatch(event="provider.compute.instances.list",
               priority=BaseInstanceService.STANDARD_EVENT_PRIORITY)
     def list(self, limit=None, marker=None):
-        return self.svc.find(filter_names='availability-zone',
-                             filter_values=self.provider.zone_name.name,
-                             limit=limit, marker=marker)
+        return self.svc.find(
+            filters={'availability-zone': self.provider.zone_name},
+            limit=limit, marker=marker)
 
     @dispatch(event="provider.compute.instances.delete",
               priority=BaseInstanceService.STANDARD_EVENT_PRIORITY)
@@ -945,7 +943,7 @@ class AWSNetworkService(BaseNetworkService):
                 "attributes: %s" % (kwargs, 'label'))
 
         log.debug("Searching for AWS Network Service %s", label)
-        return self.svc.find(filter_name='tag:Name', filter_value=label)
+        return self.svc.find(filters={'tag:Name': label})
 
     @dispatch(event="provider.networking.networks.create",
               priority=BaseNetworkService.STANDARD_EVENT_PRIORITY)
@@ -1007,14 +1005,14 @@ class AWSSubnetService(BaseSubnetService):
     def list(self, network=None, limit=None, marker=None):
         network_id = network.id if isinstance(network, AWSNetwork) else network
         if network_id:
-            return self.svc.find(filter_names=['vpc-id', 'availability-zone'],
-                                 filter_values=[network_id,
-                                                self.provider.zone_name.name],
-                                 limit=limit, marker=marker)
+            return self.svc.find(
+                filters={'vpc-id': network_id,
+                         'availability-zone': self.provider.zone_name},
+                limit=limit, marker=marker)
         else:
-            return self.svc.find(filter_names='availability-zone',
-                                 filter_values=self.provider.zone_name.name,
-                                 limit=limit, marker=marker)
+            return self.svc.find(
+                filters={'availability-zone': self.provider.zone_name},
+                limit=limit, marker=marker)
 
     @dispatch(event="provider.networking.subnets.find",
               priority=BaseSubnetService.STANDARD_EVENT_PRIORITY)
@@ -1028,9 +1026,9 @@ class AWSSubnetService(BaseSubnetService):
                 "attributes: %s" % (kwargs, 'label'))
 
         log.debug("Searching for AWS Subnet Service %s", label)
-        return self.svc.find(filter_names=['tag:Name', 'availability-zone'],
-                             filter_values=[label,
-                                            self.provider.zone_name.name])
+        return self.svc.find(
+            filters={'tag:Name': label,
+                     'availability-zone': self.provider.zone_name})
 
     @dispatch(event="provider.networking.subnets.create",
               priority=BaseSubnetService.STANDARD_EVENT_PRIORITY)
@@ -1184,7 +1182,7 @@ class AWSRouterService(BaseRouterService):
                 "attributes: %s" % (kwargs, 'label'))
 
         log.debug("Searching for AWS Router Service %s", label)
-        return self.svc.find(filter_name='tag:Name', filter_value=label)
+        return self.svc.find(filters={'tag:Name': label})
 
     @dispatch(event="provider.networking.routers.list",
               priority=BaseRouterService.STANDARD_EVENT_PRIORITY)
@@ -1226,8 +1224,7 @@ class AWSGatewayService(BaseGatewayService):
         # Don't filter by label because it may conflict with at least the
         # default VPC that most accounts have but that network is typically
         # without a name.
-        gtw = self.svc.find(filter_name='attachment.vpc-id',
-                            filter_value=network_id)
+        gtw = self.svc.find(filters={'attachment.vpc-id': network_id})
         if gtw:
             return gtw[0]  # There can be only one gtw attached to a VPC
         # Gateway does not exist so create one and attach to the supplied net

--- a/cloudbridge/cloud/providers/aws/services.py
+++ b/cloudbridge/cloud/providers/aws/services.py
@@ -671,12 +671,12 @@ class AWSInstanceService(BaseInstanceService):
         if subnet:
             # subnet's zone takes precedence
             zone_id = subnet.zone.id
-        if isinstance(vm_firewalls, list) and isinstance(
+        if vm_firewalls and isinstance(vm_firewalls, list) and isinstance(
                 vm_firewalls[0], VMFirewall):
             vm_firewall_ids = [fw.id for fw in vm_firewalls]
         else:
             vm_firewall_ids = vm_firewalls
-        return subnet.id, zone_id, vm_firewall_ids
+        return subnet.id if subnet else None, zone_id, vm_firewall_ids
 
     def _process_block_device_mappings(self, launch_config):
         """

--- a/cloudbridge/cloud/providers/aws/services.py
+++ b/cloudbridge/cloud/providers/aws/services.py
@@ -341,12 +341,16 @@ class AWSVolumeService(BaseVolumeService):
                 "attributes: %s" % (kwargs, 'label'))
 
         log.debug("Searching for AWS Volume Service %s", label)
-        return self.svc.find(filter_name='tag:Name', filter_value=label)
+        return self.svc.find(filter_names=['tag:Name', 'availability-zone'],
+                             filter_values=[label,
+                                            self.provider.zone_name.name])
 
     @dispatch(event="provider.storage.volumes.list",
               priority=BaseVolumeService.STANDARD_EVENT_PRIORITY)
     def list(self, limit=None, marker=None):
-        return self.svc.list(limit=limit, marker=marker)
+        return self.svc.find(filter_names='availability-zone',
+                             filter_values=self.provider.zone_name.name,
+                             limit=limit, marker=marker)
 
     @dispatch(event="provider.storage.volumes.create",
               priority=BaseVolumeService.STANDARD_EVENT_PRIORITY)
@@ -791,12 +795,16 @@ class AWSInstanceService(BaseInstanceService):
                 "Unrecognised parameters for search: %s. Supported "
                 "attributes: %s" % (kwargs, 'label'))
 
-        return self.svc.find(filter_name='tag:Name', filter_value=label)
+        return self.svc.find(filter_names=['tag:Name', 'availability-zone'],
+                             filter_values=[label,
+                                            self.provider.zone_name.name])
 
     @dispatch(event="provider.compute.instances.list",
               priority=BaseInstanceService.STANDARD_EVENT_PRIORITY)
     def list(self, limit=None, marker=None):
-        return self.svc.list(limit=limit, marker=marker)
+        return self.svc.find(filter_names='availability-zone',
+                             filter_values=self.provider.zone_name.name,
+                             limit=limit, marker=marker)
 
     @dispatch(event="provider.compute.instances.delete",
               priority=BaseInstanceService.STANDARD_EVENT_PRIORITY)
@@ -999,11 +1007,14 @@ class AWSSubnetService(BaseSubnetService):
     def list(self, network=None, limit=None, marker=None):
         network_id = network.id if isinstance(network, AWSNetwork) else network
         if network_id:
-            return self.svc.find(
-                filter_name='vpc-id', filter_value=network_id,
-                limit=limit, marker=marker)
+            return self.svc.find(filter_names=['vpc-id', 'availability-zone'],
+                                 filter_values=[network_id,
+                                                self.provider.zone_name.name],
+                                 limit=limit, marker=marker)
         else:
-            return self.svc.list(limit=limit, marker=marker)
+            return self.svc.find(filter_names='availability-zone',
+                                 filter_values=self.provider.zone_name.name,
+                                 limit=limit, marker=marker)
 
     @dispatch(event="provider.networking.subnets.find",
               priority=BaseSubnetService.STANDARD_EVENT_PRIORITY)
@@ -1017,7 +1028,9 @@ class AWSSubnetService(BaseSubnetService):
                 "attributes: %s" % (kwargs, 'label'))
 
         log.debug("Searching for AWS Subnet Service %s", label)
-        return self.svc.find(filter_name='tag:Name', filter_value=label)
+        return self.svc.find(filter_names=['tag:Name', 'availability-zone'],
+                             filter_values=[label,
+                                            self.provider.zone_name.name])
 
     @dispatch(event="provider.networking.subnets.create",
               priority=BaseSubnetService.STANDARD_EVENT_PRIORITY)

--- a/cloudbridge/cloud/providers/azure/provider.py
+++ b/cloudbridge/cloud/providers/azure/provider.py
@@ -30,17 +30,19 @@ class AzureCloudProvider(BaseCloudProvider):
         self.subscription_id = self._get_config_value(
             'azure_subscription_id', get_env('AZURE_SUBSCRIPTION_ID'))
         self.client_id = self._get_config_value(
-            'azure_client_id', get_env('AZURE_CLIENT_ID', None))
+            'azure_client_id', get_env('AZURE_CLIENT_ID'))
         self.secret = self._get_config_value(
-            'azure_secret', get_env('AZURE_SECRET', None))
+            'azure_secret', get_env('AZURE_SECRET'))
         self.tenant = self._get_config_value(
-            'azure_tenant', get_env('AZURE_TENANT', None))
+            'azure_tenant', get_env('AZURE_TENANT'))
 
         # optional config values
         self.access_token = self._get_config_value(
-            'azure_access_token', get_env('AZURE_ACCESS_TOKEN', None))
-        self.region_name = self._get_config_value(
+            'azure_access_token', get_env('AZURE_ACCESS_TOKEN'))
+        self._region_name = self._get_config_value(
             'azure_region_name', get_env('AZURE_REGION_NAME', 'eastus'))
+        self._zone_name = self._get_config_value(
+            'azure_zone_name', get_env('AZURE_ZONE_NAME'))
         self.resource_group = self._get_config_value(
             'azure_resource_group', get_env('AZURE_RESOURCE_GROUP',
                                             'cloudbridge'))
@@ -59,7 +61,7 @@ class AzureCloudProvider(BaseCloudProvider):
 
         self.vm_default_user_name = self._get_config_value(
                 'azure_vm_default_username', get_env(
-                    'AZURE_VM_DEFAULT_USERNAME', None)) \
+                    'AZURE_VM_DEFAULT_USERNAME')) \
             or self.__get_deprecated_username('cbuser')
 
         self.public_key_storage_table_name = self._get_config_value(

--- a/cloudbridge/cloud/providers/azure/resources.py
+++ b/cloudbridge/cloud/providers/azure/resources.py
@@ -554,13 +554,12 @@ class AzureSnapshot(BaseSnapshot):
             # set the state to unknown
             self._state = 'unknown'
 
-    def create_volume(self, placement=None,
-                      size=None, volume_type=None, iops=None):
+    def create_volume(self, size=None, volume_type=None, iops=None):
         """
         Create a new Volume from this Snapshot.
         """
         return self._provider.storage.volumes. \
-            create(self.name, self.size, zone=placement, snapshot=self)
+            create(self.name, self.size, snapshot=self)
 
 
 class AzureMachineImage(BaseMachineImage):

--- a/cloudbridge/cloud/providers/gcp/provider.py
+++ b/cloudbridge/cloud/providers/gcp/provider.py
@@ -221,12 +221,11 @@ class GCPCloudProvider(BaseCloudProvider):
         if self.credentials_file and not self.credentials_dict:
             with open(self.credentials_file) as creds_file:
                 self.credentials_dict = json.load(creds_file)
-        self.default_zone = self._get_config_value(
-            'gcp_default_zone',
-            os.environ.get('GCP_DEFAULT_ZONE') or 'us-central1-a')
-        self.region_name = self._get_config_value(
+        self._region_name = self._get_config_value(
             'gcp_region_name',
             os.environ.get('GCP_DEFAULT_REGION') or 'us-central1')
+        self._zone_name = self._get_config_value(
+            'gcp_zone_name', os.environ.get('GCP_ZONE_NAME'))
 
         if self.credentials_dict and 'project_id' in self.credentials_dict:
             self.project_name = self.credentials_dict['project_id']
@@ -281,7 +280,7 @@ class GCPCloudProvider(BaseCloudProvider):
                     self.gcp_compute,
                     project=self.project_name,
                     region=self.region_name,
-                    zone=self.default_zone)
+                    zone=self.zone_name)
         return self._compute_resources_cache
 
     @property

--- a/cloudbridge/cloud/providers/gcp/resources.py
+++ b/cloudbridge/cloud/providers/gcp/resources.py
@@ -1870,7 +1870,7 @@ class GCPSnapshot(BaseSnapshot):
             # snapshot no longer exists
             self._snapshot['status'] = SnapshotState.UNKNOWN
 
-    def create_volume(self, placement, size=None, volume_type=None, iops=None):
+    def create_volume(self, size=None, volume_type=None, iops=None):
         """
         Create a new Volume from this Snapshot.
 
@@ -1882,9 +1882,7 @@ class GCPSnapshot(BaseSnapshot):
                 'pd-ssd'.
             iops: Not supported by GCP.
         """
-        zone_name = placement
-        if isinstance(placement, GCPPlacementZone):
-            zone_name = placement.name
+        zone_name = self._provider.zone_name
         vol_type = 'zones/{0}/diskTypes/{1}'.format(
             zone_name,
             'pd-standard' if (volume_type != 'pd-standard' or

--- a/cloudbridge/cloud/providers/openstack/provider.py
+++ b/cloudbridge/cloud/providers/openstack/provider.py
@@ -36,22 +36,24 @@ class OpenStackCloudProvider(BaseCloudProvider):
 
         # Initialize cloud connection fields
         self.username = self._get_config_value(
-            'os_username', get_env('OS_USERNAME', None))
+            'os_username', get_env('OS_USERNAME'))
         self.password = self._get_config_value(
-            'os_password', get_env('OS_PASSWORD', None))
+            'os_password', get_env('OS_PASSWORD'))
         self.project_name = self._get_config_value(
-            'os_project_name', get_env('OS_PROJECT_NAME', None)
-            or get_env('OS_TENANT_NAME', None))
+            'os_project_name', get_env('OS_PROJECT_NAME')
+            or get_env('OS_TENANT_NAME'))
         self.auth_url = self._get_config_value(
-            'os_auth_url', get_env('OS_AUTH_URL', None))
-        self.region_name = self._get_config_value(
-            'os_region_name', get_env('OS_REGION_NAME', None))
+            'os_auth_url', get_env('OS_AUTH_URL'))
+        self._region_name = self._get_config_value(
+            'os_region_name', get_env('OS_REGION_NAME'))
+        self._zone_name = self._get_config_value(
+            'os_zone_name', get_env('OS_ZONE_NAME'))
         self.project_domain_name = self._get_config_value(
             'os_project_domain_name',
-            get_env('OS_PROJECT_DOMAIN_NAME', None))
+            get_env('OS_PROJECT_DOMAIN_NAME'))
         self.user_domain_name = self._get_config_value(
             'os_user_domain_name',
-            get_env('OS_USER_DOMAIN_NAME', None))
+            get_env('OS_USER_DOMAIN_NAME'))
 
         # Service connections, lazily initialized
         self._nova = None

--- a/cloudbridge/cloud/providers/openstack/resources.py
+++ b/cloudbridge/cloud/providers/openstack/resources.py
@@ -751,7 +751,7 @@ class OpenStackSnapshot(BaseSnapshot):
             # set the status to unknown
             self._snapshot.status = 'unknown'
 
-    def create_volume(self, placement, size=None, volume_type=None, iops=None):
+    def create_volume(self, size=None, volume_type=None, iops=None):
         """
         Create a new Volume from this Snapshot.
         """
@@ -759,7 +759,7 @@ class OpenStackSnapshot(BaseSnapshot):
         self.assert_valid_resource_label(vol_label)
         size = size if size else self._snapshot.size
         os_vol = self._provider.cinder.volumes.create(
-            size, name=vol_label, availability_zone=placement,
+            size, name=vol_label, availability_zone=self._provider.zone_name,
             snapshot_id=self._snapshot.id)
         cb_vol = OpenStackVolume(self._provider, os_vol)
         return cb_vol

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -87,8 +87,8 @@ Google Compute Cloud:
 
     config = {'gcp_project_name': 'project name',
               'gcp_service_creds_file': 'service_file.json',
-              'gcp_default_zone': 'us-east1-b',  # Use desired value
-              'gcp_region_name': 'us-east1'}  # Use desired value
+              'gcp_region_name': 'us-east1',  # Use desired value
+              'gcp_zone_name': 'us-east1-b'}  # Use desired value
     provider = CloudProviderFactory().create_provider(ProviderList.GCP, config)
     image_id = 'https://www.googleapis.com/compute/v1/projects/ubuntu-os-cloud/global/images/ubuntu-1804-bionic-v20181222'
 

--- a/docs/topics/block_storage.rst
+++ b/docs/topics/block_storage.rst
@@ -14,7 +14,7 @@ performed via the :class:`.VolumeService`. To start, let's create a 1GB volume.
 
 .. code-block:: python
 
-    vol = provider.storage.volumes.create('cloudbridge-vol', 1, 'us-east-1e')
+    vol = provider.storage.volumes.create('cloudbridge-vol', 1)
     vol.wait_till_ready()
     provider.storage.volumes.list()
 

--- a/docs/topics/design_decisions.rst
+++ b/docs/topics/design_decisions.rst
@@ -119,7 +119,18 @@ Resource identification, naming, and labeling
   `labels` adhere to the same restrictions - a minimum length of 3 which
   should be alphanumeric characters or dashes only. Names or labels should
   not begin or end with a dash, or have consecutive dashes.
-   
+
+Make providers single zone
+---------------------------
+
+  Allowing each operation to specify its own zone led to various complications,
+  such as the one detailed above. Ultimately, it led to an impasse with GCP,
+  which tended to require the zone for almost every operation and some of our
+  methods were not geared to do so. Therefore, by making the provider zone
+  specific, we have removed a considerable amount of complexity from both the
+  code, with no significant impact on usability, since operations generally
+  tend to be confined to the same zone. Multi-zone operations now require
+  multiple cloud provider instances.
 
   .. _63: https://github.com/CloudVE/cloudbridge/issues/63
   .. _131: https://github.com/CloudVE/cloudbridge/issues/131

--- a/docs/topics/launch.rst
+++ b/docs/topics/launch.rst
@@ -23,12 +23,11 @@ In addition, CloudBridge instances must be launched into a private subnet.
 While it is possible to create complex network configurations as shown in the
 `Private networking`_ section, if you don't particularly care in which subnet
 the instance is launched, CloudBridge provides a convenience function to
-quickly obtain a default subnet for use. We just need to supply a zone to use.
+quickly obtain a default subnet for use.
 
 .. code-block:: python
 
-    zone = provider.compute.regions.get(provider.region_name).zones[0]
-    subnet = provider.networking.subnets.get_or_create_default(zone)
+    subnet = provider.networking.subnets.get_or_create_default()
 
 When launching an instance, you can also specify several optional arguments
 such as the firewall (aka security group), a key pair, or instance user data.
@@ -44,13 +43,15 @@ if you don't have those resources under your account, take a look at the
 
 Launch an instance
 ------------------
-Once we have all the desired pieces, we'll use them to launch an instance:
+Once we have all the desired pieces, we'll use them to launch an instance.
+Note that the instance is launched in the provider's default region and zone,
+and can be overridden by changing the provider config.
 
 .. code-block:: python
 
     inst = provider.compute.instances.create(
         label='cloudbridge-vpc', image=img, vm_type=vm_type,
-        subnet=subnet, zone=zone, key_pair=kp, vm_firewalls=[fw])
+        subnet=subnet, key_pair=kp, vm_firewalls=[fw])
 
 Private networking
 ~~~~~~~~~~~~~~~~~~
@@ -73,7 +74,7 @@ that subnet.
 
     inst = provider.compute.instances.create(
         label='cloudbridge-vpc', image=img, vm_type=vm_type,
-        subnet=sn, zone=zone, key_pair=kp, vm_firewalls=[fw])
+        subnet=sn, key_pair=kp, vm_firewalls=[fw])
 
 For more information on how to create and setup a private network, take a look
 at `Networking <./networking.html>`_.
@@ -96,7 +97,7 @@ refer to :class:`.LaunchConfig`.
     inst = provider.compute.instances.create(
         label='cloudbridge-bdm', image=img,  vm_type=vm_type,
         launch_config=lc, key_pair=kp, vm_firewalls=[fw],
-        subnet=subnet, zone=zone)
+        subnet=subnet)
 
 where ``img`` is the :class:`.Image` object to use for the root volume.
 

--- a/docs/topics/networking.rst
+++ b/docs/topics/networking.rst
@@ -75,8 +75,7 @@ subnet (``/28``).
     net = provider.networking.networks.create(
         label='my-network', cidr_block='10.0.0.0/16')
     sn = net.subnets.create(label='my-subnet',
-                            cidr_block='10.0.0.0/28',
-                            zone=zone)
+                            cidr_block='10.0.0.0/28')
     router = provider.networking.routers.create(label='my-router', network=net)
     router.attach_subnet(sn)
     gateway = net.gateways.get_or_create()
@@ -91,9 +90,9 @@ The additional step that's required here is to assign a floating IP to the VM:
 
     net = provider.networking.networks.create(
         label='my-network', cidr_block='10.0.0.0/16')
-    sn = net.subnets.create(label='my-subnet', cidr_block='10.0.0.0/28', zone=zone)
+    sn = net.subnets.create(label='my-subnet', cidr_block='10.0.0.0/28')
 
-    vm = provider.compute.instances.create(label='my-inst', subnet=sn, zone=zone, ...)
+    vm = provider.compute.instances.create(label='my-inst', subnet=sn, ...)
 
     router = provider.networking.routers.create(label='my-router', network=net)
     router.attach_subnet(sn)

--- a/docs/topics/setup.rst
+++ b/docs/topics/setup.rst
@@ -86,31 +86,24 @@ AWS
 +---------------------+--------------------------------------------------------------+
 | Variable            | Description                                                  |
 +=====================+==============================================================+
+| aws_region_name     | Default region name. Default is ``us-east-1``.               |
++---------------------+--------------------------------------------------------------+
+| aws_zone_name       | Default zone name. If not specified, defaults to first zone  |
+|                     | in default region. If specified, must match default region.  |
++---------------------+--------------------------------------------------------------+
 | aws_session_token   | Session key for your AWS account (if using temporary         |
 |                     | credentials).                                                |
 +---------------------+--------------------------------------------------------------+
-| ec2_conn_path	      | Connection path. Default is ``/``.                           |
+| ec2_endpoint_url    | Endpoint to use. Default is ``ec2.us-east-1.amazonaws.com``. |
 +---------------------+--------------------------------------------------------------+
 | ec2_is_secure       | True to use an SSL connection. Default is ``True``.          |
-+---------------------+--------------------------------------------------------------+
-| ec2_port            | EC2 connection port. Does not need to be specified unless    |
-|                     | EC2 service is running on an alternative port.               |
-+---------------------+--------------------------------------------------------------+
-| ec2_region_endpoint | Endpoint to use. Default is ``ec2.us-east-1.amazonaws.com``. |
-+---------------------+--------------------------------------------------------------+
-| ec2_region_name     | Default region name. Default is ``us-east-1``.               |
 +---------------------+--------------------------------------------------------------+
 | ec2_validate_certs  | Whether to use SSL certificate verification. Default is      |
 |                     | ``False``.                                                   |
 +---------------------+--------------------------------------------------------------+
-| s3_conn_path        | Connection path. Default is ``/``.                           |
+| s3_endpoint_url     | Host connection endpoint. Default is ``s3.amazonaws.com``.   |
 +---------------------+--------------------------------------------------------------+
 | s3_is_secure        | True to use an SSL connection. Default is ``True``.          |
-+---------------------+--------------------------------------------------------------+
-| s3_host             | Host connection endpoint. Default is ``s3.amazonaws.com``.   |
-+---------------------+--------------------------------------------------------------+
-| s3_port             | Host connection port. Does not need to be specified unless   |
-|                     | S3 service is running on an alternative port.                |
 +---------------------+--------------------------------------------------------------+
 | s3_validate_certs   | Whether to use SSL certificate verification. Default is      |
 |                     | ``False``.                                                   |
@@ -130,6 +123,10 @@ Azure
 | azure_region_name                   | Default region to use for the current                    |
 |                                     | session. Default is ``eastus``.                          |
 +-------------------------------------+----------------------------------------------------------+
+| aws_zone_name                       | Default zone name. If not specified, defaults to first   |
+|                                     | zone in default region. If specified, must match default |
+|                                     | region.                                                  |
++-------------------------------------+--------------------------------------------------------------+
 | azure_resource_group                | Azure resource group to use. Default is ``cloudbridge``. |
 +-------------------------------------+----------------------------------------------------------+
 | azure_storage_account               | Azure storage account to use. Note that this value must  |
@@ -148,11 +145,12 @@ GCP
 +-------------------------+----------------------------------------------------------+
 | Variable                | Description                                              |
 +=========================+==========================================================+
-| gcp_default_zone        | Default placement zone to use for the current session.   |
-|                         | Default is ``us-central1-a``.                            |
-+-------------------------+----------------------------------------------------------+
 | gcp_region_name         | Default region to use for the current session. Default   |
 |                         | is ``us-central1``.                                      |
++-------------------------+----------------------------------------------------------+
+| gcp_zone_name           | Default zone name. If not specified, defaults to first   |
+|                         | zone in default region. If specified, must match default |
+|                         | region.                                                  |
 +-------------------------+----------------------------------------------------------+
 | gcp_vm_default_username | System user name for which supplied key pair will be     |
 |                         | placed.                                                  |
@@ -209,6 +207,8 @@ https://docs.microsoft.com/en-us/azure/role-based-access-control/overview.
 +-------------------------------------+-----------+
 | AZURE_REGION_NAME                   |           |
 +-------------------------------------+-----------+
+| AZURE_ZONE_NAME                     |           |
++-------------------------------------+-----------+
 | AZURE_RESOURCE_GROUP                |           |
 +-------------------------------------+-----------+
 | AZURE_STORAGE_ACCOUNT               |           |
@@ -226,7 +226,7 @@ GCP
 | or                     |           |
 | GCP_SERVICE_CREDS_FILE |           |
 +------------------------+-----------+
-| GCP_DEFAULT_ZONE       |           |
+| GCP_ZONE_NAME          |           |
 +------------------------+-----------+
 | GCP_PROJECT_NAME       |           |
 +------------------------+-----------+
@@ -248,6 +248,8 @@ OpenStack
 | OS_PROJECT_NAME        | ✔         |
 +------------------------+-----------+
 | OS_REGION_NAME         | ✔         |
++------------------------+-----------+
+| OS_ZONE_NAME           |           |
 +------------------------+-----------+
 | NOVA_SERVICE_NAME      |           |
 +------------------------+-----------+

--- a/test/test_block_store_service.py
+++ b/test/test_block_store_service.py
@@ -45,8 +45,7 @@ class CloudBlockStoreServiceTestCase(ProviderTestBase):
     def test_crud_volume(self):
         def create_vol(label):
             return self.provider.storage.volumes.create(
-                label, 1,
-                helpers.get_provider_test_data(self.provider, "placement"))
+                label, 1)
 
         def cleanup_vol(vol):
             if vol:
@@ -77,7 +76,7 @@ class CloudBlockStoreServiceTestCase(ProviderTestBase):
                 self.provider, label, subnet=subnet)
 
             test_vol = self.provider.storage.volumes.create(
-                label, 1, test_instance.zone_id)
+                label, 1)
             with cb_helpers.cleanup_action(lambda: test_vol.delete()):
                 test_vol.wait_till_ready()
                 test_vol.attach(test_instance, '/dev/sda2')
@@ -104,7 +103,7 @@ class CloudBlockStoreServiceTestCase(ProviderTestBase):
                 self.provider, label, subnet=subnet)
 
             test_vol = self.provider.storage.volumes.create(
-                label, 1, test_instance.zone_id, description=vol_desc)
+                label, 1, description=vol_desc)
             with cb_helpers.cleanup_action(lambda: test_vol.delete()):
                 test_vol.wait_till_ready()
                 self.assertTrue(
@@ -154,8 +153,7 @@ class CloudBlockStoreServiceTestCase(ProviderTestBase):
         # Delete everything afterwards.
         label = "cb-crudsnap-{0}".format(helpers.get_uuid())
         test_vol = self.provider.storage.volumes.create(
-            label, 1,
-            helpers.get_provider_test_data(self.provider, "placement"))
+            label, 1)
         with cb_helpers.cleanup_action(lambda: test_vol.delete()):
             test_vol.wait_till_ready()
 
@@ -193,8 +191,7 @@ class CloudBlockStoreServiceTestCase(ProviderTestBase):
     def test_snapshot_properties(self):
         label = "cb-snapprop-{0}".format(helpers.get_uuid())
         test_vol = self.provider.storage.volumes.create(
-            label, 1,
-            helpers.get_provider_test_data(self.provider, "placement"))
+            label, 1)
         with cb_helpers.cleanup_action(lambda: test_vol.delete()):
             test_vol.wait_till_ready()
             snap_label = "cb-snap-{0}".format(label)
@@ -230,14 +227,11 @@ class CloudBlockStoreServiceTestCase(ProviderTestBase):
                 # Test volume creation from a snapshot (via VolumeService)
                 sv_label = "cb-snapvol-{0}".format(test_snap.name)
                 snap_vol = self.provider.storage.volumes.create(
-                    sv_label, 1,
-                    helpers.get_provider_test_data(self.provider, "placement"),
-                    snapshot=test_snap)
+                    sv_label, 1, snapshot=test_snap)
                 with cb_helpers.cleanup_action(lambda: snap_vol.delete()):
                     snap_vol.wait_till_ready()
 
                 # Test volume creation from a snapshot (via Snapshot)
-                snap_vol2 = test_snap.create_volume(
-                    helpers.get_provider_test_data(self.provider, "placement"))
+                snap_vol2 = test_snap.create_volume()
                 with cb_helpers.cleanup_action(lambda: snap_vol2.delete()):
                     snap_vol2.wait_till_ready()

--- a/test/test_compute_service.py
+++ b/test/test_compute_service.py
@@ -241,9 +241,7 @@ class CloudComputeServiceTestCase(ProviderTestBase):
                                 " not stable enough yet")
 
         test_vol = self.provider.storage.volumes.create(
-           label, 1,
-           helpers.get_provider_test_data(self.provider,
-                                          "placement"))
+           label, 1)
         with cb_helpers.cleanup_action(lambda: test_vol.delete()):
             test_vol.wait_till_ready()
             test_snap = test_vol.create_snapshot(label=label,
@@ -332,10 +330,7 @@ class CloudComputeServiceTestCase(ProviderTestBase):
             net = self.provider.networking.networks.create(
                 label=label, cidr_block=BaseNetwork.CB_DEFAULT_IPV4RANGE)
             cidr = '10.0.1.0/24'
-            subnet = net.subnets.create(label=label, cidr_block=cidr,
-                                        zone=helpers.get_provider_test_data(
-                                                     self.provider,
-                                                     'placement'))
+            subnet = net.subnets.create(label=label, cidr_block=cidr)
             test_inst = helpers.get_test_instance(self.provider, label,
                                                   subnet=subnet)
             fw = self.provider.security.vm_firewalls.create(

--- a/test/test_image_service.py
+++ b/test/test_image_service.py
@@ -62,9 +62,7 @@ class CloudImageServiceTestCase(ProviderTestBase):
                 img_instance = self.provider.compute.instances.create(
                     img_inst_label, img,
                     helpers.get_provider_test_data(self.provider, 'vm_type'),
-                    subnet=subnet,
-                    zone=helpers.get_provider_test_data(
-                        self.provider, 'placement'))
+                    subnet=subnet)
                 img_instance.wait_till_ready()
                 self.assertIsInstance(img_instance, Instance)
                 self.assertEqual(

--- a/test/test_interface.py
+++ b/test/test_interface.py
@@ -64,7 +64,12 @@ class CloudInterfaceTestCase(ProviderTestBase):
 
     def test_provider_zone_in_region(self):
         cloned_config = self.provider.config.copy()
-        cloned_config['zone_name'] = None
+        # Just a simpler way set zone to null for any provider
+        # instead of doing it individually for each provider
+        cloned_config['aws_zone_name'] = None
+        cloned_config['azure_zone_name'] = None
+        cloned_config['gcp_zone_name'] = None
+        cloned_config['openstack_zone_name'] = None
         cloned_provider = CloudProviderFactory().create_provider(
                 self.provider.PROVIDER_ID, cloned_config)
         region = cloned_provider.compute.regions.get(
@@ -75,7 +80,12 @@ class CloudInterfaceTestCase(ProviderTestBase):
 
     def test_provider_always_has_zone(self):
         cloned_config = self.provider.config.copy()
-        cloned_config['zone_name'] = None
+        # Just a simpler way set zone to null for any provider
+        # instead of doing it individually for each provider
+        cloned_config['aws_zone_name'] = None
+        cloned_config['azure_zone_name'] = None
+        cloned_config['gcp_zone_name'] = None
+        cloned_config['openstack_zone_name'] = None
         cloned_provider = CloudProviderFactory().create_provider(
                 self.provider.PROVIDER_ID, cloned_config)
         self.assertIsNotNone(cloned_provider.zone_name)

--- a/test/test_interface.py
+++ b/test/test_interface.py
@@ -61,3 +61,21 @@ class CloudInterfaceTestCase(ProviderTestBase):
             cloned_provider = CloudProviderFactory().create_provider(
                 self.provider.PROVIDER_ID, cloned_config)
             cloned_provider.authenticate()
+
+    def test_provider_zone_in_region(self):
+        cloned_config = self.provider.config.copy()
+        cloned_config['zone_name'] = None
+        cloned_provider = CloudProviderFactory().create_provider(
+                self.provider.PROVIDER_ID, cloned_config)
+        region = cloned_provider.compute.regions.get(
+            cloned_provider.region_name)
+        matches = [zone.name for zone in region.zones
+                   if zone.name == cloned_provider.zone_name]
+        self.assertListEqual([cloned_provider.zone_name], matches)
+
+    def test_provider_always_has_zone(self):
+        cloned_config = self.provider.config.copy()
+        cloned_config['zone_name'] = None
+        cloned_provider = CloudProviderFactory().create_provider(
+                self.provider.PROVIDER_ID, cloned_config)
+        self.assertIsNotNone(cloned_provider.zone_name)

--- a/test/test_network_service.py
+++ b/test/test_network_service.py
@@ -9,7 +9,6 @@ from cloudbridge.cloud.interfaces.resources import SubnetState
 
 import test.helpers as helpers
 from test.helpers import ProviderTestBase
-from test.helpers import get_provider_test_data
 from test.helpers import standard_interface_tests as sit
 
 
@@ -91,9 +90,7 @@ class CloudNetworkServiceTestCase(ProviderTestBase):
 
             cidr = '10.0.20.0/24'
             sn = net.subnets.create(
-                label=subnet_label, cidr_block=cidr,
-                zone=helpers.get_provider_test_data(self.provider,
-                                                    'placement'))
+                label=subnet_label, cidr_block=cidr)
             with cb_helpers.cleanup_action(lambda: helpers.cleanup_subnet(sn)):
                 self.assertTrue(
                     sn in net.subnets,
@@ -138,9 +135,7 @@ class CloudNetworkServiceTestCase(ProviderTestBase):
 
         def create_subnet(label):
             return self.provider.networking.subnets.create(
-                label=label, network=net, cidr_block="10.0.10.0/24",
-                zone=helpers.get_provider_test_data(
-                    self.provider, 'placement'))
+                label=label, network=net, cidr_block="10.0.10.0/24")
 
         def cleanup_subnet(subnet):
             if subnet:
@@ -236,9 +231,7 @@ class CloudNetworkServiceTestCase(ProviderTestBase):
             router = self.provider.networking.routers.create(label=label,
                                                              network=net)
             cidr = '10.0.15.0/24'
-            sn = net.subnets.create(label=label, cidr_block=cidr,
-                                    zone=helpers.get_provider_test_data(
-                                        self.provider, 'placement'))
+            sn = net.subnets.create(label=label, cidr_block=cidr)
 
             # Check basic router properties
             sit.check_standard_behaviour(
@@ -275,6 +268,5 @@ class CloudNetworkServiceTestCase(ProviderTestBase):
 
     @helpers.skipIfNoService(['networking.networks'])
     def test_default_network(self):
-        subnet = self.provider.networking.subnets.get_or_create_default(
-            zone=get_provider_test_data(self.provider, 'placement'))
+        subnet = self.provider.networking.subnets.get_or_create_default()
         self.assertIsInstance(subnet, Subnet)

--- a/test/test_object_life_cycle.py
+++ b/test/test_object_life_cycle.py
@@ -17,8 +17,7 @@ class CloudObjectLifeCycleTestCase(ProviderTestBase):
         test_vol = None
         with cb_helpers.cleanup_action(lambda: test_vol.delete()):
             test_vol = self.provider.storage.volumes.create(
-                label, 1,
-                helpers.get_provider_test_data(self.provider, "placement"))
+                label, 1)
 
             # Waiting for an invalid timeout should raise an exception
             with self.assertRaises(AssertionError):


### PR DESCRIPTION
This adds a property named zone_name to all providers, in addition to region_name, and makes all provider instances zone specific. This helps to resolve: https://github.com/CloudVE/cloudbridge/issues/54 in addition to simplifying the code, because most operations tend to be confined to a single zone.

However, this does have downstream impact as the zone parameter must no longer be specified when performing zonal operations such as launching instances or creating volumes. If zone specific operations are needed, a new provider instance will be required.

When instantiating a provider, if a zone is not specified, the provider defaults to the first available zone within the provider's default region. Currently, no checks are performed to make sure that the specified default_region and default_zone match up.
