### PR TITLE
Enable passing GCP `project_id` in config.

### DIFF
--- a/cloudbridge/providers/gcp/provider.py
+++ b/cloudbridge/providers/gcp/provider.py
@@ -230,6 +230,8 @@ class GCPCloudProvider(BaseCloudProvider):
 
         if self.credentials_dict and 'project_id' in self.credentials_dict:
             self.project_name = self.credentials_dict['project_id']
+        elif self._get_config_value("project_id"):
+            self.project_name = self._get_config_value("project_id")
         else:
             self.project_name = os.environ.get('GCP_PROJECT_NAME')
 

--- a/docs/topics/setup.rst
+++ b/docs/topics/setup.rst
@@ -56,9 +56,9 @@ will override environment values.
     }
     config = {'gcp_service_creds_dict': gcp_creds}
     # A third alternative is to use a GCP credentials object provided by the GCP python
-    # sdk. This is for advanced usage scenarios.
-    # e.g. credentials = AccessTokenCredentials(access_token, "MyAgent/1.0", None)
-    config = {'gcp_credentials_obj': credentials}
+    # sdk. Using this option, the `project_id` shall also be provided via the 
+    # `config` dictionary.
+    config = {'gcp_credentials_obj': credentials, 'project_id': '<project_id>'}
     provider = CloudProviderFactory().create_provider(ProviderList.GCP, config)
 
 


### PR DESCRIPTION
The GCP backend expects the `project_id` in either credentials file/dict or from an environment variable. This PR adds a third option of passing the `project_id` via the `config` dictionary