### PR TITLE
Accepting dict for zone_name (for CL

### DIFF
--- a/cloudbridge/base/provider.py
+++ b/cloudbridge/base/provider.py
@@ -1,4 +1,5 @@
 """Base implementation of a provider interface."""
+import ast
 import functools
 import logging
 import os
@@ -102,7 +103,15 @@ class BaseCloudProvider(CloudProvider):
             region = self.compute.regions.current
             zone = region.default_zone
             self._zone_name = zone.name if zone else None
-        return self._zone_name
+            return self._zone_name
+        else:
+            try:
+                zone_dict = ast.literal_eval(self._zone_name)
+                if isinstance(zone_dict, dict):
+                    return zone_dict
+            except (ValueError, SyntaxError):
+                pass
+            return self._zone_name
 
     @property
     def config(self):

--- a/cloudbridge/providers/openstack/provider.py
+++ b/cloudbridge/providers/openstack/provider.py
@@ -290,13 +290,29 @@ class OpenStackCloudProvider(BaseCloudProvider):
 
     def service_zone_name(self, service):
         service_name = service._service_event_pattern
-        if "networking" in service_name and self.networking.service_zone_name:
-            return self.networking.service_zone_name
-        elif "security" in service_name and self.security.service_zone_name:
-            return self.security.service_zone_name
-        elif "compute" in service_name and self.compute.service_zone_name:
-            return self.compute.service_zone_name
-        elif "storage" in service_name and self.storage.service_zone_name:
-            return self.storage.service_zone_name
-        else:
+        if "networking" in service_name:
+            if self.networking.service_zone_name:
+                return self.networking.service_zone_name
+            elif isinstance(self.zone_name, dict) and self.zone_name.get("networking_zone"):
+                return self.zone_name.get("networking_zone")
+        elif "security" in service_name:
+            if self.security.service_zone_name:
+                return self.security.service_zone_name
+            elif isinstance(self.zone_name, dict) and self.zone_name.get("security_zone"):
+                return self.zone_name.get("security_zone")
+        elif "compute" in service_name:
+            if self.compute.service_zone_name:
+                return self.compute.service_zone_name
+            elif isinstance(self.zone_name, dict) and self.zone_name.get("compute_zone"):
+                return self.zone_name.get("compute_zone")
+        elif "storage" in service_name:
+            if self.storage.service_zone_name:
+                return self.storage.service_zone_name
+            elif isinstance(self.zone_name, dict) and self.zone_name.get("storage_zone"):
+                return self.zone_name.get("storage_zone")
+        elif isinstance(self.zone_name, dict) and self.zone_name.get("default_zone"):
+                return self.zone_name.get("default_zone")
+        elif isinstance(self.zone_name, str):
             return self.zone_name
+        else:
+            return None


### PR DESCRIPTION
The current cloudlaunch setup sends a zone argument to many functions (notably getting a list for the UI, for example). Although using `{'os_networking_zone_name' :'nova'}` as an additional config allows the `provider` object to be created properly, it isn't enough to bypass the zone that is being sent to functions (eg: listing networks will still look in the default `zone-r1` and the `nova` override will not take effect).
This PR extends the service-level zone-names, so that the global zone_name can be passed as a dict. Passing just a string as before will be interpreted as a default zone for all services. i.e.:
`'zone-r1'` will be equivalent to `'{'default-zone': 'zone-r1'}'`. Valid keys are: `default_zone`, `networking_zone`, `security_zone`, `compute_zone`, and `storage_zone`.
Applying this CloudBridge change along with setting the value of the default zone to `{'networking_zone': 'nova', 'default_zone': 'zone-r1'}` on CloudLaunch should fix the JetStream launch