### PR TITLE
AWS VMTypes from new APIs

### DIFF
--- a/cloudbridge/providers/aws/resources.py
+++ b/cloudbridge/providers/aws/resources.py
@@ -197,8 +197,7 @@ class AWSVMType(BaseVMType):
         ram = self._inst_dict.get('MemoryInfo')
         if ram:
             mib = ram.get('SizeInMiB', 0)
-            if mib:
-                return mib / 1024
+            return mib / 1024
         return 0
 
     @property

--- a/cloudbridge/providers/aws/resources.py
+++ b/cloudbridge/providers/aws/resources.py
@@ -171,7 +171,7 @@ class AWSVMType(BaseVMType):
 
     @property
     def id(self):
-        return str(self._inst_dict['instance_type'])
+        return str(self._inst_dict.get('InstanceType'))
 
     @property
     def name(self):
@@ -179,18 +179,27 @@ class AWSVMType(BaseVMType):
 
     @property
     def family(self):
-        return self._inst_dict.get('family')
+        # Limited to whether CurrentGeneration or not
+        curr = self._inst_dict.get('CurrentGeneration')
+        if curr:
+            return 'CurrentGeneration'
+        return None
 
     @property
     def vcpus(self):
-        vcpus = self._inst_dict.get('vCPU')
-        if vcpus == 'N/A':
-            return None
-        return vcpus
+        vcpus = self._inst_dict.get('VCpuInfo')
+        if vcpus:
+            return vcpus.get('DefaultVCpus', 0)
+        return 0
 
     @property
     def ram(self):
-        return self._inst_dict.get('memory')
+        ram = self._inst_dict.get('MemoryInfo')
+        if ram:
+            mib = ram.get('SizeInMiB', 0)
+            if mib:
+                return mib / 1024
+        return 0
 
     @property
     def size_root_disk(self):
@@ -198,24 +207,22 @@ class AWSVMType(BaseVMType):
 
     @property
     def size_ephemeral_disks(self):
-        storage = self._inst_dict.get('storage')
+        storage = self._inst_dict.get('InstanceStorageInfo')
         if storage:
-            return storage.get('size') * storage.get("devices")
-        else:
-            return 0
+            return storage.get('TotalSizeInGB', 0)
+        return 0
 
     @property
     def num_ephemeral_disks(self):
-        storage = self._inst_dict.get('storage')
+        storage = self._inst_dict.get('InstanceStorageInfo')
         if storage:
-            return storage.get("devices")
-        else:
-            return 0
+            return storage.get("Disks", {}).get("Count", 0)
+        return 0
 
     @property
     def extra_data(self):
         return {key: val for key, val in self._inst_dict.items()
-                if key not in ["instance_type", "family", "vCPU", "memory"]}
+                if key not in ["InstanceType", "VCpuInfo", "MemoryInfo"]}
 
 
 class AWSInstance(BaseInstance):

--- a/cloudbridge/providers/aws/services.py
+++ b/cloudbridge/providers/aws/services.py
@@ -5,6 +5,7 @@ import string
 import uuid
 
 from botocore.exceptions import ClientError
+
 import cloudbridge.base.helpers as cb_helpers
 from cloudbridge.base.middleware import dispatch
 from cloudbridge.base.resources import ClientPagedResultList

--- a/cloudbridge/providers/aws/services.py
+++ b/cloudbridge/providers/aws/services.py
@@ -5,11 +5,6 @@ import string
 import uuid
 
 from botocore.exceptions import ClientError
-
-import cachetools
-
-import requests
-
 import cloudbridge.base.helpers as cb_helpers
 from cloudbridge.base.middleware import dispatch
 from cloudbridge.base.resources import ClientPagedResultList
@@ -855,6 +850,7 @@ class AWSVMTypeService(BaseVMTypeService):
         next_token = vmt_list_resp.get("NextToken")
         vmt_list_names = [x.get("InstanceType")
                           for x in vmt_list_resp.get('InstanceTypeOfferings')]
+        # describe_instance_types call can get at most 100 types per request
         chunks = [vmt_list_names[x:x + 100]
                   for x in range(0, len(vmt_list_names), 100)]
         raw_types = []

--- a/cloudbridge/providers/aws/services.py
+++ b/cloudbridge/providers/aws/services.py
@@ -846,7 +846,7 @@ class AWSVMTypeService(BaseVMTypeService):
             LocationType='availability-zone',
             Filters=[{'Name': 'location',
                       'Values': [self.provider.zone_name]}],
-            **trim_empty_params({'MaxRestuls': limit, 'NextToken': marker}))
+            **trim_empty_params({'MaxResults': limit, 'NextToken': marker}))
         next_token = vmt_list_resp.get("NextToken")
         vmt_list_names = [x.get("InstanceType")
                           for x in vmt_list_resp.get('InstanceTypeOfferings')]

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,6 @@ with open(os.path.join('cloudbridge', '__init__.py')) as f:
 REQS_BASE = [
     'six>=1.11',
     'tenacity>=6.0',
-    'cachetools>=2.1.0',
     'deprecation>=2.0.7',
     'pyeventsystem<2'
 ]


### PR DESCRIPTION
Replaces: https://github.com/CloudVE/cloudbridge/pull/208 since AWS _finally_ introduced an API to get Instance Types per zone: https://aws.amazon.com/blogs/compute/it-just-got-easier-to-discover-and-compare-ec2-instance-types/