### PR TITLE
Remove azure form default installation as it's too large

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,9 @@ REQS_OPENSTACK = [
     'python-neutronclient>=6.0.0',
     'python-keystoneclient>=3.13.0'
 ]
-REQS_FULL = REQS_BASE + REQS_AWS + REQS_AZURE + REQS_GCP + REQS_OPENSTACK
+REQS_SIMPLE = REQS_BASE + REQS_AWS + REQS_GCP + REQS_OPENSTACK
+REQS_AZURE = REQS_SIMPLE + REQS_AZURE
+REQS_FULL = REQS_SIMPLE + REQS_AZURE
 # httpretty is required with/for moto 1.0.0 or AWS tests fail
 REQS_DEV = ([
     'tox>=2.1.1',
@@ -76,9 +78,10 @@ setup(
     author_email='help@genome.edu.au',
     url='http://cloudbridge.cloudve.org/',
     setup_requires=['nose>=1.0'],
-    install_requires=REQS_FULL,
+    install_requires=REQS_SIMPLE,
     extras_require={
         ':python_version<"3.3"': ['ipaddress'],
+        'azure': REQS_AZURE,
         'full': REQS_FULL,
         'dev': REQS_DEV
     },


### PR DESCRIPTION
The azure libraries take up over 100MB on disk, single-handedly doubling installation size and bloating up any containers which include cloudbridge. This is despite the fact that we've already trimmed azure dependencies to the bare minimum. This PR removes azure from default installations and makes it an optional add-on.

To install with azure:
```
pip install cloudbridge[azure]
```
or
```
pip install cloudbridge[full]
```
