### PR TITLE
Fixing wrong logging object in AWS module files

### DIFF
--- a/cloudbridge/providers/aws/helpers.py
+++ b/cloudbridge/providers/aws/helpers.py
@@ -1,5 +1,5 @@
 """A set of AWS-specific helper methods used by the framework."""
-import logging as log
+import logging
 
 from boto3.resources.params import create_request_parameters
 
@@ -9,6 +9,9 @@ from botocore.utils import merge_dicts
 
 from cloudbridge.base.resources import ClientPagedResultList
 from cloudbridge.base.resources import ServerPagedResultList
+
+
+log = logging.getLogger(__name__)
 
 
 def trim_empty_params(params_dict):

--- a/cloudbridge/providers/aws/provider.py
+++ b/cloudbridge/providers/aws/provider.py
@@ -1,5 +1,5 @@
 """Provider implementation based on boto library for AWS-compatible clouds."""
-import logging as log
+import logging
 
 import boto3
 
@@ -13,6 +13,9 @@ from .services import AWSDnsService
 from .services import AWSNetworkingService
 from .services import AWSSecurityService
 from .services import AWSStorageService
+
+
+log = logging.getLogger(__name__)
 
 
 class AWSCloudProvider(BaseCloudProvider):


### PR DESCRIPTION
Before this change, it was not able to mute or change the logging levels of these files.
Now, they will belong to the cloudbridge module, so users will be able to do something like:
`logging.getLogger('cloudbridge').setLevel(logging.INFO)` for their own use :)