### PR TITLE
Add azure_resource_group to create a provider

### DIFF
--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -79,6 +79,7 @@ Azure:
               'azure_client_id': 'REPLACE WITH ACTUAL VALUE',
               'azure_secret': 'REPLACE WITH ACTUAL VALUE',
               'azure_tenant': ' REPLACE WITH ACTUAL VALUE',
+              'azure_resource_group': 'REPLACE WITH ACTUAL VALUE',
               'azure_zone_name': 'zone_name'}
     provider = CloudProviderFactory().create_provider(ProviderList.AZURE, config)
     image_id = 'Canonical:UbuntuServer:16.04.0-LTS:latest'  # Ubuntu 16.04


### PR DESCRIPTION
This is a very small PR to add `azure_resource_group` to the create a provider page. I didn't link to the setup page since the link already exists (I just missed that when I was reading the docs, my bad!)

Not sure if you think this is still worth adding, I'm happy to make this small change in the PR that I have open if you would prefer that.

closes #280