### PR TITLE
Fix issues with upload blob, blob url and snapshots

### DIFF
--- a/cloudbridge/providers/azure/azure_client.py
+++ b/cloudbridge/providers/azure/azure_client.py
@@ -526,11 +526,12 @@ class AzureClient(object):
         return self.compute_client.snapshots.get(self.resource_group,
                                                  snapshot_name)
 
-    def create_snapshot(self, snapshot_name, params):
+    def create_snapshot(self, snapshot_name, volume, params):
         return self.compute_client.snapshots.begin_create_or_update(
             self.resource_group,
             snapshot_name,
-            params
+            volume,
+            params=params
         ).result()
 
     def delete_snapshot(self, snapshot_id):

--- a/cloudbridge/providers/azure/resources.py
+++ b/cloudbridge/providers/azure/resources.py
@@ -169,7 +169,6 @@ class AzureBucketObject(BaseBucketObject):
         else:
             self._blob_properties = self._blob_client.get_blob_properties()
 
-
     @property
     def id(self):
         return self._blob_properties.name
@@ -285,6 +284,7 @@ class AzureBucket(BaseBucket):
     @property
     def objects(self):
         return self._object_container
+
 
 class AzureVolume(BaseVolume):
     VOLUME_STATE_MAP = {

--- a/cloudbridge/providers/azure/resources.py
+++ b/cloudbridge/providers/azure/resources.py
@@ -164,7 +164,6 @@ class AzureBucketObject(BaseBucketObject):
         super(AzureBucketObject, self).__init__(provider)
         self._container = container
         self._blob_client = blob_client
-        breakpoint()
         if isinstance(self._blob_client, BlobProperties):
             self._blob_properties = blob_client
         else:

--- a/cloudbridge/providers/azure/resources.py
+++ b/cloudbridge/providers/azure/resources.py
@@ -24,6 +24,7 @@ from azure.common import AzureException
 from azure.core.exceptions import HttpResponseError
 from azure.mgmt.devtestlabs.models import GalleryImageReference
 from azure.mgmt.network.models import NetworkSecurityGroup
+from azure.storage.blob._models import BlobProperties
 
 from . import helpers as azure_helpers
 from .subservices import (AzureBucketObjectSubService,
@@ -163,21 +164,27 @@ class AzureBucketObject(BaseBucketObject):
         super(AzureBucketObject, self).__init__(provider)
         self._container = container
         self._blob_client = blob_client
+        breakpoint()
+        if isinstance(self._blob_client, BlobProperties):
+            self._blob_properties = blob_client
+        else:
+            self._blob_properties = self._blob_client.get_blob_properties()
+
 
     @property
     def id(self):
-        return self._blob_client.blob_name
+        return self._blob_properties.name
 
     @property
     def name(self):
-        return self._blob_client.blob_name
+        return self._blob_properties.name
 
     @property
     def size(self):
         """
         Get this object's size.
         """
-        return self._blob_client.get_blob_properties().content_length
+        return self._blob_properties.size
 
     @property
     def last_modified(self):
@@ -185,15 +192,14 @@ class AzureBucketObject(BaseBucketObject):
         """
         Get the date and time this object was last modified.
         """
-        return self._blob_client.get_blob_properties().last_modified. \
-            strftime("%Y-%m-%dT%H:%M:%S.%f")
+        return self._blob_properties.last_modified.strftime("%Y-%m-%dT%H:%M:%S.%f")
 
     def iter_content(self):
         """
         Returns this object's content as an
         iterable.
         """
-        return self._blob_client.download_blob.chunks()
+        return self._container._bucket.download_blob(self._blob_client).chunks()
 
     def upload(self, data):
         """
@@ -213,8 +219,10 @@ class AzureBucketObject(BaseBucketObject):
         Store the contents of the file pointed by the "path" variable.
         """
         try:
-            with open(path, "rb") as stream:
-                self._blob_client.upload_blob(stream, overwrite=True)
+            self._provider.azure_client.create_blob_from_file(
+                self._container.name, self._blob_client,
+                path
+            )
             return True
         except AzureException as azureEx:
             log.exception(azureEx)
@@ -227,7 +235,7 @@ class AzureBucketObject(BaseBucketObject):
         :rtype: bool
         :return: True if successful
         """
-        self._blob_client.delete_blob()
+        self._provider.azure_client.delete_blob(self._container.name, self.name)
 
     def generate_url(self, expires_in):
         """
@@ -278,8 +286,6 @@ class AzureBucket(BaseBucket):
     @property
     def objects(self):
         return self._object_container
-
-
 
 class AzureVolume(BaseVolume):
     VOLUME_STATE_MAP = {

--- a/cloudbridge/providers/azure/services.py
+++ b/cloudbridge/providers/azure/services.py
@@ -476,18 +476,13 @@ class AzureSnapshotService(BaseSnapshotService):
         volume = (self.provider.storage.volumes.get(volume)
                   if isinstance(volume, str) else volume)
 
-        params = {
-            'location': self.provider.azure_client.region_name,
-            'creation_data': {
-                'create_option': DiskCreateOption.copy,
-                'source_uri': volume.resource_id
-            },
-            'disk_size_gb': volume.size,
-            'tags': tags
-        }
+        # We need to pass the Disk Object to create the snapshot
+        volume = volume._volume
 
-        azure_snap = self.provider.azure_client.create_snapshot(snapshot_name,
-                                                                params)
+        azure_snap = self.provider.azure_client.create_snapshot(
+            snapshot_name,volume, tags
+        )
+
         return AzureSnapshot(self.provider, azure_snap)
 
     @dispatch(event="provider.storage.snapshots.delete",

--- a/cloudbridge/providers/azure/services.py
+++ b/cloudbridge/providers/azure/services.py
@@ -480,7 +480,7 @@ class AzureSnapshotService(BaseSnapshotService):
         volume = volume._volume
 
         azure_snap = self.provider.azure_client.create_snapshot(
-            snapshot_name,volume, tags
+            snapshot_name, volume, tags
         )
 
         return AzureSnapshot(self.provider, azure_snap)

--- a/tests/test_network_service.py
+++ b/tests/test_network_service.py
@@ -1,11 +1,8 @@
 from cloudbridge.base import helpers as cb_helpers
 from cloudbridge.base.resources import BaseNetwork
-from cloudbridge.interfaces.resources import FloatingIP
-from cloudbridge.interfaces.resources import Network
-from cloudbridge.interfaces.resources import NetworkState
-from cloudbridge.interfaces.resources import RouterState
-from cloudbridge.interfaces.resources import Subnet
-from cloudbridge.interfaces.resources import SubnetState
+from cloudbridge.interfaces.resources import (FloatingIP, Network,
+                                              NetworkState, RouterState,
+                                              Subnet, SubnetState)
 
 import tests.helpers as helpers
 from tests.helpers import ProviderTestBase


### PR DESCRIPTION
I've seeing some weird things locally and going through each bit is taking a bit too long :disappointed: 

This new PR fixes issues with the blob - I also add to add the `Storage Blob Contributor` role in order to get the objects inside a storage bucket.

Getting the signed URL was also broken so I fixed it in this PR. Creating a snapshot from a volume wasn't working anymore because `create_or_update` expects you to pass a snapshot class. This PR adds the Disk object to the API, but there are some issues, for example, I didn't yet figure out how to get the new tag into the snapshot so our fetching will be broken :disappointed: 

A note on the `AzureBucketObject`, when we are listing the objects, Azure returns a BlobProperties, but when we are getting it returns the blobclient. The easiest way to handle this was to add `self._blob_properties` to the class and use that instead