### PR TITLE
Separate the dependencies

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -64,7 +64,9 @@ Install the latest release from PyPi:
 
 .. code-block:: shell
 
-  pip install cloudbridge
+  pip install cloudbridge[aws,gcp,azure,openstack]
+
+You can remove the cloud providers not using from the dependencies.
 
 For other installation options, see the `installation page`_ in
 the documentation.

--- a/README.rst
+++ b/README.rst
@@ -64,9 +64,7 @@ Install the latest release from PyPi:
 
 .. code-block:: shell
 
-  pip install cloudbridge[aws,gcp,azure,openstack]
-
-You can remove the cloud providers not using from the dependencies.
+  pip install cloudbridge[full]
 
 For other installation options, see the `installation page`_ in
 the documentation.

--- a/docs/topics/install.rst
+++ b/docs/topics/install.rst
@@ -27,6 +27,15 @@ The development version of the library can be installed directly from the
 
     $ pip install --upgrade git+https://github.com/CloudVE/cloudbridge.git
 
+Single Provider Installation
+-----------------------------
+If you only require to integrate with one to two providers, you can install
+the particular providers only as the following.
+
+    $ pip install cloudbridge[aws,gcp]
+
+The available options are aws, azure, gcp and openstack.
+
 Developer installation
 ----------------------
 To install additional libraries required by CloudBridge contributors, such as

--- a/setup.py
+++ b/setup.py
@@ -53,9 +53,7 @@ REQS_OPENSTACK = [
     'python-neutronclient>=6.0.0,<8.0',
     'python-keystoneclient>=3.13.0,<5.0'
 ]
-REQS_SIMPLE = REQS_BASE + REQS_AWS + REQS_GCP + REQS_OPENSTACK
-REQS_AZURE = REQS_SIMPLE + REQS_AZURE
-REQS_FULL = REQS_SIMPLE + REQS_AZURE
+REQS_FULL = REQS_BASE + REQS_AWS + REQS_GCP + REQS_OPENSTACK + REQS_AZURE
 # httpretty is required with/for moto 1.0.0 or AWS tests fail
 REQS_DEV = ([
     'tox>=2.1.1',
@@ -76,10 +74,13 @@ setup(
     author_email='help@genome.edu.au',
     url='http://cloudbridge.cloudve.org/',
     setup_requires=['nose>=1.0'],
-    install_requires=REQS_SIMPLE,
+    install_requires=REQS_BASE,
     extras_require={
         ':python_version<"3.3"': ['ipaddress'],
         'azure': REQS_AZURE,
+        'gcp': REQS_GCP,
+        'aws': REQS_AWS,
+        'openstack': REQS_OPENSTACK,
         'full': REQS_FULL,
         'dev': REQS_DEV
     },

--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,7 @@ REQS_OPENSTACK = [
     'python-neutronclient>=6.0.0,<8.0',
     'python-keystoneclient>=3.13.0,<5.0'
 ]
-REQS_FULL = REQS_BASE + REQS_AWS + REQS_GCP + REQS_OPENSTACK + REQS_AZURE
+REQS_FULL = REQS_AWS + REQS_GCP + REQS_OPENSTACK + REQS_AZURE
 # httpretty is required with/for moto 1.0.0 or AWS tests fail
 REQS_DEV = ([
     'tox>=2.1.1',


### PR DESCRIPTION
Tested with `pip install .[aws,gcp]`
And here is the output for `pip freeze`
```
> pip freeze
boto3==1.20.7
botocore==1.23.7
cachetools==4.2.4
certifi==2021.10.8
charset-normalizer==2.0.7
cloudbridge==2.2.0
deprecation==2.1.0
google-api-core==2.2.2
google-api-python-client==2.31.0
google-auth==2.3.3
google-auth-httplib2==0.1.0
googleapis-common-protos==1.53.0
httplib2==0.20.2
idna==3.3
jmespath==0.10.0
packaging==21.2
protobuf==3.19.1
pyasn1==0.4.8
pyasn1-modules==0.2.8
pyeventsystem==0.1.0
pyparsing==2.4.7
python-dateutil==2.8.2
requests==2.26.0
rsa==4.7.2
s3transfer==0.5.0
six==1.16.0
tenacity==8.0.1
uritemplate==4.1.1
urllib3==1.26.7
```
And it is the set of dependencies we want.
We will need to bump the major version for the release because of the package breaking change.