### PR TITLE
Allow users to create signed urls with write permissions

### DIFF
--- a/cloudbridge/interfaces/resources.py
+++ b/cloudbridge/interfaces/resources.py
@@ -2204,7 +2204,7 @@ class BucketObject(CloudResource):
         pass
 
     @abstractmethod
-    def generate_url(self, expires_in, write=False):
+    def generate_url(self, expires_in, writable=False):
         """
         Generate a signed URL to this object.
 
@@ -2214,8 +2214,8 @@ class BucketObject(CloudResource):
 
         :type expires_in: ``int``
         :param expires_in: Time to live of the generated URL in seconds.
-        :type write: ``bool``
-        :param write: Write permission for this signed URL. Users with the URL
+        :type writable: ``bool``
+        :param writable: Write permission for this signed URL. Users with the URL
             will be able to upload to this object, but they will NOT be able to
             read from it.
 

--- a/cloudbridge/interfaces/resources.py
+++ b/cloudbridge/interfaces/resources.py
@@ -2204,7 +2204,7 @@ class BucketObject(CloudResource):
         pass
 
     @abstractmethod
-    def generate_url(self, expires_in):
+    def generate_url(self, expires_in, write=False):
         """
         Generate a signed URL to this object.
 
@@ -2214,6 +2214,10 @@ class BucketObject(CloudResource):
 
         :type expires_in: ``int``
         :param expires_in: Time to live of the generated URL in seconds.
+        :type write: ``bool``
+        :param write: Write permission for this signed URL. Users with the URL
+            will be able to upload to this object, but they will NOT be able to
+            read from it.
 
         :rtype: ``str``
         :return: A URL to access the object.

--- a/cloudbridge/providers/aws/resources.py
+++ b/cloudbridge/providers/aws/resources.py
@@ -871,7 +871,7 @@ class AWSBucketObject(BaseBucketObject):
     def delete(self):
         self._obj.delete()
 
-    def generate_url(self, expires_in, writable):
+    def generate_url(self, expires_in, writable=False):
         if writable:
             return self._provider.s3_conn.meta.client.generate_presigned_post(
                 self._obj.bucket_name, self.id, ExpiresIn=expires_in

--- a/cloudbridge/providers/aws/resources.py
+++ b/cloudbridge/providers/aws/resources.py
@@ -871,7 +871,11 @@ class AWSBucketObject(BaseBucketObject):
     def delete(self):
         self._obj.delete()
 
-    def generate_url(self, expires_in):
+    def generate_url(self, expires_in, write):
+        if write:
+            return self._provider.s3_conn.meta.client.create_presigned_post(
+                self._obj.bucket_name, self.id, expiration=expires_in
+            )
         return self._provider.s3_conn.meta.client.generate_presigned_url(
             'get_object',
             Params={'Bucket': self._obj.bucket_name, 'Key': self.id},

--- a/cloudbridge/providers/aws/resources.py
+++ b/cloudbridge/providers/aws/resources.py
@@ -871,10 +871,10 @@ class AWSBucketObject(BaseBucketObject):
     def delete(self):
         self._obj.delete()
 
-    def generate_url(self, expires_in, write):
-        if write:
-            return self._provider.s3_conn.meta.client.create_presigned_post(
-                self._obj.bucket_name, self.id, expiration=expires_in
+    def generate_url(self, expires_in, writable):
+        if writable:
+            return self._provider.s3_conn.meta.client.generate_presigned_post(
+                self._obj.bucket_name, self.id, ExpiresIn=expires_in
             )
         return self._provider.s3_conn.meta.client.generate_presigned_url(
             'get_object',

--- a/cloudbridge/providers/azure/azure_client.py
+++ b/cloudbridge/providers/azure/azure_client.py
@@ -451,7 +451,7 @@ class AzureClient(object):
         blob_client = self.blob_client(container_name, blob_name)
         blob_client.delete_blob(delete_snapshots)
 
-    def get_blob_url(self, container_name, blob_name, expiry_time, write):
+    def get_blob_url(self, container_name, blob_name, expiry_time, writable):
         now = datetime.datetime.utcnow()
         expiry = now + datetime.timedelta(
             seconds=expiry_time)
@@ -462,7 +462,7 @@ class AzureClient(object):
         )
         sas = generate_blob_sas(
             self.storage_account, container_name, blob_name,
-            permission=BlobSasPermissions(read=True, write=write), expiry=expiry,
+            permission=BlobSasPermissions(read=True, write=writable), expiry=expiry,
             user_delegation_key=delegation_key
         )
         url = (

--- a/cloudbridge/providers/azure/azure_client.py
+++ b/cloudbridge/providers/azure/azure_client.py
@@ -451,7 +451,7 @@ class AzureClient(object):
         blob_client = self.blob_client(container_name, blob_name)
         blob_client.delete_blob(delete_snapshots)
 
-    def get_blob_url(self, container_name, blob_name, expiry_time):
+    def get_blob_url(self, container_name, blob_name, expiry_time, write):
         now = datetime.datetime.utcnow()
         expiry = now + datetime.timedelta(
             seconds=expiry_time)
@@ -462,7 +462,7 @@ class AzureClient(object):
         )
         sas = generate_blob_sas(
             self.storage_account, container_name, blob_name,
-            permission=BlobSasPermissions(read=True), expiry=expiry,
+            permission=BlobSasPermissions(read=True, write=write), expiry=expiry,
             user_delegation_key=delegation_key
         )
         url = (

--- a/cloudbridge/providers/azure/resources.py
+++ b/cloudbridge/providers/azure/resources.py
@@ -258,7 +258,7 @@ class AzureBucketObject(BaseBucketObject):
         """
         self._blob_client.delete_blob()
 
-    def generate_url(self, expires_in, writable):
+    def generate_url(self, expires_in, writable=False):
         """
         Generate a URL to this object.
         """

--- a/cloudbridge/providers/azure/resources.py
+++ b/cloudbridge/providers/azure/resources.py
@@ -258,12 +258,12 @@ class AzureBucketObject(BaseBucketObject):
         """
         self._blob_client.delete_blob()
 
-    def generate_url(self, expires_in):
+    def generate_url(self, expires_in, write):
         """
         Generate a URL to this object.
         """
         return self._provider.azure_client.get_blob_url(
-            self._container, self.name, expires_in)
+            self._container, self.name, expires_in, write)
 
     def refresh(self):
         pass

--- a/cloudbridge/providers/azure/resources.py
+++ b/cloudbridge/providers/azure/resources.py
@@ -258,12 +258,12 @@ class AzureBucketObject(BaseBucketObject):
         """
         self._blob_client.delete_blob()
 
-    def generate_url(self, expires_in, write):
+    def generate_url(self, expires_in, writable):
         """
         Generate a URL to this object.
         """
         return self._provider.azure_client.get_blob_url(
-            self._container, self.name, expires_in, write)
+            self._container, self.name, expires_in, writable)
 
     def refresh(self):
         pass

--- a/cloudbridge/providers/gcp/resources.py
+++ b/cloudbridge/providers/gcp/resources.py
@@ -1978,8 +1978,13 @@ class GCPBucketObject(BaseBucketObject):
     def generate_url(self, expires_in, write):
         """
         Generates a signed URL accessible to everyone.
+
+        Note that if the user asks for write permissions, we need
+        to set the `http_method` as PUT so the user can keep updating
+        the files with the same URL.
+
         """
-        http_method = "POST" if write else "GET"
+        http_method = "PUT" if write else "GET"
 
         # pylint:disable=protected-access
         return helpers.generate_signed_url(

--- a/cloudbridge/providers/gcp/resources.py
+++ b/cloudbridge/providers/gcp/resources.py
@@ -1975,7 +1975,7 @@ class GCPBucketObject(BaseBucketObject):
              .delete(bucket=self._obj['bucket'], object=self.name)
              .execute())
 
-    def generate_url(self, expires_in, write):
+    def generate_url(self, expires_in, writable):
         """
         Generates a signed URL accessible to everyone.
 
@@ -1984,7 +1984,7 @@ class GCPBucketObject(BaseBucketObject):
         the files with the same URL.
 
         """
-        http_method = "PUT" if write else "GET"
+        http_method = "PUT" if writable else "GET"
 
         # pylint:disable=protected-access
         return helpers.generate_signed_url(

--- a/cloudbridge/providers/gcp/resources.py
+++ b/cloudbridge/providers/gcp/resources.py
@@ -1975,14 +1975,16 @@ class GCPBucketObject(BaseBucketObject):
              .delete(bucket=self._obj['bucket'], object=self.name)
              .execute())
 
-    def generate_url(self, expires_in):
+    def generate_url(self, expires_in, write):
         """
         Generates a signed URL accessible to everyone.
         """
+        http_method = "POST" if write else "GET"
+
         # pylint:disable=protected-access
         return helpers.generate_signed_url(
             self._provider._credentials, self._obj['bucket'], self.name,
-            expiration=expires_in)
+            expiration=expires_in, http_method=http_method)
 
     def refresh(self):
         # pylint:disable=protected-access

--- a/cloudbridge/providers/gcp/resources.py
+++ b/cloudbridge/providers/gcp/resources.py
@@ -1975,7 +1975,7 @@ class GCPBucketObject(BaseBucketObject):
              .delete(bucket=self._obj['bucket'], object=self.name)
              .execute())
 
-    def generate_url(self, expires_in, writable):
+    def generate_url(self, expires_in, writable=False):
         """
         Generates a signed URL accessible to everyone.
 

--- a/cloudbridge/providers/openstack/resources.py
+++ b/cloudbridge/providers/openstack/resources.py
@@ -1316,8 +1316,8 @@ class OpenStackBucketObject(BaseBucketObject):
                 result = result and del_res['success']
         return result
 
-    def generate_url(self, expires_in, write):
-        http_method = "POST" if write else "GET"
+    def generate_url(self, expires_in, writable):
+        http_method = "POST" if writable else "GET"
         # Set a temp url key on the object (http://bit.ly/2NBiXGD)
         temp_url_key = "cloudbridge-tmp-url-key"
         self._provider.swift.post_account(

--- a/cloudbridge/providers/openstack/resources.py
+++ b/cloudbridge/providers/openstack/resources.py
@@ -1316,7 +1316,7 @@ class OpenStackBucketObject(BaseBucketObject):
                 result = result and del_res['success']
         return result
 
-    def generate_url(self, expires_in, writable):
+    def generate_url(self, expires_in, writable=False):
         http_method = "POST" if writable else "GET"
         # Set a temp url key on the object (http://bit.ly/2NBiXGD)
         temp_url_key = "cloudbridge-tmp-url-key"

--- a/cloudbridge/providers/openstack/resources.py
+++ b/cloudbridge/providers/openstack/resources.py
@@ -1316,7 +1316,8 @@ class OpenStackBucketObject(BaseBucketObject):
                 result = result and del_res['success']
         return result
 
-    def generate_url(self, expires_in):
+    def generate_url(self, expires_in, write):
+        http_method = "POST" if write else "GET"
         # Set a temp url key on the object (http://bit.ly/2NBiXGD)
         temp_url_key = "cloudbridge-tmp-url-key"
         self._provider.swift.post_account(
@@ -1325,7 +1326,7 @@ class OpenStackBucketObject(BaseBucketObject):
         access_point = "{0}://{1}".format(base_url.scheme, base_url.netloc)
         url_path = "/".join([base_url.path, self.cbcontainer.name, self.name])
         return urljoin(access_point, generate_temp_url(url_path, expires_in,
-                                                       temp_url_key, 'GET'))
+                                                       temp_url_key, http_method))
 
     def refresh(self):
         self._obj = self.cbcontainer.objects.get(self.id)._obj

--- a/docs/topics/object_storage.rst
+++ b/docs/topics/object_storage.rst
@@ -68,3 +68,56 @@ Once a provider is obtained, you can access the container as usual:
     bucket = provider.storage.buckets.get(container)
     obj = bucket.objects.create('my_object.txt')
     obj.upload_from_file(source)
+
+
+Generating signed URLs
+----------------------
+
+Signed URLs are a great way to allow users who do not have credentials for
+the cloud provider of your choice, to interact with an object within a
+storage bucket.
+
+You can generate signed URLs with ``GET`` permissions to allow a user to
+get an object. 
+
+.. code-block:: python
+ 
+    provider = CloudProviderFactory().create_provider(
+        ProviderList.AWS,
+        {'aws_access_key': 'ACCESS_KEY',
+         'aws_secret_key': 'SECRET_KEY',
+         'aws_session_token': 'MY_SESSION_TOKEN'}) 
+
+    bucket = provider.storage.buckets.get("my-bucket")
+    obj = bucket.objects.get("my-file.txt")
+
+    url = obj.generate_url(expires_in=7200)
+
+You can also generate a signed URL with `PUT``permissions to allow users 
+to upload files to your storage bucket.
+
+.. code-block:: python
+ 
+    provider = CloudProviderFactory().create_provider(
+        ProviderList.AWS,
+        {'aws_access_key': 'ACCESS_KEY',
+         'aws_secret_key': 'SECRET_KEY',
+         'aws_session_token': 'MY_SESSION_TOKEN'}) 
+
+    bucket = provider.storage.buckets.get("my-bucket")
+    obj = bucket.objects.create("my-file.txt")
+    url = obj.generate_url(expires_in=7200, writable=True)
+
+
+With your signed URL, you or someone on your team can upload a file like this
+
+.. code-block:: python
+
+    import requests
+
+    content = b"Hello world!"
+    # Example for AWS
+    requests.put(url["url"], data=url["fields"], files={"file": ("my-file.txt", content)})
+
+    # Example for GCP/Azure
+    requests.put(url, data=content)

--- a/tests/test_object_store_service.py
+++ b/tests/test_object_store_service.py
@@ -194,6 +194,28 @@ class CloudObjectStoreServiceTestCase(ProviderTestBase):
                 self.assertEqual(requests.get(url).content, content)
 
     @helpers.skipIfNoService(['storage.buckets'])
+    def test_generate_url_write_permissions(self):
+        name = "cbtestbucketobjs-{0}".format(helpers.get_uuid())
+        test_bucket = self.provider.storage.buckets.create(name)
+
+        with cb_helpers.cleanup_action(lambda: test_bucket.delete()):
+            obj_name = "hello_upload_download.txt"
+            obj = test_bucket.objects.create(obj_name)
+
+            with cb_helpers.cleanup_action(lambda: obj.delete()):
+                content = b"Hello World. Generate a url."
+                obj.upload(content)
+                target_stream = BytesIO()
+                obj.save_content(target_stream)
+
+                url = obj.generate_url(100, write=True)
+                if isinstance(self.provider, TestMockHelperMixin):
+                    raise self.skipTest(
+                        "Skipping rest of test - mock providers can't"
+                        " access generated url")
+                self.assertEqual(requests.post(url).content, content)
+
+    @helpers.skipIfNoService(['storage.buckets'])
     def test_upload_download_bucket_content_from_file(self):
         name = "cbtestbucketobjs-{0}".format(helpers.get_uuid())
         test_bucket = self.provider.storage.buckets.create(name)

--- a/tests/test_object_store_service.py
+++ b/tests/test_object_store_service.py
@@ -12,8 +12,6 @@ from cloudbridge.interfaces.exceptions import DuplicateResourceException
 from cloudbridge.interfaces.provider import TestMockHelperMixin
 from cloudbridge.interfaces.resources import Bucket
 from cloudbridge.interfaces.resources import BucketObject
-from cloudbridge.providers.aws.provider import AWSCloudProvider
-from cloudbridge.providers.gcp import GCPCloudProvider
 
 from tests import helpers
 from tests.helpers import ProviderTestBase
@@ -212,12 +210,8 @@ class CloudObjectStoreServiceTestCase(ProviderTestBase):
                     raise self.skipTest(
                         "Skipping rest of test - mock providers can't"
                         " access generated url")
-                elif isinstance(self.provider, GCPCloudProvider):
-                    requests.put(url, data=content)
-                elif isinstance(self.provider, AWSCloudProvider):
-                    requests.put(url['url'], data=url['fields'], files={"file": (obj_name, content)})
                 else:
-                    requests.post(url, data=content)
+                    requests.put(url, data=content)
                 
                 obj = test_bucket.objects.get(obj_name)
                 obj_content = [content for content in obj.iter_content()]


### PR DESCRIPTION
Fixes #293 

This is a draft PR to allow users to generate signed URLs with write permissions. I was a bit unsure on what to name the parameter, I was torn between:
- permissions
- is_write
- allow_write

Initially, I was implementing an ENUM so users could specify their permissions, would that be preferable? I decided against it after giving it some thought since perhaps accepting a bool would make it easier to work with the `generate_url` method, but I'm happy with either as long as we have some docs for it.

One thing that is missing from this PR is testing, I'm planning to reuse the `test_generate_url` test that we have and push the content with the URL then check that it's there.

So far I've tested this with GCP and seems to work fine, but I want to do a bit more manual testing as well