### PR TITLE
Add app creds support to OS provider for JS2

### DIFF
--- a/cloudbridge/__init__.py
+++ b/cloudbridge/__init__.py
@@ -2,7 +2,7 @@
 import logging
 
 # Current version of the library
-__version__ = '3.0.0'
+__version__ = '3.1.0'
 
 
 def get_version():

--- a/cloudbridge/providers/openstack/provider.py
+++ b/cloudbridge/providers/openstack/provider.py
@@ -134,8 +134,10 @@ class OpenStackCloudProvider(BaseCloudProvider):
                                                 project_domain_id=self.project_domain_id,
                                                 project_domain_name=self.project_domain_name,
                                                 project_name=self.project_name)
-            else raise ProviderConnectionException("No valid credentials were found. You must supply either \
-            'os_username' and 'os_password', or 'os_application_credential_id' and 'os_application_credential_secret'")
+            else:
+                raise ProviderConnectionException("""No valid credentials were found. You must supply either
+                                                     'os_username' and 'os_password', or 'os_application_credential_id'
+                                                     and 'os_application_credential_secret'""")
             self._cached_keystone_session = session.Session(auth=auth)
         else:
             from keystoneauth1.identity import v2

--- a/cloudbridge/providers/openstack/provider.py
+++ b/cloudbridge/providers/openstack/provider.py
@@ -129,11 +129,7 @@ class OpenStackCloudProvider(BaseCloudProvider):
             elif self.app_cred_id and self.app_cred_secret:
                 auth = v3.ApplicationCredential(auth_url=self.auth_url,
                                                 application_credential_id=self.app_cred_id,
-                                                application_credential_secret=self.app_cred_secret,
-                                                user_domain_name=self.user_domain_name,
-                                                project_domain_id=self.project_domain_id,
-                                                project_domain_name=self.project_domain_name,
-                                                project_name=self.project_name)
+                                                application_credential_secret=self.app_cred_secret)
             else:
                 raise ProviderConnectionException("""No valid credentials were found. You must supply either
                                                      'os_username' and 'os_password', or 'os_application_credential_id'

--- a/cloudbridge/providers/openstack/provider.py
+++ b/cloudbridge/providers/openstack/provider.py
@@ -148,12 +148,7 @@ class OpenStackCloudProvider(BaseCloudProvider):
             region_name=self.region_name,
             user_agent='cloudbridge',
             auth_url=self.auth_url,
-            project_name=self.project_name,
-            username=self.username,
-            password=self.password,
-            user_domain_name=self.user_domain_name,
-            project_domain_id=self.project_domain_id,
-            project_domain_name=self.project_domain_name
+            session=self._keystone_session,
         )
 
     @property

--- a/setup.py
+++ b/setup.py
@@ -48,8 +48,8 @@ REQS_GCP = [
 ]
 REQS_OPENSTACK = [
     'openstacksdk>=0.12.0,<1.0.0',
-    'python-novaclient>=7.0.0,<=18.0',
-    'python-swiftclient>=3.2.0,<=4.0',
+    'python-novaclient>=7.0.0,<19.0',
+    'python-swiftclient>=3.2.0,<5.0',
     'python-neutronclient>=6.0.0,<8.0',
     'python-keystoneclient>=3.13.0,<5.0'
 ]

--- a/setup.py
+++ b/setup.py
@@ -48,8 +48,8 @@ REQS_GCP = [
 ]
 REQS_OPENSTACK = [
     'openstacksdk>=0.12.0,<1.0.0',
-    'python-novaclient>=7.0.0,<18.0',
-    'python-swiftclient>=3.2.0,<4.0',
+    'python-novaclient>=7.0.0,<=18.0',
+    'python-swiftclient>=3.2.0,<=4.0',
     'python-neutronclient>=6.0.0,<8.0',
     'python-keystoneclient>=3.13.0,<5.0'
 ]


### PR DESCRIPTION
JS2 has Globus Xsede auth instead of Keystone credentials, so application credentials have to be generated for programmatic use. This adds support for Application credentials login

Friends with https://github.com/galaxyproject/cloudlaunch/pull/260 https://github.com/CloudVE/cloudman-boot/pull/56 https://github.com/CloudVE/djcloudbridge/pull/10