### PR TITLE
Add new `ec2_retries_value` config for  `AWSCloudProvider`

### DIFF
--- a/cloudbridge/providers/aws/provider.py
+++ b/cloudbridge/providers/aws/provider.py
@@ -41,7 +41,11 @@ class AWSCloudProvider(BaseCloudProvider):
         self.ec2_cfg = {
             'use_ssl': self._get_config_value('ec2_is_secure', True),
             'verify': self._get_config_value('ec2_validate_certs', True),
-            'endpoint_url': self._get_config_value('ec2_endpoint_url')
+            'endpoint_url': self._get_config_value('ec2_endpoint_url'),
+            'config': Config(
+                retries={
+                    'max_attempts': self._get_config_value('ec2_retries_value', 4),
+                    'mode': 'standard'})
         }
         self.s3_cfg = {
             'use_ssl': self._get_config_value('s3_is_secure', True),

--- a/docs/topics/setup.rst
+++ b/docs/topics/setup.rst
@@ -106,6 +106,9 @@ AWS
 | ec2_validate_certs  | Whether to use SSL certificate verification. Default is      |
 |                     | ``False``.                                                   |
 +---------------------+--------------------------------------------------------------+
+| ec2_retries_value   | The number of retries to configure boto ec2 client with      |
+|                     | Default is ``4``.                                            |
++---------------------+--------------------------------------------------------------+
 | s3_endpoint_url     | Host connection endpoint. Default is ``s3.amazonaws.com``.   |
 +---------------------+--------------------------------------------------------------+
 | s3_is_secure        | True to use an SSL connection. Default is ``True``.          |


### PR DESCRIPTION
As a user with lots of parallel boto3 requests, I would like to be able and modify the ec2 retries value, in case of some AWS issues