### PR TITLE
Azure - add AZURE_NETWORK_RESOURCE_GROUP to pick vnet from another ResourceGroup

### DIFF
--- a/cloudbridge/providers/azure/azure_client.py
+++ b/cloudbridge/providers/azure/azure_client.py
@@ -625,7 +625,7 @@ class AzureClient(object):
 
     def create_network(self, name, params):
         return self.network_management_client.virtual_networks. \
-            begin_create_or_update(self.netowrk_resource_group, name, parameters=params).result()
+            begin_create_or_update(self.networking_resource_group, name, parameters=params).result()
 
     def delete_network(self, network_id):
         url_params = azure_helpers.parse_url(NETWORK_RESOURCE_ID, network_id)

--- a/cloudbridge/providers/azure/azure_client.py
+++ b/cloudbridge/providers/azure/azure_client.py
@@ -204,6 +204,10 @@ class AzureClient(object):
         return self._config.get('azure_resource_group')
 
     @property
+    def network_resource_group(self):
+        return self._config.get('azure_network_resource_group')
+
+    @property
     def storage_account(self):
         return self._config.get('azure_storage_account')
 
@@ -610,30 +614,30 @@ class AzureClient(object):
 
     def list_networks(self):
         return self.network_management_client.virtual_networks.list(
-            self.resource_group)
+            self.network_resource_group)
 
     def get_network(self, network_id):
         url_params = azure_helpers.parse_url(NETWORK_RESOURCE_ID,
                                              network_id)
         network_name = url_params.get(NETWORK_NAME, "")
         return self.network_management_client.virtual_networks.get(
-            self.resource_group, network_name)
+            self.network_resource_group, network_name)
 
     def create_network(self, name, params):
         return self.network_management_client.virtual_networks. \
-            begin_create_or_update(self.resource_group, name, parameters=params).result()
+            begin_create_or_update(self.netowrk_resource_group, name, parameters=params).result()
 
     def delete_network(self, network_id):
         url_params = azure_helpers.parse_url(NETWORK_RESOURCE_ID, network_id)
         network_name = url_params.get(NETWORK_NAME, "")
         return self.network_management_client.virtual_networks. \
-            begin_delete(self.resource_group, network_name).wait()
+            begin_delete(self.network_resource_group, network_name).wait()
 
     def update_network_tags(self, network_id, tags):
         url_params = azure_helpers.parse_url(NETWORK_RESOURCE_ID, network_id)
         network_name = url_params.get(NETWORK_NAME, "")
         return self.network_management_client.virtual_networks. \
-            begin_create_or_update(self.resource_group, network_name, tags).result()
+            begin_create_or_update(self.network_resource_group, network_name, tags).result()
 
     def get_network_id_for_subnet(self, subnet_id):
         url_params = azure_helpers.parse_url(SUBNET_RESOURCE_ID, subnet_id)
@@ -646,7 +650,7 @@ class AzureClient(object):
         url_params = azure_helpers.parse_url(NETWORK_RESOURCE_ID, network_id)
         network_name = url_params.get(NETWORK_NAME, "")
         return self.network_management_client.subnets. \
-            list(self.resource_group, network_name)
+            list(self.network_resource_group, network_name)
 
     def get_subnet(self, subnet_id):
         url_params = azure_helpers.parse_url(SUBNET_RESOURCE_ID,
@@ -654,14 +658,14 @@ class AzureClient(object):
         network_name = url_params.get(NETWORK_NAME, "")
         subnet_name = url_params.get(SUBNET_NAME, "")
         return self.network_management_client.subnets. \
-            get(self.resource_group, network_name, subnet_name)
+            get(self.network_resource_group, network_name, subnet_name)
 
     def create_subnet(self, network_id, subnet_name, params):
         url_params = azure_helpers.parse_url(NETWORK_RESOURCE_ID, network_id)
         network_name = url_params.get(NETWORK_NAME, "")
         result_create = self.network_management_client \
             .subnets.begin_create_or_update(
-                self.resource_group,
+                self.network_resource_group,
                 network_name,
                 subnet_name,
                 params
@@ -690,7 +694,7 @@ class AzureClient(object):
         try:
             result_delete = self.network_management_client \
                 .subnets.begin_delete(
-                    self.resource_group,
+                    self.network_resource_group,
                     network_name,
                     subnet_name
                 )
@@ -701,7 +705,7 @@ class AzureClient(object):
 
     def create_floating_ip(self, public_ip_name, public_ip_parameters):
         return self.network_management_client.public_ip_addresses. \
-            begin_create_or_update(self.resource_group,
+            begin_create_or_update(self.network_resource_group,
                                    public_ip_name, public_ip_parameters).result()
 
     def get_floating_ip(self, public_ip_id):
@@ -709,14 +713,14 @@ class AzureClient(object):
                                              public_ip_id)
         public_ip_name = url_params.get(PUBLIC_IP_NAME, "")
         return self.network_management_client. \
-            public_ip_addresses.get(self.resource_group, public_ip_name)
+            public_ip_addresses.get(self.network_resource_group, public_ip_name)
 
     def delete_floating_ip(self, public_ip_id):
         url_params = azure_helpers.parse_url(PUBLIC_IP_RESOURCE_ID,
                                              public_ip_id)
         public_ip_name = url_params.get(PUBLIC_IP_NAME, "")
         self.network_management_client. \
-            public_ip_addresses.begin_delete(self.resource_group,
+            public_ip_addresses.begin_delete(self.network_resource_group,
                                              public_ip_name).wait()
 
     def update_fip_tags(self, fip_id, tags):
@@ -724,11 +728,11 @@ class AzureClient(object):
                                              fip_id)
         fip_name = url_params.get(PUBLIC_IP_NAME, "")
         self.network_management_client.public_ip_addresses. \
-            begin_create_or_update(self.resource_group, fip_name, tags).result()
+            begin_create_or_update(self.network_resource_group, fip_name, tags).result()
 
     def list_floating_ips(self):
         return self.network_management_client.public_ip_addresses.list(
-            self.resource_group)
+            self.network_resource_group)
 
     def list_vm(self):
         return self.compute_client.virtual_machines.list(

--- a/cloudbridge/providers/azure/azure_client.py
+++ b/cloudbridge/providers/azure/azure_client.py
@@ -204,8 +204,8 @@ class AzureClient(object):
         return self._config.get('azure_resource_group')
 
     @property
-    def network_resource_group(self):
-        return self._config.get('azure_network_resource_group')
+    def networking_resource_group(self):
+        return self._config.get('azure_networking_resource_group')
 
     @property
     def storage_account(self):
@@ -614,14 +614,14 @@ class AzureClient(object):
 
     def list_networks(self):
         return self.network_management_client.virtual_networks.list(
-            self.network_resource_group)
+            self.networking_resource_group)
 
     def get_network(self, network_id):
         url_params = azure_helpers.parse_url(NETWORK_RESOURCE_ID,
                                              network_id)
         network_name = url_params.get(NETWORK_NAME, "")
         return self.network_management_client.virtual_networks.get(
-            self.network_resource_group, network_name)
+            self.networking_resource_group, network_name)
 
     def create_network(self, name, params):
         return self.network_management_client.virtual_networks. \
@@ -631,13 +631,13 @@ class AzureClient(object):
         url_params = azure_helpers.parse_url(NETWORK_RESOURCE_ID, network_id)
         network_name = url_params.get(NETWORK_NAME, "")
         return self.network_management_client.virtual_networks. \
-            begin_delete(self.network_resource_group, network_name).wait()
+            begin_delete(self.networking_resource_group, network_name).wait()
 
     def update_network_tags(self, network_id, tags):
         url_params = azure_helpers.parse_url(NETWORK_RESOURCE_ID, network_id)
         network_name = url_params.get(NETWORK_NAME, "")
         return self.network_management_client.virtual_networks. \
-            begin_create_or_update(self.network_resource_group, network_name, tags).result()
+            begin_create_or_update(self.networking_resource_group, network_name, tags).result()
 
     def get_network_id_for_subnet(self, subnet_id):
         url_params = azure_helpers.parse_url(SUBNET_RESOURCE_ID, subnet_id)
@@ -650,7 +650,7 @@ class AzureClient(object):
         url_params = azure_helpers.parse_url(NETWORK_RESOURCE_ID, network_id)
         network_name = url_params.get(NETWORK_NAME, "")
         return self.network_management_client.subnets. \
-            list(self.network_resource_group, network_name)
+            list(self.networking_resource_group, network_name)
 
     def get_subnet(self, subnet_id):
         url_params = azure_helpers.parse_url(SUBNET_RESOURCE_ID,
@@ -658,14 +658,14 @@ class AzureClient(object):
         network_name = url_params.get(NETWORK_NAME, "")
         subnet_name = url_params.get(SUBNET_NAME, "")
         return self.network_management_client.subnets. \
-            get(self.network_resource_group, network_name, subnet_name)
+            get(self.networking_resource_group, network_name, subnet_name)
 
     def create_subnet(self, network_id, subnet_name, params):
         url_params = azure_helpers.parse_url(NETWORK_RESOURCE_ID, network_id)
         network_name = url_params.get(NETWORK_NAME, "")
         result_create = self.network_management_client \
             .subnets.begin_create_or_update(
-                self.network_resource_group,
+                self.networking_resource_group,
                 network_name,
                 subnet_name,
                 params
@@ -694,7 +694,7 @@ class AzureClient(object):
         try:
             result_delete = self.network_management_client \
                 .subnets.begin_delete(
-                    self.network_resource_group,
+                    self.networking_resource_group,
                     network_name,
                     subnet_name
                 )
@@ -705,7 +705,7 @@ class AzureClient(object):
 
     def create_floating_ip(self, public_ip_name, public_ip_parameters):
         return self.network_management_client.public_ip_addresses. \
-            begin_create_or_update(self.network_resource_group,
+            begin_create_or_update(self.networking_resource_group,
                                    public_ip_name, public_ip_parameters).result()
 
     def get_floating_ip(self, public_ip_id):
@@ -713,14 +713,14 @@ class AzureClient(object):
                                              public_ip_id)
         public_ip_name = url_params.get(PUBLIC_IP_NAME, "")
         return self.network_management_client. \
-            public_ip_addresses.get(self.network_resource_group, public_ip_name)
+            public_ip_addresses.get(self.networking_resource_group, public_ip_name)
 
     def delete_floating_ip(self, public_ip_id):
         url_params = azure_helpers.parse_url(PUBLIC_IP_RESOURCE_ID,
                                              public_ip_id)
         public_ip_name = url_params.get(PUBLIC_IP_NAME, "")
         self.network_management_client. \
-            public_ip_addresses.begin_delete(self.network_resource_group,
+            public_ip_addresses.begin_delete(self.networking_resource_group,
                                              public_ip_name).wait()
 
     def update_fip_tags(self, fip_id, tags):
@@ -728,11 +728,11 @@ class AzureClient(object):
                                              fip_id)
         fip_name = url_params.get(PUBLIC_IP_NAME, "")
         self.network_management_client.public_ip_addresses. \
-            begin_create_or_update(self.network_resource_group, fip_name, tags).result()
+            begin_create_or_update(self.networking_resource_group, fip_name, tags).result()
 
     def list_floating_ips(self):
         return self.network_management_client.public_ip_addresses.list(
-            self.network_resource_group)
+            self.networking_resource_group)
 
     def list_vm(self):
         return self.compute_client.virtual_machines.list(

--- a/cloudbridge/providers/azure/provider.py
+++ b/cloudbridge/providers/azure/provider.py
@@ -47,6 +47,9 @@ class AzureCloudProvider(BaseCloudProvider):
         self.resource_group = self._get_config_value(
             'azure_resource_group', get_env('AZURE_RESOURCE_GROUP',
                                             'cloudbridge'))
+        self.network_resource_group = self._get_config_value(
+            'azure_network_resource_group', get_env('AZURE_NETWORK_RESOURCE_GROUP',
+                                            self.resource_group))
         # Storage account name is limited to a max length of 24 alphanum chars
         # and unique across all of Azure. Thus, a uuid is used to generate a
         # unique name for the Storage Account based on the resource group,
@@ -128,6 +131,7 @@ class AzureCloudProvider(BaseCloudProvider):
                 'azure_tenant': self.tenant,
                 'azure_region_name': self.region_name,
                 'azure_resource_group': self.resource_group,
+                'azure_network_resource_group': self.network_resource_group,
                 'azure_storage_account': self.storage_account,
                 'azure_public_key_storage_table_name':
                     self.public_key_storage_table_name,
@@ -175,5 +179,17 @@ class AzureCloudProvider(BaseCloudProvider):
                     else:
                         raise cloud_error2
 
+            else:
+                raise cloud_error
+
+        """
+        Verify that resource group used for network exists,
+        if not, use the self.resource_group
+        """
+        try:
+            self._azure_client.get_resource_group(self.network_resource_group)
+        except CloudError as cloud_error:
+            if cloud_error.error.error == "ResourceGroupNotFound":
+                self.network_resource_group = self.resource_group
             else:
                 raise cloud_error

--- a/cloudbridge/providers/azure/provider.py
+++ b/cloudbridge/providers/azure/provider.py
@@ -49,7 +49,7 @@ class AzureCloudProvider(BaseCloudProvider):
                                             'cloudbridge'))
         self.network_resource_group = self._get_config_value(
             'azure_network_resource_group', get_env('AZURE_NETWORK_RESOURCE_GROUP',
-                                            self.resource_group))
+                                                    self.resource_group))
         # Storage account name is limited to a max length of 24 alphanum chars
         # and unique across all of Azure. Thus, a uuid is used to generate a
         # unique name for the Storage Account based on the resource group,

--- a/cloudbridge/providers/azure/provider.py
+++ b/cloudbridge/providers/azure/provider.py
@@ -49,7 +49,7 @@ class AzureCloudProvider(BaseCloudProvider):
                                             'cloudbridge'))
         self.networking_resource_group = self._get_config_value(
             'azure_networking_resource_group', get_env('AZURE_NETWORKING_RESOURCE_GROUP',
-                                                    self.resource_group))
+                                                       self.resource_group))
         # Storage account name is limited to a max length of 24 alphanum chars
         # and unique across all of Azure. Thus, a uuid is used to generate a
         # unique name for the Storage Account based on the resource group,

--- a/cloudbridge/providers/azure/provider.py
+++ b/cloudbridge/providers/azure/provider.py
@@ -47,8 +47,8 @@ class AzureCloudProvider(BaseCloudProvider):
         self.resource_group = self._get_config_value(
             'azure_resource_group', get_env('AZURE_RESOURCE_GROUP',
                                             'cloudbridge'))
-        self.network_resource_group = self._get_config_value(
-            'azure_network_resource_group', get_env('AZURE_NETWORK_RESOURCE_GROUP',
+        self.networking_resource_group = self._get_config_value(
+            'azure_networking_resource_group', get_env('AZURE_NETWORKING_RESOURCE_GROUP',
                                                     self.resource_group))
         # Storage account name is limited to a max length of 24 alphanum chars
         # and unique across all of Azure. Thus, a uuid is used to generate a
@@ -131,7 +131,7 @@ class AzureCloudProvider(BaseCloudProvider):
                 'azure_tenant': self.tenant,
                 'azure_region_name': self.region_name,
                 'azure_resource_group': self.resource_group,
-                'azure_network_resource_group': self.network_resource_group,
+                'azure_networking_resource_group': self.networking_resource_group,
                 'azure_storage_account': self.storage_account,
                 'azure_public_key_storage_table_name':
                     self.public_key_storage_table_name,
@@ -187,9 +187,9 @@ class AzureCloudProvider(BaseCloudProvider):
         if not, use the self.resource_group
         """
         try:
-            self._azure_client.get_resource_group(self.network_resource_group)
+            self._azure_client.get_resource_group(self.networking_resource_group)
         except CloudError as cloud_error:
             if cloud_error.error.error == "ResourceGroupNotFound":
-                self.network_resource_group = self.resource_group
+                self.networking_resource_group = self.resource_group
             else:
                 raise cloud_error


### PR DESCRIPTION
This PR adds new option for defining extra ResourceGroup from which vnet can be picked. 

Closes #320 