### PR TITLE
Use a trusted publisher when publishing to PyPI

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -8,6 +8,7 @@ on:
 
 permissions:
   contents: read
+  id-token: write  # Required for trusted publishing to PyPI
 
 jobs:
   build-n-publish:
@@ -33,11 +34,8 @@ jobs:
     - name: Publish distribution 📦 to Test PyPI
       uses: pypa/gh-action-pypi-publish@v1.14.0
       with:
-        password: ${{ secrets.TEST_PYPI_API_TOKEN }}
         repository_url: https://test.pypi.org/legacy/
         skip_existing: true
     - name: Publish distribution 📦 to PyPI
       if: github.event_name == 'release'
       uses: pypa/gh-action-pypi-publish@v1.14.0
-      with:
-        password: ${{ secrets.PYPI_API_TOKEN }}


### PR DESCRIPTION
This PR implements trusted publishing for PyPI uploads to enhance security and reduce the risk of supply chain attacks. The changes replace the traditional API token-based authentication with OpenID Connect (OIDC) token-based authentication provided by GitHub Actions.

The deployment workflow has been updated to use the trusted publishing mechanism where GitHub Actions generates short-lived OIDC tokens that PyPI can verify and trust. This eliminates the need to store long-lived API tokens as repository secrets, reducing the attack surface and potential for credential compromise.

**PyPI Configuration Required:** After merging this PR, repository administrators must configure trusted publishing on both PyPI and Test PyPI before the next release:

**For Production PyPI:**
1. Visit https://pypi.org
2. Login with maintainer credentials
3. Navigate to the `cloudbridge` project
4. Click "Manage" and then click "Publishing"
5. Fill in the form:
   - **Owner**: `CloudVE`
   - **Repository name**: `cloudbridge`
   - **Workflow filename**: `deploy.yaml`
   - **Environment name**: (leave blank)
6. Click "Add"

**For Test PyPI:**
1. Visit https://test.pypi.org
2. Login with maintainer credentials
3. Repeat the same configuration as above

**Post-Configuration:**
- Test the setup by creating a new pre-release tag
- Monitor the workflow execution to ensure trusted publishing works
- Remove the old API token secrets (`PYPI_API_TOKEN` and `TEST_PYPI_API_TOKEN`) from repository secrets once confirmed working
- If issues arise, the workflow can be temporarily reverted and API tokens restored

The trusted publishing setup provides better security, audit trails, and eliminates the need for credential rotation while maintaining the same publishing functionality.

Closes #329