### PR TITLE
CI hygiene: split deploy job + dedicated env, skip CI on docs-only changes

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -6,13 +6,9 @@ on:
     tags:
       - '*'
 
-permissions:
-  contents: read
-  id-token: write  # Required for trusted publishing to PyPI
-
 jobs:
-  build-n-publish:
-    name: Build and publish Python 🐍 distributions 📦 to PyPI and TestPyPI
+  build_packages:
+    name: Build Python 🐍 distributions 📦
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v6
@@ -31,6 +27,23 @@ jobs:
         python3 -m build
         twine check dist/*
         ls -l dist
+    - uses: actions/upload-artifact@v7
+      with:
+        name: packages
+        path: dist/
+
+  publish:
+    name: Publish distributions 📦 to PyPI and TestPyPI
+    needs: [build_packages]
+    runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      id-token: write  # Required for trusted publishing to PyPI
+    steps:
+    - uses: actions/download-artifact@v8
+      with:
+        name: packages
+        path: dist
     - name: Publish distribution 📦 to Test PyPI
       uses: pypa/gh-action-pypi-publish@v1.14.0
       with:

--- a/.github/workflows/integration-cloud.yaml
+++ b/.github/workflows/integration-cloud.yaml
@@ -26,8 +26,18 @@ name: Cloud integration tests
 on:
   pull_request_target:
     types: [labeled]
+    paths-ignore:
+    - 'docs/**'
+    - '**.md'
+    - '**.rst'
+    - LICENSE
   push:
     branches: [main]
+    paths-ignore:
+    - 'docs/**'
+    - '**.md'
+    - '**.rst'
+    - LICENSE
   workflow_dispatch: {}
 
 permissions:

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -12,9 +12,19 @@ on:
   push:
     branches:
     - main
+    paths-ignore:
+    - 'docs/**'
+    - '**.md'
+    - '**.rst'
+    - LICENSE
   pull_request:
     branches:
       - main
+    paths-ignore:
+    - 'docs/**'
+    - '**.md'
+    - '**.rst'
+    - LICENSE
   workflow_dispatch: {}
 
 permissions:


### PR DESCRIPTION
Two unrelated CI tweaks bundled together.

## 1. Tighten trusted-publishing blast radius (follow-up to #330). ping @nsoranzo
Addresses https://github.com/CloudVE/cloudbridge/pull/330#issuecomment-4491898064.

- Split `deploy.yaml` into `build_packages` (no special permissions, uploads the sdist/wheel as an artifact) and `publish` (downloads and uploads). Only `publish` requests `id-token: write`, so the OIDC token can no longer be minted during the build step.
- Pin the `publish` job to a dedicated `pypi` GitHub environment so the trusted-publisher binding (and any future protection rules / environment-scoped secrets) is isolated to that environment rather than the whole repo.

PyPI and Test PyPI trusted-publisher configuration already updated.

## 2. Skip integration CI on docs-only changes
Adds `paths-ignore` for `docs/**`, `**.md`, `**.rst`, and `LICENSE` on every trigger in `integration.yaml` and `integration-cloud.yaml`. Doc-only PRs and pushes no longer burn lint, mock-provider, and cloud-provider test minutes.