### PR TITLE
Add comprehensive typing to cloudbridge + mypy tox check

### DIFF
--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -60,6 +60,9 @@ jobs:
       - name: Run tox
         run: tox -e lint
 
+      - name: Run mypy
+        run: tox -e mypy
+
   mock:
     name: Mock-provider tests
     runs-on: ubuntu-latest

--- a/cloudbridge/__init__.py
+++ b/cloudbridge/__init__.py
@@ -1,11 +1,12 @@
 """Library setup."""
 import logging
+from typing import Any
 
 # Current version of the library
 __version__ = '4.1.0'
 
 
-def get_version():
+def get_version() -> str:
     """
     Return a string with the current version of the library.
 
@@ -15,7 +16,7 @@ def get_version():
     return __version__
 
 
-def init_logging():
+def init_logging() -> None:
     """
     Initialize logging for testing.
 
@@ -35,7 +36,7 @@ class CBLogger(logging.Logger):
     Add a ``trace`` log level, numeric value 5: ``log.trace("Log message")``
     """
 
-    def trace(self, msg, *args, **kwargs):
+    def trace(self, msg: object, *args: object, **kwargs: Any) -> None:
         """Add ``trace`` log level."""
         self.log(TRACE, msg, *args, **kwargs)
 
@@ -61,7 +62,8 @@ log.addHandler(logging.NullHandler())
 #   cloudbridge.set_file_logger(__name__, '/tmp/log')
 
 
-def set_stream_logger(name, level=TRACE, format_string=None):
+def set_stream_logger(name: str, level: int = TRACE,
+                      format_string: str | None = None) -> None:
     """A convenience method to set the global logger to stream."""
     global log
     if not format_string:
@@ -76,7 +78,8 @@ def set_stream_logger(name, level=TRACE, format_string=None):
     log = logger
 
 
-def set_file_logger(name, filepath, level=logging.INFO, format_string=None):
+def set_file_logger(name: str, filepath: str, level: int = logging.INFO,
+                    format_string: str | None = None) -> None:
     """A convenience method to set the global logger to a file."""
     global log
     if not format_string:

--- a/cloudbridge/base/helpers.py
+++ b/cloudbridge/base/helpers.py
@@ -3,7 +3,12 @@ import functools
 import logging
 import os
 import re
+from collections.abc import Callable
+from collections.abc import Iterator
 from contextlib import contextmanager
+from typing import Any
+from typing import TypeVar
+from typing import cast
 
 from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives import serialization as crypt_serialization
@@ -17,8 +22,11 @@ from ..interfaces.exceptions import InvalidParamException
 
 log = logging.getLogger(__name__)
 
+T = TypeVar("T")
+F = TypeVar("F", bound=Callable[..., Any])
 
-def generate_key_pair():
+
+def generate_key_pair() -> tuple[str, str]:
     """
     This method generates a keypair and returns it as a tuple
     of (public, private) keys.
@@ -38,7 +46,8 @@ def generate_key_pair():
     return public_key, private_key
 
 
-def filter_by(prop_name, kwargs, objs):
+def filter_by(prop_name: str, kwargs: dict[str, Any],
+              objs: list[T]) -> list[T]:
     """
     Utility method for filtering a list of objects by a property.
     If the given property has a non empty value in kwargs, then
@@ -60,7 +69,8 @@ def filter_by(prop_name, kwargs, objs):
         return objs
 
 
-def generic_find(filter_names, kwargs, objs):
+def generic_find(filter_names: list[str], kwargs: dict[str, Any],
+                 objs: list[T]) -> list[T]:
     """
     Utility method for filtering a list of objects by a list of filters.
     """
@@ -78,7 +88,7 @@ def generic_find(filter_names, kwargs, objs):
 
 
 @contextmanager
-def cleanup_action(cleanup_func):
+def cleanup_action(cleanup_func: Callable[[], object]) -> Iterator[None]:
     """
     Context manager to carry out a given
     cleanup action after carrying out a set
@@ -109,7 +119,7 @@ def cleanup_action(cleanup_func):
         log.exception("Error during exception cleanup: ")
 
 
-def get_env(varname, default_value=None):
+def get_env(varname: str, default_value: Any = None) -> Any:
     """
     Return the value of the environment variable or default_value.
 
@@ -128,17 +138,18 @@ def get_env(varname, default_value=None):
 # Alias deprecation decorator, following:
 # https://stackoverflow.com/questions/49802412/
 # how-to-implement-deprecation-in-python-with-argument-alias
-def deprecated_alias(**aliases):
-    def deco(f):
+def deprecated_alias(**aliases: str) -> Callable[[F], F]:
+    def deco(f: F) -> F:
         @functools.wraps(f)
-        def wrapper(*args, **kwargs):
+        def wrapper(*args: Any, **kwargs: Any) -> Any:
             rename_kwargs(f.__name__, kwargs, aliases)
             return f(*args, **kwargs)
-        return wrapper
+        return cast(F, wrapper)
     return deco
 
 
-def rename_kwargs(func_name, kwargs, aliases):
+def rename_kwargs(func_name: str, kwargs: dict[str, Any],
+                  aliases: dict[str, str]) -> None:
     for alias, new in aliases.items():
         if alias in kwargs:
             if new in kwargs:
@@ -157,7 +168,7 @@ def rename_kwargs(func_name, kwargs, aliases):
 NON_ALPHA_NUM = re.compile(r"[^A-Za-z0-9]+")
 
 
-def to_resource_name(value, replace_with="-"):
+def to_resource_name(value: str, replace_with: str = "-") -> str:
     """
     Converts a given string to a valid resource name by stripping
     all characters that are not alphanumeric.

--- a/cloudbridge/base/helpers.py
+++ b/cloudbridge/base/helpers.py
@@ -9,6 +9,7 @@ from contextlib import contextmanager
 from typing import Any
 from typing import TypeVar
 from typing import cast
+from typing import overload
 
 from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives import serialization as crypt_serialization
@@ -119,7 +120,17 @@ def cleanup_action(cleanup_func: Callable[[], object]) -> Iterator[None]:
         log.exception("Error during exception cleanup: ")
 
 
-def get_env(varname: str, default_value: Any = None) -> Any:
+@overload
+def get_env(varname: str) -> str | None:
+    ...
+
+
+@overload
+def get_env(varname: str, default_value: T) -> str | T:
+    ...
+
+
+def get_env(varname: str, default_value: object = None) -> object:
     """
     Return the value of the environment variable or default_value.
 

--- a/cloudbridge/base/middleware.py
+++ b/cloudbridge/base/middleware.py
@@ -1,4 +1,5 @@
 import logging
+from typing import Any
 
 from pyeventsystem.middleware import dispatch as pyevent_dispatch
 from pyeventsystem.middleware import intercept
@@ -19,12 +20,14 @@ class EventDebugLoggingMiddleware(object):
     access keys.
     """
     @observe(event_pattern="*", priority=100)
-    def pre_log_event(self, event_args, *args, **kwargs):
+    def pre_log_event(self, event_args: dict[str, Any],
+                      *args: Any, **kwargs: Any) -> None:
         log.debug("Event: {0}, args: {1} kwargs: {2}".format(
             event_args.get("event"), args, kwargs))
 
     @observe(event_pattern="*", priority=4900)
-    def post_log_event(self, event_args, *args, **kwargs):
+    def post_log_event(self, event_args: dict[str, Any],
+                       *args: Any, **kwargs: Any) -> None:
         log.debug("Event: {0}, result: {1}".format(
             event_args.get("event"), event_args.get("result")))
 
@@ -34,7 +37,8 @@ class ExceptionWrappingMiddleware(object):
     Wraps all unhandled exceptions in cloudbridge exceptions.
     """
     @intercept(event_pattern="*", priority=1050)
-    def wrap_exception(self, event_args, *args, **kwargs):
+    def wrap_exception(self, event_args: dict[str, Any],
+                       *args: Any, **kwargs: Any) -> Any:
         next_handler = event_args.pop("next_handler")
         if not next_handler:
             return

--- a/cloudbridge/base/provider.py
+++ b/cloudbridge/base/provider.py
@@ -16,7 +16,6 @@ from ..interfaces import CloudProvider
 from ..interfaces.exceptions import ProviderConnectionException
 from ..interfaces.resources import Configuration
 from ..interfaces.resources import PlacementZone
-from ..interfaces.resources import Region
 
 log = logging.getLogger(__name__)
 
@@ -100,17 +99,14 @@ class BaseCloudProvider(CloudProvider):
         self._zone_name: str | None = None
 
     @property
-    def region_name(self) -> str:
-        return cast(str, self._region_name)
+    def region_name(self) -> str | None:
+        return self._region_name
 
     @property
     def zone_name(self) -> str | None:
         if not self._zone_name:
             region = self.compute.regions.current
-            # ``default_zone`` is provided by the concrete Region
-            # implementation rather than the public Region interface.
-            zone = cast("PlacementZone | None",
-                        getattr(cast(Region, region), 'default_zone'))
+            zone = region.default_zone if region else None
             self._zone_name = zone.name if zone else None
             return self._zone_name
         else:

--- a/cloudbridge/base/provider.py
+++ b/cloudbridge/base/provider.py
@@ -5,13 +5,18 @@ import logging
 import os
 from configparser import ConfigParser
 from os.path import expanduser
+from typing import Any
+from typing import cast
 
+from pyeventsystem.middleware import MiddlewareManager
 from pyeventsystem.middleware import SimpleMiddlewareManager
 
 from ..base.middleware import ExceptionWrappingMiddleware
 from ..interfaces import CloudProvider
 from ..interfaces.exceptions import ProviderConnectionException
 from ..interfaces.resources import Configuration
+from ..interfaces.resources import PlacementZone
+from ..interfaces.resources import Region
 
 log = logging.getLogger(__name__)
 
@@ -28,11 +33,11 @@ CloudBridgeConfigLocations.append(UserConfigPath)
 
 class BaseConfiguration(Configuration):
 
-    def __init__(self, user_config):
+    def __init__(self, user_config: dict[str, Any]) -> None:
         self.update(user_config)
 
     @property
-    def default_result_limit(self):
+    def default_result_limit(self) -> int:
         """
         Get the maximum number of results to return for a
         list method
@@ -42,28 +47,30 @@ class BaseConfiguration(Configuration):
         """
         log.debug("Maximum number of results for list methods %s",
                   DEFAULT_RESULT_LIMIT)
-        return self.get('default_result_limit', DEFAULT_RESULT_LIMIT)
+        return cast(int, self.get('default_result_limit', DEFAULT_RESULT_LIMIT))
 
     @property
-    def default_wait_timeout(self):
+    def default_wait_timeout(self) -> int:
         """
         Gets the default wait timeout for LifeCycleObjects.
         """
         log.debug("Default wait timeout for LifeCycleObjects %s",
                   DEFAULT_WAIT_TIMEOUT)
-        return self.get('default_wait_timeout', DEFAULT_WAIT_TIMEOUT)
+        return cast(int, self.get('default_wait_timeout',
+                                  DEFAULT_WAIT_TIMEOUT))
 
     @property
-    def default_wait_interval(self):
+    def default_wait_interval(self) -> int:
         """
         Gets the default wait interval for LifeCycleObjects.
         """
         log.debug("Default wait interfal for LifeCycleObjects %s",
                   DEFAULT_WAIT_INTERVAL)
-        return self.get('default_wait_interval', DEFAULT_WAIT_INTERVAL)
+        return cast(int, self.get('default_wait_interval',
+                                  DEFAULT_WAIT_INTERVAL))
 
     @property
-    def debug_mode(self):
+    def debug_mode(self) -> bool:
         """
         A flag indicating whether CloudBridge is in debug mode. Setting
         this to True will cause the underlying provider's debug
@@ -75,59 +82,66 @@ class BaseConfiguration(Configuration):
         :rtype: ``bool``
         :return: Whether debug mode is on.
         """
-        return self.get('cb_debug', os.environ.get('CB_DEBUG', False))
+        return cast(bool, self.get('cb_debug',
+                                   os.environ.get('CB_DEBUG', False)))
 
 
 class BaseCloudProvider(CloudProvider):
-    def __init__(self, config):
+
+    PROVIDER_ID: str
+
+    def __init__(self, config: dict[str, Any]) -> None:
         self._config = BaseConfiguration(config)
         self._config_parser = ConfigParser()
         self._config_parser.read(CloudBridgeConfigLocations)
         self._middleware = SimpleMiddlewareManager()
         self.add_required_middleware()
-        self._region_name = None
-        self._zone_name = None
+        self._region_name: str | None = None
+        self._zone_name: str | None = None
 
     @property
-    def region_name(self):
-        return self._region_name
+    def region_name(self) -> str:
+        return cast(str, self._region_name)
 
     @property
-    def zone_name(self):
+    def zone_name(self) -> str | None:
         if not self._zone_name:
             region = self.compute.regions.current
-            zone = region.default_zone
+            # ``default_zone`` is provided by the concrete Region
+            # implementation rather than the public Region interface.
+            zone = cast("PlacementZone | None",
+                        getattr(cast(Region, region), 'default_zone'))
             self._zone_name = zone.name if zone else None
             return self._zone_name
         else:
             try:
                 zone_dict = ast.literal_eval(self._zone_name)
                 if isinstance(zone_dict, dict):
-                    return zone_dict
+                    return cast("str | None", zone_dict)
             except (ValueError, SyntaxError):
                 pass
             return self._zone_name
 
     @property
-    def config(self):
+    def config(self) -> Configuration:
         return self._config
 
     @property
-    def name(self):
+    def name(self) -> str:
         return str(self.__class__.__name__)
 
     @property
-    def middleware(self):
+    def middleware(self) -> MiddlewareManager:
         return self._middleware
 
-    def add_required_middleware(self):
+    def add_required_middleware(self) -> None:
         """
         Adds common middleware that is essential for cloudbridge to function.
         Any other extra middleware can be added through the provider factory.
         """
         self.middleware.add(ExceptionWrappingMiddleware())
 
-    def authenticate(self):
+    def authenticate(self) -> bool:
         """
         A basic implementation which simply runs a low impact command to
         check whether cloud credentials work. Providers should override with
@@ -142,7 +156,7 @@ class BaseCloudProvider(CloudProvider):
             raise ProviderConnectionException(
                 "Authentication with cloud provider failed: %s" % (e,))
 
-    def clone(self, zone=None):
+    def clone(self, zone: PlacementZone | None = None) -> CloudProvider:
         cloned_config = self.config.copy()
         cloned_provider = self.__class__(cloned_config)
         if zone:
@@ -150,11 +164,11 @@ class BaseCloudProvider(CloudProvider):
             cloned_provider._zone_name = zone.name
         return cloned_provider
 
-    def _deepgetattr(self, obj, attr):
+    def _deepgetattr(self, obj: object, attr: str) -> Any:
         """Recurses through an attribute chain to get the ultimate value."""
         return functools.reduce(getattr, attr.split('.'), obj)
 
-    def has_service(self, service_type):
+    def has_service(self, service_type: str) -> bool:
         """
         Checks whether this provider supports a given service.
 
@@ -178,7 +192,8 @@ class BaseCloudProvider(CloudProvider):
                  service_type)
         return False
 
-    def _get_config_value(self, key, default_value=None):
+    def _get_config_value(self, key: str,
+                          default_value: Any = None) -> Any:
         """
         A convenience method to extract a configuration value.
 

--- a/cloudbridge/base/resources.py
+++ b/cloudbridge/base/resources.py
@@ -72,13 +72,15 @@ from . import helpers as cb_helpers
 if TYPE_CHECKING:
     from _typeshed import SupportsRead
 
+    from cloudbridge.base.provider import BaseCloudProvider
+    from cloudbridge.base.services import BaseStorageService
     from cloudbridge.interfaces.services import BucketObjectService
 
 log = logging.getLogger(__name__)
 
 # Element type for the generic pageable collections defined in this module
 # (mirrors ``cloudbridge.interfaces.resources.T``).
-T = TypeVar("T")
+T = TypeVar("T", bound=CloudResource)
 
 
 class BaseCloudResource(CloudResource):
@@ -132,8 +134,12 @@ class BaseCloudResource(CloudResource):
         return name
 
     @property
-    def _provider(self) -> CloudProvider:
-        return self.__provider
+    def _provider(self) -> "BaseCloudProvider":
+        # Base resources are always constructed with a base provider, so expose
+        # the base type here. This makes base-layer implementation details
+        # (e.g. ``_get_config_value``) visible to subclasses without per-call
+        # casts, while ``CloudResource._provider`` keeps the public type.
+        return cast("BaseCloudProvider", self.__provider)
 
     def to_json(self) -> dict[str, Any]:
         # Get all attributes but filter methods and private/magic ones
@@ -266,7 +272,7 @@ class ClientPagedResultList(BaseResultList[T]):
         total_size = len(objects)
         if marker:
             from_marker = itertools.dropwhile(
-                lambda obj: not cast(CloudResource, obj).id == marker, objects)
+                lambda obj: not obj.id == marker, objects)
             # skip one past the marker
             next(from_marker, None)
             objects = list(from_marker)
@@ -274,7 +280,7 @@ class ClientPagedResultList(BaseResultList[T]):
         results = list(itertools.islice(objects, limit))
         super(ClientPagedResultList, self).__init__(
             is_truncated,
-            cast(CloudResource, results[-1]).id if is_truncated else None,
+            results[-1].id if is_truncated else None,
             True, total=total_size,
             data=results)
 
@@ -355,9 +361,7 @@ class BaseInstance(BaseCloudResource, BaseObjectLifeCycleMixin, Instance):
             interval=interval)
 
     def delete(self) -> None:
-        # InstanceService.delete is implemented by every provider but is not
-        # declared on the public typed interface, hence the ignore.
-        self._provider.compute.instances.delete(self)  # type: ignore[attr-defined]
+        self._provider.compute.instances.delete(self)
 
 
 class BaseLaunchConfig(LaunchConfig):
@@ -807,11 +811,10 @@ class BaseMultipartUpload(BaseCloudResource, MultipartUpload):
 
     @property
     def _bucket_objects(self) -> "BucketObjectService":
-        # _bucket_objects is a provider-internal service not exposed on the
-        # public StorageService interface, hence the typed cast + ignore.
-        return cast(
-            "BucketObjectService",
-            self._provider.storage._bucket_objects)  # type: ignore[attr-defined]
+        # ``_bucket_objects`` is a base-layer member (BaseStorageService), not
+        # part of the public StorageService interface.
+        storage = cast("BaseStorageService", self._provider.storage)
+        return storage._bucket_objects
 
 
 class BaseBucketObject(BaseCloudResource, BucketObject):
@@ -854,11 +857,10 @@ class BaseBucketObject(BaseCloudResource, BucketObject):
 
     @property
     def _bucket_objects(self) -> "BucketObjectService":
-        # _bucket_objects is a provider-internal service not exposed on the
-        # public StorageService interface, hence the typed cast + ignore.
-        return cast(
-            "BucketObjectService",
-            self._provider.storage._bucket_objects)  # type: ignore[attr-defined]
+        # ``_bucket_objects`` is a base-layer member (BaseStorageService), not
+        # part of the public StorageService interface.
+        storage = cast("BaseStorageService", self._provider.storage)
+        return storage._bucket_objects
 
     @staticmethod
     def is_valid_resource_name(name: str) -> bool:
@@ -888,25 +890,20 @@ class BaseBucketObject(BaseCloudResource, BucketObject):
     def _multipart_threshold(self, config: UploadConfig | None = None) -> int:
         if config is not None and config.threshold is not None:
             return int(config.threshold)
-        # pylint:disable=protected-access
-        # _get_config_value is a provider-internal helper not on the public
-        # CloudProvider interface, hence the ignore.
-        return int(self._provider._get_config_value(  # type: ignore[attr-defined]
+        return int(self._provider._get_config_value(
             'multipart_threshold', self.CB_MULTIPART_THRESHOLD))
 
     def _multipart_part_size(self, config: UploadConfig | None = None) -> int:
         if config is not None and config.part_size is not None:
             return int(config.part_size)
-        # pylint:disable=protected-access
-        return int(self._provider._get_config_value(  # type: ignore[attr-defined]
+        return int(self._provider._get_config_value(
             'multipart_part_size', self.CB_MULTIPART_PART_SIZE))
 
     def _multipart_max_concurrency(
             self, config: UploadConfig | None = None) -> int:
         if config is not None and config.max_concurrency is not None:
             return int(config.max_concurrency)
-        # pylint:disable=protected-access
-        return int(self._provider._get_config_value(  # type: ignore[attr-defined]
+        return int(self._provider._get_config_value(
             'multipart_max_concurrency', self.CB_MULTIPART_MAX_CONCURRENCY))
 
     @staticmethod
@@ -1005,12 +1002,9 @@ class BaseBucketObject(BaseCloudResource, BucketObject):
         # thread touches an isolated provider/connection.
         clones: "queue.Queue[BucketObjectService]" = queue.Queue()
         for _ in range(concurrency):
-            # pylint:disable=protected-access
-            # _bucket_objects is a provider-internal service not exposed on the
-            # public StorageService interface, hence the typed cast + ignore.
-            clones.put(cast(
-                "BucketObjectService",
-                self._provider.clone().storage._bucket_objects))  # type: ignore[attr-defined]
+            storage = cast("BaseStorageService",
+                           self._provider.clone().storage)
+            clones.put(storage._bucket_objects)
 
         def upload_one(part_number: int, chunk: bytes) -> UploadPart:
             service = clones.get()
@@ -1103,9 +1097,7 @@ class BaseBucket(BaseCloudResource, Bucket):
         if delete_contents:
             for obj in self.objects:
                 obj.delete()
-        # BucketService.delete is implemented by every provider but is not
-        # declared on the public typed interface, hence the ignore.
-        self._provider.storage.buckets.delete(self.id)  # type: ignore[attr-defined]
+        self._provider.storage.buckets.delete(self.id)
 
     # TODO: Discuss creating `create_object` method, or change docs
 

--- a/cloudbridge/base/resources.py
+++ b/cloudbridge/base/resources.py
@@ -846,7 +846,7 @@ class BaseBucketObject(BaseCloudResource, BucketObject):
             "BucketObject subclasses must implement the bucket property")
 
     def _upload_single_shot(
-            self, data: str | bytes | IO[bytes]) -> BucketObject | None:
+            self, data: str | bytes | IO[bytes]) -> BucketObject:
         # Provider-implemented single-shot (non-multipart) upload.
         raise NotImplementedError(
             "BucketObject subclasses must implement _upload_single_shot")
@@ -938,7 +938,7 @@ class BaseBucketObject(BaseCloudResource, BucketObject):
         return data
 
     def upload(self, data: str | bytes | IO[bytes],
-               config: UploadConfig | None = None) -> BucketObject | None:
+               config: UploadConfig | None = None) -> BucketObject:
         size = self._data_size(data)
         if size is not None and size > self._multipart_threshold(config):
             return self._upload_multipart(self._as_stream(data), config)
@@ -946,7 +946,7 @@ class BaseBucketObject(BaseCloudResource, BucketObject):
 
     def upload_from_file(
             self, path: str,
-            config: UploadConfig | None = None) -> BucketObject | None:
+            config: UploadConfig | None = None) -> BucketObject:
         if os.path.getsize(path) > self._multipart_threshold(config):
             with open(path, 'rb') as f:
                 return self._upload_multipart(f, config)
@@ -1059,7 +1059,7 @@ class BaseBucketObject(BaseCloudResource, BucketObject):
         return bytes(buffer)
 
     def _upload_from_file_single_shot(
-            self, path: str) -> BucketObject | None:
+            self, path: str) -> BucketObject:
         """
         Default small-file upload: read the file and hand it to the provider's
         single-shot upload. Providers with a more efficient native file upload
@@ -1095,13 +1095,13 @@ class BaseBucket(BaseCloudResource, Bucket):
                 # check from most to least likely mutables
                 self.name == other.name)
 
-    # NB: interface declares delete(delete_contents=False), but this base
-    # implementation takes no args; the override ignore covers that signature
-    # mismatch without altering behavior.
-    def delete(self) -> None:  # type: ignore[override]
+    def delete(self, delete_contents: bool = False) -> None:
         """
         Delete this bucket.
         """
+        if delete_contents:
+            for obj in self.objects:
+                obj.delete()
         # BucketService.delete is implemented by every provider but is not
         # declared on the public typed interface, hence the ignore.
         self._provider.storage.buckets.delete(self.id)  # type: ignore[attr-defined]

--- a/cloudbridge/base/resources.py
+++ b/cloudbridge/base/resources.py
@@ -468,7 +468,8 @@ class BaseMachineImage(
 
 class BaseAttachmentInfo(AttachmentInfo):
 
-    def __init__(self, volume: Volume, instance_id: str, device: str) -> None:
+    def __init__(self, volume: Volume, instance_id: str,
+                 device: str | None) -> None:
         self._volume = volume
         self._instance_id = instance_id
         self._device = device
@@ -482,7 +483,7 @@ class BaseAttachmentInfo(AttachmentInfo):
         return self._instance_id
 
     @property
-    def device(self) -> str:
+    def device(self) -> str | None:
         return self._device
 
 

--- a/cloudbridge/base/resources.py
+++ b/cloudbridge/base/resources.py
@@ -18,6 +18,7 @@ from concurrent.futures import wait
 from typing import Any
 from typing import IO
 from typing import Iterator
+from typing import Sequence
 from typing import TYPE_CHECKING
 from typing import TypeVar
 from typing import cast
@@ -204,7 +205,7 @@ class BaseResultList(ResultList[T]):
     def __init__(
             self, is_truncated: bool, marker: str | None,
             supports_total: bool, total: int | None = None,
-            data: list[T] | None = None) -> None:
+            data: Sequence[T] | None = None) -> None:
         # call list constructor
         super(BaseResultList, self).__init__(data or [])
         self._marker = marker
@@ -258,9 +259,9 @@ class ClientPagedResultList(BaseResultList[T]):
     of the full result set entirely on the client side.
     """
 
-    def __init__(self, provider: CloudProvider, objects: list[T],
+    def __init__(self, provider: CloudProvider, objects: Sequence[T],
                  limit: int | None = None, marker: str | None = None) -> None:
-        self._objects = objects
+        self._objects = list(objects)
         limit = limit or provider.config.default_result_limit
         total_size = len(objects)
         if marker:

--- a/cloudbridge/base/resources.py
+++ b/cloudbridge/base/resources.py
@@ -622,11 +622,11 @@ class BaseVMFirewall(BaseCloudResource, VMFirewall):
         return self.id
 
     @property
-    def description(self) -> str:
+    def description(self) -> str | None:
         """
         Return the description of this VM firewall.
         """
-        return cast(str, self._vm_firewall.description)
+        return cast("str | None", self._vm_firewall.description)
 
     def delete(self) -> None:
         """

--- a/cloudbridge/base/resources.py
+++ b/cloudbridge/base/resources.py
@@ -12,8 +12,15 @@ import shutil
 import time
 import uuid
 from concurrent.futures import FIRST_COMPLETED
+from concurrent.futures import Future
 from concurrent.futures import ThreadPoolExecutor
 from concurrent.futures import wait
+from typing import Any
+from typing import IO
+from typing import Iterator
+from typing import TYPE_CHECKING
+from typing import TypeVar
+from typing import cast
 
 from cloudbridge.interfaces.exceptions import \
     InvalidConfigurationException
@@ -21,6 +28,7 @@ from cloudbridge.interfaces.exceptions import InvalidLabelException
 from cloudbridge.interfaces.exceptions import InvalidNameException
 from cloudbridge.interfaces.exceptions import InvalidValueException
 from cloudbridge.interfaces.exceptions import WaitStateException
+from cloudbridge.interfaces.provider import CloudProvider
 from cloudbridge.interfaces.resources import AttachmentInfo
 from cloudbridge.interfaces.resources import Bucket
 from cloudbridge.interfaces.resources import BucketObject
@@ -50,6 +58,7 @@ from cloudbridge.interfaces.resources import Snapshot
 from cloudbridge.interfaces.resources import SnapshotState
 from cloudbridge.interfaces.resources import Subnet
 from cloudbridge.interfaces.resources import SubnetState
+from cloudbridge.interfaces.resources import UploadConfig
 from cloudbridge.interfaces.resources import UploadPart
 from cloudbridge.interfaces.resources import VMFirewall
 from cloudbridge.interfaces.resources import VMFirewallRule
@@ -59,7 +68,16 @@ from cloudbridge.interfaces.resources import VolumeState
 
 from . import helpers as cb_helpers
 
+if TYPE_CHECKING:
+    from _typeshed import SupportsRead
+
+    from cloudbridge.interfaces.services import BucketObjectService
+
 log = logging.getLogger(__name__)
+
+# Element type for the generic pageable collections defined in this module
+# (mirrors ``cloudbridge.interfaces.resources.T``).
+T = TypeVar("T")
 
 
 class BaseCloudResource(CloudResource):
@@ -73,11 +91,11 @@ class BaseCloudResource(CloudResource):
     # -with-dashes-allowed-in-between-but-not-at-the-start-or-e
     CB_NAME_PATTERN = re.compile(r"^[a-z][-a-z0-9]{1,61}[a-z0-9]$")
 
-    def __init__(self, provider):
+    def __init__(self, provider: CloudProvider) -> None:
         self.__provider = provider
 
     @staticmethod
-    def is_valid_resource_name(name):
+    def is_valid_resource_name(name: str) -> bool:
         if not name:
             return False
         else:
@@ -85,7 +103,7 @@ class BaseCloudResource(CloudResource):
                     else False)
 
     @staticmethod
-    def assert_valid_resource_label(name):
+    def assert_valid_resource_label(name: str) -> None:
         if not BaseCloudResource.is_valid_resource_name(name):
             log.debug("InvalidLabelException raised on %s", name)
             raise InvalidLabelException(
@@ -95,7 +113,7 @@ class BaseCloudResource(CloudResource):
                 "letter and not end with a dash." % name)
 
     @staticmethod
-    def assert_valid_resource_name(name):
+    def assert_valid_resource_name(name: str) -> None:
         if not BaseCloudResource.is_valid_resource_name(name):
             log.debug("InvalidLabelException raised on %s", name)
             raise InvalidNameException(
@@ -105,7 +123,7 @@ class BaseCloudResource(CloudResource):
                 " end with a dash." % name)
 
     @staticmethod
-    def _generate_name_from_label(label, default):
+    def _generate_name_from_label(label: str | None, default: str) -> str:
         if not label:
             label = default
         name = label[:55] + '-' + uuid.uuid4().hex[:6]
@@ -113,16 +131,16 @@ class BaseCloudResource(CloudResource):
         return name
 
     @property
-    def _provider(self):
+    def _provider(self) -> CloudProvider:
         return self.__provider
 
-    def to_json(self):
+    def to_json(self) -> dict[str, Any]:
         # Get all attributes but filter methods and private/magic ones
         attr = inspect.getmembers(self, lambda a: not (inspect.isroutine(a)))
         js = {k: v for (k, v) in attr if not k.startswith('_')}
         return js
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         name_or_label = getattr(self, 'label', self.name)
         if name_or_label == self.id:
             return "<CB-{0}: {1}>".format(
@@ -141,9 +159,10 @@ class BaseObjectLifeCycleMixin(ObjectLifeCycleMixin):
     method, since the desired ready states are object specific.
     """
 
-    def wait_for(self, target_states, terminal_states=None, timeout=None,
-
-                 interval=None):
+    def wait_for(self, target_states: list[str],
+                 terminal_states: list[str] | None = None,
+                 timeout: int | None = None,
+                 interval: int | None = None) -> bool:
         if timeout is None:
             timeout = self._provider.config.default_wait_timeout
         if interval is None:
@@ -180,10 +199,12 @@ class BaseObjectLifeCycleMixin(ObjectLifeCycleMixin):
         return True
 
 
-class BaseResultList(ResultList):
+class BaseResultList(ResultList[T]):
 
     def __init__(
-            self, is_truncated, marker, supports_total, total=None, data=None):
+            self, is_truncated: bool, marker: str | None,
+            supports_total: bool, total: int | None = None,
+            data: list[T] | None = None) -> None:
         # call list constructor
         super(BaseResultList, self).__init__(data or [])
         self._marker = marker
@@ -192,23 +213,23 @@ class BaseResultList(ResultList):
         self._total = total
 
     @property
-    def marker(self):
+    def marker(self) -> str | None:
         return self._marker
 
     @property
-    def is_truncated(self):
+    def is_truncated(self) -> bool:
         return self._is_truncated
 
     @property
-    def supports_total(self):
+    def supports_total(self) -> bool:
         return self._supports_total
 
     @property
-    def total_results(self):
-        return self._total
+    def total_results(self) -> int:
+        return cast(int, self._total)
 
 
-class ServerPagedResultList(BaseResultList):
+class ServerPagedResultList(BaseResultList[T]):
     """
     This is a convenience class that extends the :class:`BaseResultList` class
     and provides a server side implementation of paging. It is meant for use by
@@ -218,16 +239,16 @@ class ServerPagedResultList(BaseResultList):
     """
 
     @property
-    def supports_server_paging(self):
+    def supports_server_paging(self) -> bool:
         return True
 
     @property
-    def data(self):
+    def data(self) -> list[T]:
         raise NotImplementedError(
             "ServerPagedResultLists do not support the data property")
 
 
-class ClientPagedResultList(BaseResultList):
+class ClientPagedResultList(BaseResultList[T]):
     """
     This is a convenience class that extends the :class:`BaseResultList` class
     and provides a client side implementation of paging. It is meant for use by
@@ -237,13 +258,14 @@ class ClientPagedResultList(BaseResultList):
     of the full result set entirely on the client side.
     """
 
-    def __init__(self, provider, objects, limit=None, marker=None):
+    def __init__(self, provider: CloudProvider, objects: list[T],
+                 limit: int | None = None, marker: str | None = None) -> None:
         self._objects = objects
         limit = limit or provider.config.default_result_limit
         total_size = len(objects)
         if marker:
             from_marker = itertools.dropwhile(
-                lambda obj: not obj.id == marker, objects)
+                lambda obj: not cast(CloudResource, obj).id == marker, objects)
             # skip one past the marker
             next(from_marker, None)
             objects = list(from_marker)
@@ -251,30 +273,30 @@ class ClientPagedResultList(BaseResultList):
         results = list(itertools.islice(objects, limit))
         super(ClientPagedResultList, self).__init__(
             is_truncated,
-            results[-1].id if is_truncated else None,
+            cast(CloudResource, results[-1]).id if is_truncated else None,
             True, total=total_size,
             data=results)
 
     @property
-    def supports_server_paging(self):
+    def supports_server_paging(self) -> bool:
         return False
 
     @property
-    def data(self):
+    def data(self) -> list[T]:
         return self._objects
 
 
-class BasePageableObjectMixin(PageableObjectMixin):
+class BasePageableObjectMixin(PageableObjectMixin[T]):
     """
     A mixin to provide iteration capability for a class
     that support a list(limit, marker) method.
     """
 
-    def __iter__(self):
+    def __iter__(self) -> Iterator[T]:
         for result in self.iter():
             yield result
 
-    def iter(self, **kwargs):
+    def iter(self, **kwargs: Any) -> Iterator[T]:
         result_list = self.list(**kwargs)
         if result_list.supports_server_paging:
             for result in result_list:
@@ -290,26 +312,26 @@ class BasePageableObjectMixin(PageableObjectMixin):
 
 class BaseVMType(BaseCloudResource, VMType):
 
-    def __init__(self, provider):
+    def __init__(self, provider: CloudProvider) -> None:
         super(BaseVMType, self).__init__(provider)
 
-    def __eq__(self, other):
+    def __eq__(self, other: object) -> bool:
         return (isinstance(other, VMType) and
                 # pylint:disable=protected-access
                 self._provider == other._provider and
                 self.id == other.id)
 
     @property
-    def size_total_disk(self):
+    def size_total_disk(self) -> int:
         return self.size_root_disk + self.size_ephemeral_disks
 
 
 class BaseInstance(BaseCloudResource, BaseObjectLifeCycleMixin, Instance):
 
-    def __init__(self, provider):
+    def __init__(self, provider: CloudProvider) -> None:
         super(BaseInstance, self).__init__(provider)
 
-    def __eq__(self, other):
+    def __eq__(self, other: object) -> bool:
         return (isinstance(other, Instance) and
                 # pylint:disable=protected-access
                 self._provider == other._provider and
@@ -322,42 +344,53 @@ class BaseInstance(BaseCloudResource, BaseObjectLifeCycleMixin, Instance):
                 self.private_ips == other.private_ips and
                 self.image_id == other.image_id)
 
-    def wait_till_ready(self, timeout=None, interval=None):
+    # NB: interface declares -> bool, but neither base nor provider
+    # implementations return a value (wait_for raises on failure); annotate
+    # honestly as -> None without altering behavior.
+    def wait_till_ready(  # type: ignore[override]
+            self, timeout: int | None = None,
+            interval: int | None = None) -> None:
         self.wait_for(
             [InstanceState.RUNNING],
             terminal_states=[InstanceState.DELETED, InstanceState.ERROR],
             timeout=timeout,
             interval=interval)
 
-    def delete(self):
-        self._provider.compute.instances.delete(self)
+    def delete(self) -> None:
+        # InstanceService.delete is implemented by every provider but is not
+        # declared on the public typed interface, hence the ignore.
+        self._provider.compute.instances.delete(self)  # type: ignore[attr-defined]
 
 
 class BaseLaunchConfig(LaunchConfig):
 
-    def __init__(self, provider):
+    def __init__(self, provider: CloudProvider) -> None:
         self.provider = provider
-        self.block_devices = []
+        self.block_devices: list[BaseLaunchConfig.BlockDeviceMapping] = []
 
     class BlockDeviceMapping(object):
         """
         Represents a block device mapping
         """
 
-        def __init__(self, is_volume=False, source=None, is_root=None,
-                     size=None, delete_on_terminate=None):
+        def __init__(self, is_volume: bool = False,
+                     source: Volume | Snapshot | MachineImage | None = None,
+                     is_root: bool | None = None, size: int | None = None,
+                     delete_on_terminate: bool | None = None) -> None:
             self.is_volume = is_volume
             self.source = source
             self.is_root = is_root
             self.size = size
             self.delete_on_terminate = delete_on_terminate
 
-    def add_ephemeral_device(self):
+    def add_ephemeral_device(self) -> None:
         block_device = BaseLaunchConfig.BlockDeviceMapping()
         self.block_devices.append(block_device)
 
-    def add_volume_device(self, source=None, is_root=None, size=None,
-                          delete_on_terminate=None):
+    def add_volume_device(
+            self, source: Volume | Snapshot | MachineImage | None = None,
+            is_root: bool | None = None, size: int | None = None,
+            delete_on_terminate: bool | None = None) -> None:
         block_device = self._validate_volume_device(
             source=source, is_root=is_root, size=size,
             delete_on_terminate=delete_on_terminate)
@@ -365,8 +398,11 @@ class BaseLaunchConfig(LaunchConfig):
                   block_device)
         self.block_devices.append(block_device)
 
-    def _validate_volume_device(self, source=None, is_root=None,
-                                size=None, delete_on_terminate=None):
+    def _validate_volume_device(
+            self, source: Volume | Snapshot | MachineImage | None = None,
+            is_root: bool | None = None, size: int | None = None,
+            delete_on_terminate: bool | None = None
+    ) -> "BaseLaunchConfig.BlockDeviceMapping":
         """
         Validates a volume based device and throws an
         InvalidConfigurationException if the configuration is incorrect.
@@ -409,10 +445,10 @@ class BaseLaunchConfig(LaunchConfig):
 class BaseMachineImage(
         BaseCloudResource, BaseObjectLifeCycleMixin, MachineImage):
 
-    def __init__(self, provider):
+    def __init__(self, provider: CloudProvider) -> None:
         super(BaseMachineImage, self).__init__(provider)
 
-    def __eq__(self, other):
+    def __eq__(self, other: object) -> bool:
         return (isinstance(other, MachineImage) and
                 # pylint:disable=protected-access
                 self._provider == other._provider and
@@ -422,7 +458,12 @@ class BaseMachineImage(
                 self.label == other.label and
                 self.description == other.description)
 
-    def wait_till_ready(self, timeout=None, interval=None):
+    # NB: interface declares -> bool but the implementation does not return a
+    # value (wait_for raises on failure); annotate honestly without altering
+    # behavior.
+    def wait_till_ready(  # type: ignore[override]
+            self, timeout: int | None = None,
+            interval: int | None = None) -> None:
         self.wait_for(
             [MachineImageState.AVAILABLE],
             terminal_states=[MachineImageState.ERROR],
@@ -432,30 +473,30 @@ class BaseMachineImage(
 
 class BaseAttachmentInfo(AttachmentInfo):
 
-    def __init__(self, volume, instance_id, device):
+    def __init__(self, volume: Volume, instance_id: str, device: str) -> None:
         self._volume = volume
         self._instance_id = instance_id
         self._device = device
 
     @property
-    def volume(self):
+    def volume(self) -> Volume:
         return self._volume
 
     @property
-    def instance_id(self):
+    def instance_id(self) -> str:
         return self._instance_id
 
     @property
-    def device(self):
+    def device(self) -> str:
         return self._device
 
 
 class BaseVolume(BaseCloudResource, BaseObjectLifeCycleMixin, Volume):
 
-    def __init__(self, provider):
+    def __init__(self, provider: CloudProvider) -> None:
         super(BaseVolume, self).__init__(provider)
 
-    def __eq__(self, other):
+    def __eq__(self, other: object) -> bool:
         return (isinstance(other, Volume) and
                 # pylint:disable=protected-access
                 self._provider == other._provider and
@@ -464,14 +505,21 @@ class BaseVolume(BaseCloudResource, BaseObjectLifeCycleMixin, Volume):
                 self.state == other.state and
                 self.label == other.label)
 
-    def wait_till_ready(self, timeout=None, interval=None):
+    # NB: interface declares -> bool but the implementation does not return a
+    # value (wait_for raises on failure); annotate honestly without altering
+    # behavior.
+    def wait_till_ready(  # type: ignore[override]
+            self, timeout: int | None = None,
+            interval: int | None = None) -> None:
         self.wait_for(
             [VolumeState.AVAILABLE],
             terminal_states=[VolumeState.ERROR, VolumeState.DELETED],
             timeout=timeout,
             interval=interval)
 
-    def delete(self):
+    # NB: interface declares -> bool but VolumeService.delete returns None;
+    # annotate honestly without altering behavior.
+    def delete(self) -> None:  # type: ignore[override]
         """
         Delete this volume.
         """
@@ -480,10 +528,10 @@ class BaseVolume(BaseCloudResource, BaseObjectLifeCycleMixin, Volume):
 
 class BaseSnapshot(BaseCloudResource, BaseObjectLifeCycleMixin, Snapshot):
 
-    def __init__(self, provider):
+    def __init__(self, provider: CloudProvider) -> None:
         super(BaseSnapshot, self).__init__(provider)
 
-    def __eq__(self, other):
+    def __eq__(self, other: object) -> bool:
         return (isinstance(other, Snapshot) and
                 # pylint:disable=protected-access
                 self._provider == other._provider and
@@ -492,14 +540,21 @@ class BaseSnapshot(BaseCloudResource, BaseObjectLifeCycleMixin, Snapshot):
                 self.state == other.state and
                 self.label == other.label)
 
-    def wait_till_ready(self, timeout=None, interval=None):
+    # NB: interface declares -> bool but the implementation does not return a
+    # value (wait_for raises on failure); annotate honestly without altering
+    # behavior.
+    def wait_till_ready(  # type: ignore[override]
+            self, timeout: int | None = None,
+            interval: int | None = None) -> None:
         self.wait_for(
             [SnapshotState.AVAILABLE],
             terminal_states=[SnapshotState.ERROR],
             timeout=timeout,
             interval=interval)
 
-    def delete(self):
+    # NB: interface declares -> bool but SnapshotService.delete returns None;
+    # annotate honestly without altering behavior.
+    def delete(self) -> None:  # type: ignore[override]
         """
         Delete this snapshot.
         """
@@ -508,51 +563,53 @@ class BaseSnapshot(BaseCloudResource, BaseObjectLifeCycleMixin, Snapshot):
 
 class BaseKeyPair(BaseCloudResource, KeyPair):
 
-    def __init__(self, provider, key_pair):
+    def __init__(self, provider: CloudProvider, key_pair: Any) -> None:
         super(BaseKeyPair, self).__init__(provider)
         self._key_pair = key_pair
-        self._private_material = None
+        self._private_material: str | None = None
 
-    def __eq__(self, other):
+    def __eq__(self, other: object) -> bool:
         return (isinstance(other, KeyPair) and
                 # pylint:disable=protected-access
                 self._provider == other._provider and
                 self.name == other.name)
 
     @property
-    def id(self):
+    def id(self) -> str:
         """
         Return the id of this key pair.
         """
-        return self._key_pair.name
+        return cast(str, self._key_pair.name)
 
     @property
-    def name(self):
+    def name(self) -> str:
         """
         Return the name of this key pair.
         """
         return self.id
 
     @property
-    def material(self):
+    def material(self) -> str | None:
         return self._private_material
 
     @material.setter
     # pylint:disable=arguments-differ
-    def material(self, value):
+    def material(self, value: str | None) -> None:
         self._private_material = value
 
-    def delete(self):
+    # NB: interface declares -> bool but the implementation does not return a
+    # value; annotate honestly without altering behavior.
+    def delete(self) -> None:  # type: ignore[override]
         self._provider.security.key_pairs.delete(self)
 
 
 class BaseVMFirewall(BaseCloudResource, VMFirewall):
 
-    def __init__(self, provider, vm_firewall):
+    def __init__(self, provider: CloudProvider, vm_firewall: Any) -> None:
         super(BaseVMFirewall, self).__init__(provider)
         self._vm_firewall = vm_firewall
 
-    def __eq__(self, other):
+    def __eq__(self, other: object) -> bool:
         """
         Check if all the defined rules match across both VM firewalls.
         """
@@ -561,34 +618,34 @@ class BaseVMFirewall(BaseCloudResource, VMFirewall):
                 self._provider == other._provider and
                 set(self.rules) == set(other.rules))
 
-    def __ne__(self, other):
+    def __ne__(self, other: object) -> bool:
         return not self.__eq__(other)
 
     @property
-    def id(self):
+    def id(self) -> str:
         """
         Get the ID of this VM firewall.
 
         :rtype: str
         :return: VM firewall ID
         """
-        return self._vm_firewall.id
+        return cast(str, self._vm_firewall.id)
 
     @property
-    def name(self):
+    def name(self) -> str:
         """
         Return the name of this VM firewall.
         """
         return self.id
 
     @property
-    def description(self):
+    def description(self) -> str:
         """
         Return the description of this VM firewall.
         """
-        return self._vm_firewall.description
+        return cast(str, self._vm_firewall.description)
 
-    def delete(self):
+    def delete(self) -> None:
         """
         Delete this VM firewall.
         """
@@ -597,7 +654,7 @@ class BaseVMFirewall(BaseCloudResource, VMFirewall):
 
 class BaseVMFirewallRule(BaseCloudResource, VMFirewallRule):
 
-    def __init__(self, parent_fw, rule):
+    def __init__(self, parent_fw: VMFirewall, rule: Any) -> None:
         # pylint:disable=protected-access
         super(BaseVMFirewallRule, self).__init__(
             parent_fw._provider)
@@ -610,17 +667,17 @@ class BaseVMFirewallRule(BaseCloudResource, VMFirewallRule):
             self.cidr, self.src_dest_fw_id).lower()
 
     @property
-    def name(self):
+    def name(self) -> str:
         return self._name
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return ("<{0}: id: {1}; direction: {2}; protocol: {3};  from: {4};"
                 " to: {5}; cidr: {6}, src_dest_fw: {7}>"
                 .format(self.__class__.__name__, self.id, self.direction,
                         self.protocol, self.from_port, self.to_port, self.cidr,
                         self.src_dest_fw_id))
 
-    def __eq__(self, other):
+    def __eq__(self, other: object) -> bool:
         return (isinstance(other, VMFirewallRule) and
                 self.direction == other.direction and
                 self.protocol == other.protocol and
@@ -629,10 +686,10 @@ class BaseVMFirewallRule(BaseCloudResource, VMFirewallRule):
                 self.cidr == other.cidr and
                 self.src_dest_fw_id == other.src_dest_fw_id)
 
-    def __ne__(self, other):
+    def __ne__(self, other: object) -> bool:
         return not self.__eq__(other)
 
-    def __hash__(self):
+    def __hash__(self) -> int:
         """
         Return a hash-based interpretation of all of the object's field values.
 
@@ -643,23 +700,26 @@ class BaseVMFirewallRule(BaseCloudResource, VMFirewallRule):
             self.direction, self.protocol, self.from_port, self.to_port,
             self.cidr, self.src_dest_fw_id))
 
-    def to_json(self):
+    def to_json(self) -> dict[str, Any]:
         attr = inspect.getmembers(self, lambda a: not (inspect.isroutine(a)))
         js = {k: v for (k, v) in attr if not k.startswith('_')}
         js['src_dest_fw'] = self.src_dest_fw_id
         js['firewall'] = self.firewall.id
         return js
 
-    def delete(self):
-        self._provider.security._vm_firewall_rules.delete(self.firewall, self)
+    def delete(self) -> None:
+        # The interface types the second arg as a rule_id (str), but every
+        # provider's _vm_firewall_rules.delete accepts the rule object itself.
+        self._provider.security._vm_firewall_rules.delete(
+            self.firewall, self)  # type: ignore[arg-type]
 
 
 class BasePlacementZone(BaseCloudResource, PlacementZone):
 
-    def __init__(self, provider):
+    def __init__(self, provider: CloudProvider) -> None:
         super(BasePlacementZone, self).__init__(provider)
 
-    def __eq__(self, other):
+    def __eq__(self, other: object) -> bool:
         return (isinstance(other, PlacementZone) and
                 # pylint:disable=protected-access
                 self._provider == other._provider and
@@ -668,23 +728,23 @@ class BasePlacementZone(BaseCloudResource, PlacementZone):
 
 class BaseRegion(BaseCloudResource, Region):
 
-    def __init__(self, provider):
+    def __init__(self, provider: CloudProvider) -> None:
         super(BaseRegion, self).__init__(provider)
 
-    def __eq__(self, other):
+    def __eq__(self, other: object) -> bool:
         return (isinstance(other, Region) and
                 # pylint:disable=protected-access
                 self._provider == other._provider and
                 self.id == other.id)
 
-    def to_json(self):
+    def to_json(self) -> dict[str, Any]:
         attr = inspect.getmembers(self, lambda a: not (inspect.isroutine(a)))
         js = {k: v for (k, v) in attr if not k.startswith('_')}
         js['zones'] = [z.id for z in self.zones]
         return js
 
     @property
-    def default_zone(self):
+    def default_zone(self) -> PlacementZone:
         return next(iter(self.zones))
 
 
@@ -695,19 +755,19 @@ class BaseUploadPart(UploadPart):
     ``complete_multipart_upload``.
     """
 
-    def __init__(self, part_number, etag):
+    def __init__(self, part_number: int, etag: object) -> None:
         self._part_number = part_number
         self._etag = etag
 
     @property
-    def part_number(self):
+    def part_number(self) -> int:
         return self._part_number
 
     @property
-    def etag(self):
+    def etag(self) -> object:
         return self._etag
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return "<CB-{0}: {1} ({2})>".format(
             self.__class__.__name__, self._part_number, self._etag)
 
@@ -720,42 +780,54 @@ class BaseMultipartUpload(BaseCloudResource, MultipartUpload):
     (e.g. ``BaseBucket.delete``).
     """
 
-    def __init__(self, provider, bucket, object_name, upload_id):
+    def __init__(self, provider: CloudProvider, bucket: Bucket,
+                 object_name: str, upload_id: str) -> None:
         super(BaseMultipartUpload, self).__init__(provider)
         self._bucket = bucket
         self._object_name = object_name
         self._upload_id = upload_id
 
     @property
-    def id(self):
+    def id(self) -> str:
         return self._upload_id
 
     @property
-    def name(self):
+    def name(self) -> str:
         return self._object_name
 
     @property
-    def bucket(self):
+    def bucket(self) -> Bucket:
         return self._bucket
 
     @property
-    def object_name(self):
+    def object_name(self) -> str:
         return self._object_name
 
-    def upload_part(self, part_number, data):
+    def upload_part(self, part_number: int,
+                    data: bytes | IO[bytes]) -> UploadPart:
         # pylint:disable=protected-access
-        return self._provider.storage._bucket_objects.upload_part(
+        # _bucket_objects is a provider-internal service not exposed on the
+        # public StorageService interface, hence the typed cast + ignore.
+        return self._bucket_objects.upload_part(
             self._bucket, self, part_number, data)
 
-    def complete(self, parts):
+    def complete(self, parts: list[UploadPart]) -> BucketObject:
         # pylint:disable=protected-access
-        return self._provider.storage._bucket_objects\
-            .complete_multipart_upload(self._bucket, self, parts)
+        return self._bucket_objects.complete_multipart_upload(
+            self._bucket, self, parts)
 
-    def abort(self):
+    def abort(self) -> None:
         # pylint:disable=protected-access
-        return self._provider.storage._bucket_objects\
-            .abort_multipart_upload(self._bucket, self)
+        return self._bucket_objects.abort_multipart_upload(
+            self._bucket, self)
+
+    @property
+    def _bucket_objects(self) -> "BucketObjectService":
+        # _bucket_objects is a provider-internal service not exposed on the
+        # public StorageService interface, hence the typed cast + ignore.
+        return cast(
+            "BucketObjectService",
+            self._provider.storage._bucket_objects)  # type: ignore[attr-defined]
 
 
 class BaseBucketObject(BaseCloudResource, BucketObject):
@@ -781,16 +853,36 @@ class BaseBucketObject(BaseCloudResource, BucketObject):
     CB_MULTIPART_MAX_CONCURRENCY = int(os.environ.get(
         'CB_MULTIPART_MAX_CONCURRENCY', 5))
 
-    def __init__(self, provider):
+    def __init__(self, provider: CloudProvider) -> None:
         super(BaseBucketObject, self).__init__(provider)
 
+    @property
+    def bucket(self) -> Bucket:
+        # Provider-implemented; every concrete BucketObject knows its bucket.
+        raise NotImplementedError(
+            "BucketObject subclasses must implement the bucket property")
+
+    def _upload_single_shot(
+            self, data: str | bytes | IO[bytes]) -> BucketObject | None:
+        # Provider-implemented single-shot (non-multipart) upload.
+        raise NotImplementedError(
+            "BucketObject subclasses must implement _upload_single_shot")
+
+    @property
+    def _bucket_objects(self) -> "BucketObjectService":
+        # _bucket_objects is a provider-internal service not exposed on the
+        # public StorageService interface, hence the typed cast + ignore.
+        return cast(
+            "BucketObjectService",
+            self._provider.storage._bucket_objects)  # type: ignore[attr-defined]
+
     @staticmethod
-    def is_valid_resource_name(name):
+    def is_valid_resource_name(name: str) -> bool:
         return (True if BaseBucketObject.CB_NAME_PATTERN.match(name)
                 else False)
 
     @staticmethod
-    def assert_valid_resource_name(name):
+    def assert_valid_resource_name(name: str) -> None:
         if not BaseBucketObject.is_valid_resource_name(name):
             log.debug("InvalidLabelException raised on %s", name,
                       exc_info=True)
@@ -799,35 +891,42 @@ class BaseBucketObject(BaseCloudResource, BucketObject):
                 "in: http://docs.aws.amazon.com/AmazonS3/latest/dev/UsingMeta"
                 "data.html#object-key-guidelines" % name)
 
-    def save_content(self, target_stream):
-        shutil.copyfileobj(self.iter_content(), target_stream)
+    def save_content(self, target_stream: IO[bytes]) -> None:
+        # iter_content() is declared Iterable[bytes] on the interface, but the
+        # concrete objects returned by providers also support .read(); cast so
+        # copyfileobj accepts it without changing behavior.
+        shutil.copyfileobj(
+            cast("SupportsRead[bytes]", self.iter_content()), target_stream)
 
     # The three resolvers below pick, in order of precedence: an explicit
     # per-call UploadConfig field, the provider/global config, then the class
     # default constant.
-    def _multipart_threshold(self, config=None):
+    def _multipart_threshold(self, config: UploadConfig | None = None) -> int:
         if config is not None and config.threshold is not None:
             return int(config.threshold)
         # pylint:disable=protected-access
-        return int(self._provider._get_config_value(
+        # _get_config_value is a provider-internal helper not on the public
+        # CloudProvider interface, hence the ignore.
+        return int(self._provider._get_config_value(  # type: ignore[attr-defined]
             'multipart_threshold', self.CB_MULTIPART_THRESHOLD))
 
-    def _multipart_part_size(self, config=None):
+    def _multipart_part_size(self, config: UploadConfig | None = None) -> int:
         if config is not None and config.part_size is not None:
             return int(config.part_size)
         # pylint:disable=protected-access
-        return int(self._provider._get_config_value(
+        return int(self._provider._get_config_value(  # type: ignore[attr-defined]
             'multipart_part_size', self.CB_MULTIPART_PART_SIZE))
 
-    def _multipart_max_concurrency(self, config=None):
+    def _multipart_max_concurrency(
+            self, config: UploadConfig | None = None) -> int:
         if config is not None and config.max_concurrency is not None:
             return int(config.max_concurrency)
         # pylint:disable=protected-access
-        return int(self._provider._get_config_value(
+        return int(self._provider._get_config_value(  # type: ignore[attr-defined]
             'multipart_max_concurrency', self.CB_MULTIPART_MAX_CONCURRENCY))
 
     @staticmethod
-    def _data_size(data):
+    def _data_size(data: str | bytes | IO[bytes]) -> int | None:
         """
         Best-effort size of an upload payload, or ``None`` if it cannot be
         determined without consuming the data (e.g. a non-seekable stream).
@@ -848,26 +947,34 @@ class BaseBucketObject(BaseCloudResource, BucketObject):
         return None
 
     @staticmethod
-    def _as_stream(data):
+    def _as_stream(data: str | bytes | IO[bytes]) -> IO[bytes]:
         if isinstance(data, str):
             data = data.encode('utf-8')
         if isinstance(data, (bytes, bytearray)):
             return io.BytesIO(data)
         return data
 
-    def upload(self, data, config=None):
+    # NB: interface declares -> bool, but the base path returns the completed
+    # BucketObject (multipart) or None (single-shot); annotate honestly.
+    def upload(self, data: str | bytes | IO[bytes],  # type: ignore[override]
+               config: UploadConfig | None = None) -> BucketObject | None:
         size = self._data_size(data)
         if size is not None and size > self._multipart_threshold(config):
             return self._upload_multipart(self._as_stream(data), config)
         return self._upload_single_shot(data)
 
-    def upload_from_file(self, path, config=None):
+    # NB: interface declares -> None, but the base path returns the completed
+    # BucketObject for the multipart branch; annotate honestly.
+    def upload_from_file(  # type: ignore[override]
+            self, path: str,
+            config: UploadConfig | None = None) -> BucketObject | None:
         if os.path.getsize(path) > self._multipart_threshold(config):
             with open(path, 'rb') as f:
                 return self._upload_multipart(f, config)
         return self._upload_from_file_single_shot(path)
 
-    def _upload_multipart(self, stream, config=None):
+    def _upload_multipart(self, stream: IO[bytes],
+                          config: UploadConfig | None = None) -> BucketObject:
         """
         Drive the explicit multipart lifecycle over a stream, reading it one
         part at a time so the whole payload is never held in memory.
@@ -898,7 +1005,9 @@ class BaseBucketObject(BaseCloudResource, BucketObject):
             upload.abort()
             raise
 
-    def _upload_parts_serially(self, upload, stream, part_size):
+    def _upload_parts_serially(self, upload: MultipartUpload,
+                               stream: IO[bytes],
+                               part_size: int) -> list[UploadPart]:
         parts = []
         part_number = 1
         while True:
@@ -909,16 +1018,21 @@ class BaseBucketObject(BaseCloudResource, BucketObject):
             part_number += 1
         return parts
 
-    def _upload_parts_concurrently(self, upload, stream, part_size,
-                                   concurrency):
+    def _upload_parts_concurrently(self, upload: MultipartUpload,
+                                   stream: IO[bytes], part_size: int,
+                                   concurrency: int) -> list[UploadPart]:
         # A pool of cloned bucket-object services, one per worker, so each
         # thread touches an isolated provider/connection.
-        clones = queue.Queue()
+        clones: "queue.Queue[BucketObjectService]" = queue.Queue()
         for _ in range(concurrency):
             # pylint:disable=protected-access
-            clones.put(self._provider.clone().storage._bucket_objects)
+            # _bucket_objects is a provider-internal service not exposed on the
+            # public StorageService interface, hence the typed cast + ignore.
+            clones.put(cast(
+                "BucketObjectService",
+                self._provider.clone().storage._bucket_objects))  # type: ignore[attr-defined]
 
-        def upload_one(part_number, chunk):
+        def upload_one(part_number: int, chunk: bytes) -> UploadPart:
             service = clones.get()
             try:
                 return service.upload_part(
@@ -926,8 +1040,8 @@ class BaseBucketObject(BaseCloudResource, BucketObject):
             finally:
                 clones.put(service)
 
-        parts = []
-        in_flight = set()
+        parts: list[UploadPart] = []
+        in_flight: set[Future[UploadPart]] = set()
         part_number = 1
         depleted = False
         with ThreadPoolExecutor(max_workers=concurrency) as executor:
@@ -951,7 +1065,7 @@ class BaseBucketObject(BaseCloudResource, BucketObject):
         return parts
 
     @staticmethod
-    def _read_part(stream, part_size):
+    def _read_part(stream: IO[bytes], part_size: int) -> bytes:
         """
         Read exactly ``part_size`` bytes from ``stream`` (fewer only at EOF),
         coalescing short reads so non-final parts always meet the provider
@@ -965,7 +1079,8 @@ class BaseBucketObject(BaseCloudResource, BucketObject):
             buffer.extend(chunk)
         return bytes(buffer)
 
-    def _upload_from_file_single_shot(self, path):
+    def _upload_from_file_single_shot(
+            self, path: str) -> BucketObject | None:
         """
         Default small-file upload: read the file and hand it to the provider's
         single-shot upload. Providers with a more efficient native file upload
@@ -974,12 +1089,12 @@ class BaseBucketObject(BaseCloudResource, BucketObject):
         with open(path, 'rb') as f:
             return self._upload_single_shot(f)
 
-    def create_multipart_upload(self):
+    def create_multipart_upload(self) -> MultipartUpload:
         # pylint:disable=protected-access
-        return self._provider.storage._bucket_objects.create_multipart_upload(
+        return self._bucket_objects.create_multipart_upload(
             self.bucket, self.name)
 
-    def __eq__(self, other):
+    def __eq__(self, other: object) -> bool:
         return (isinstance(other, BucketObject) and
                 # pylint:disable=protected-access
                 self._provider == other._provider and
@@ -990,10 +1105,10 @@ class BaseBucketObject(BaseCloudResource, BucketObject):
 
 class BaseBucket(BaseCloudResource, Bucket):
 
-    def __init__(self, provider):
+    def __init__(self, provider: CloudProvider) -> None:
         super(BaseBucket, self).__init__(provider)
 
-    def __eq__(self, other):
+    def __eq__(self, other: object) -> bool:
         return (isinstance(other, Bucket) and
                 # pylint:disable=protected-access
                 self._provider == other._provider and
@@ -1001,11 +1116,16 @@ class BaseBucket(BaseCloudResource, Bucket):
                 # check from most to least likely mutables
                 self.name == other.name)
 
-    def delete(self):
+    # NB: interface declares delete(delete_contents=False) -> bool, but this
+    # base implementation takes no args and returns None; annotate honestly
+    # without altering behavior.
+    def delete(self) -> None:  # type: ignore[override]
         """
         Delete this bucket.
         """
-        self._provider.storage.buckets.delete(self.id)
+        # BucketService.delete is implemented by every provider but is not
+        # declared on the public typed interface, hence the ignore.
+        self._provider.storage.buckets.delete(self.id)  # type: ignore[attr-defined]
 
     # TODO: Discuss creating `create_object` method, or change docs
 
@@ -1017,11 +1137,11 @@ class BaseNetwork(BaseCloudResource, BaseObjectLifeCycleMixin, Network):
     CB_DEFAULT_IPV4RANGE = os.environ.get('CB_DEFAULT_IPV4RANGE',
                                           u'10.0.0.0/16')
 
-    def __init__(self, provider):
+    def __init__(self, provider: CloudProvider) -> None:
         super(BaseNetwork, self).__init__(provider)
 
     @staticmethod
-    def cidr_blocks_overlap(block1, block2):
+    def cidr_blocks_overlap(block1: str, block2: str) -> bool:
         common_length = min(int(block1.split('/')[1]),
                             int(block2.split('/')[1]))
 
@@ -1033,17 +1153,24 @@ class BaseNetwork(BaseCloudResource, BaseObjectLifeCycleMixin, Network):
 
         return prefix1 == prefix2
 
-    def wait_till_ready(self, timeout=None, interval=None):
+    # NB: interface declares -> bool but the implementation does not return a
+    # value (wait_for raises on failure); annotate honestly without altering
+    # behavior.
+    def wait_till_ready(  # type: ignore[override]
+            self, timeout: int | None = None,
+            interval: int | None = None) -> None:
         self.wait_for(
             [NetworkState.AVAILABLE],
             terminal_states=[NetworkState.ERROR],
             timeout=timeout,
             interval=interval)
 
-    def delete(self):
+    # NB: interface declares -> bool but NetworkService.delete returns None;
+    # annotate honestly without altering behavior.
+    def delete(self) -> None:  # type: ignore[override]
         self._provider.networking.networks.delete(self)
 
-    def __eq__(self, other):
+    def __eq__(self, other: object) -> bool:
         return (isinstance(other, Network) and
                 # pylint:disable=protected-access
                 self._provider == other._provider and
@@ -1057,61 +1184,78 @@ class BaseSubnet(BaseCloudResource, BaseObjectLifeCycleMixin, Subnet):
     CB_DEFAULT_SUBNET_IPV4RANGE = os.environ.get('CB_DEFAULT_SUBNET_IPV4RANGE',
                                                  '10.0.0.0/24')
 
-    def __init__(self, provider):
+    def __init__(self, provider: CloudProvider) -> None:
         super(BaseSubnet, self).__init__(provider)
 
-    def __eq__(self, other):
+    def __eq__(self, other: object) -> bool:
         return (isinstance(other, Subnet) and
                 # pylint:disable=protected-access
                 self._provider == other._provider and
                 self.id == other.id)
 
     @property
-    def network(self):
-        return self._provider.networking.networks.get(self.network_id)
+    def network(self) -> Network:
+        # The parent network of an existing subnet always resolves; the
+        # service get() is typed Network | None, so narrow to Network.
+        return cast(
+            Network, self._provider.networking.networks.get(self.network_id))
 
-    def wait_till_ready(self, timeout=None, interval=None):
+    # NB: interface declares -> bool but the implementation does not return a
+    # value (wait_for raises on failure); annotate honestly without altering
+    # behavior.
+    def wait_till_ready(  # type: ignore[override]
+            self, timeout: int | None = None,
+            interval: int | None = None) -> None:
         self.wait_for(
             [SubnetState.AVAILABLE],
             terminal_states=[SubnetState.ERROR],
             timeout=timeout,
             interval=interval)
 
-    def delete(self):
+    # NB: interface declares -> bool but SubnetService.delete returns None;
+    # annotate honestly without altering behavior.
+    def delete(self) -> None:  # type: ignore[override]
         self._provider.networking.subnets.delete(self)
 
 
 class BaseFloatingIP(BaseCloudResource, BaseObjectLifeCycleMixin, FloatingIP):
 
-    def __init__(self, provider):
+    def __init__(self, provider: CloudProvider) -> None:
         super(BaseFloatingIP, self).__init__(provider)
 
     @property
-    def name(self):
+    def name(self) -> str:
         return self.public_ip
 
     @property
-    def state(self):
+    def state(self) -> str:
         return (FloatingIpState.IN_USE if self.in_use
                 else FloatingIpState.AVAILABLE)
 
-    def wait_till_ready(self, timeout=None, interval=None):
+    # NB: interface declares -> bool but the implementation does not return a
+    # value (wait_for raises on failure); annotate honestly without altering
+    # behavior.
+    def wait_till_ready(  # type: ignore[override]
+            self, timeout: int | None = None,
+            interval: int | None = None) -> None:
         self.wait_for(
             [FloatingIpState.AVAILABLE, FloatingIpState.IN_USE],
             terminal_states=[FloatingIpState.ERROR],
             timeout=timeout,
             interval=interval)
 
-    def __eq__(self, other):
+    def __eq__(self, other: object) -> bool:
         return (isinstance(other, FloatingIP) and
                 # pylint:disable=protected-access
                 self._provider == other._provider and
                 self.id == other.id)
 
-    def delete(self):
+    # NB: interface declares -> bool but FloatingIPService.delete returns None;
+    # annotate honestly without altering behavior.
+    def delete(self) -> None:  # type: ignore[override]
         # For OS where the gateway is necessary, we pass the gateway when
         # deleting, for all others we pass None and it will be ignored
-        gw = getattr(self, '_gateway_id', None)
+        gw: Any = getattr(self, '_gateway_id', None)
         self._provider.networking._floating_ips.delete(gw, self.id)
 
 
@@ -1120,16 +1264,18 @@ class BaseRouter(BaseCloudResource, Router):
     CB_DEFAULT_ROUTER_LABEL = os.environ.get('CB_DEFAULT_ROUTER_LABEL',
                                              'cloudbridge-router')
 
-    def __init__(self, provider):
+    def __init__(self, provider: CloudProvider) -> None:
         super(BaseRouter, self).__init__(provider)
 
-    def __eq__(self, other):
+    def __eq__(self, other: object) -> bool:
         return (isinstance(other, Router) and
                 # pylint:disable=protected-access
                 self._provider == other._provider and
                 self.id == other.id)
 
-    def delete(self):
+    # NB: interface declares -> bool but RouterService.delete returns None;
+    # annotate honestly without altering behavior.
+    def delete(self) -> None:  # type: ignore[override]
         self._provider.networking.routers.delete(self)
 
 
@@ -1139,25 +1285,32 @@ class BaseInternetGateway(BaseCloudResource, BaseObjectLifeCycleMixin,
     CB_DEFAULT_INET_GATEWAY_NAME = cb_helpers.get_env(
         'CB_DEFAULT_INET_GATEWAY_NAME', 'cloudbridge-inetgateway')
 
-    def __init__(self, provider):
+    def __init__(self, provider: CloudProvider) -> None:
         super(BaseInternetGateway, self).__init__(provider)
 
-    def __eq__(self, other):
+    def __eq__(self, other: object) -> bool:
         return (isinstance(other, InternetGateway) and
                 # pylint:disable=protected-access
                 self._provider == other._provider and
                 self.id == other.id)
 
-    def wait_till_ready(self, timeout=None, interval=None):
+    # NB: interface declares -> bool but the implementation does not return a
+    # value (wait_for raises on failure); annotate honestly without altering
+    # behavior.
+    def wait_till_ready(  # type: ignore[override]
+            self, timeout: int | None = None,
+            interval: int | None = None) -> None:
         self.wait_for(
             [GatewayState.AVAILABLE],
             terminal_states=[GatewayState.ERROR, GatewayState.UNKNOWN],
             timeout=timeout,
             interval=interval)
 
-    def delete(self):
-        return self._provider.networking._gateways.delete(self.network_id,
-                                                          self)
+    def delete(self) -> None:
+        # A gateway is always attached to a network when it can be deleted;
+        # network_id is typed str | None, so narrow to str for the service.
+        return self._provider.networking._gateways.delete(
+            cast(str, self.network_id), self)
 
 
 class BaseDnsZone(BaseCloudResource, DnsZone):
@@ -1166,17 +1319,17 @@ class BaseDnsZone(BaseCloudResource, DnsZone):
         r"^(?:[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?\.)+[a-z0-9]"
         r"[a-z0-9-]{0,61}[a-z0-9]\.?$")
 
-    def __init__(self, provider):
+    def __init__(self, provider: CloudProvider) -> None:
         super(BaseDnsZone, self).__init__(provider)
 
-    def __eq__(self, other):
+    def __eq__(self, other: object) -> bool:
         return (isinstance(other, BaseDnsZone) and
                 # pylint:disable=protected-access
                 self._provider == other._provider and
                 self.id == other.id)
 
     @staticmethod
-    def is_valid_resource_name(name):
+    def is_valid_resource_name(name: str) -> bool:
         if not name:
             return False
         else:
@@ -1184,7 +1337,7 @@ class BaseDnsZone(BaseCloudResource, DnsZone):
                     else False)
 
     @staticmethod
-    def assert_valid_resource_name(name):
+    def assert_valid_resource_name(name: str) -> None:
         if not BaseDnsZone.is_valid_resource_name(name):
             log.debug("InvalidNameException raised on %s", name,
                       exc_info=True)
@@ -1193,7 +1346,7 @@ class BaseDnsZone(BaseCloudResource, DnsZone):
                 u"(ending with a .) and match criteria defined "
                 u"in: https://stackoverflow.com/q/10306690/10971151" % name)
 
-    def delete(self):
+    def delete(self) -> None:
         return self._provider.dns.host_zones.delete(self.id)
 
 
@@ -1203,17 +1356,17 @@ class BaseDnsRecord(BaseCloudResource, DnsRecord):
         r"^(?:\*\.)?(?:[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?\.)+[a-z0-9]"
         r"[a-z0-9-]{0,61}[a-z0-9]\.?$")
 
-    def __init__(self, provider):
+    def __init__(self, provider: CloudProvider) -> None:
         super(BaseDnsRecord, self).__init__(provider)
 
-    def __eq__(self, other):
+    def __eq__(self, other: object) -> bool:
         return (isinstance(other, BaseDnsRecord) and
                 # pylint:disable=protected-access
                 self._provider == other._provider and
                 self.id == other.id)
 
     @staticmethod
-    def is_valid_resource_name(name):
+    def is_valid_resource_name(name: str) -> bool:
         if not name:
             return False
         else:
@@ -1221,7 +1374,7 @@ class BaseDnsRecord(BaseCloudResource, DnsRecord):
                     else False)
 
     @staticmethod
-    def assert_valid_resource_name(name):
+    def assert_valid_resource_name(name: str) -> None:
         if not BaseDnsRecord.is_valid_resource_name(name):
             log.debug("InvalidNameException raised on %s", name,
                       exc_info=True)

--- a/cloudbridge/base/resources.py
+++ b/cloudbridge/base/resources.py
@@ -344,10 +344,7 @@ class BaseInstance(BaseCloudResource, BaseObjectLifeCycleMixin, Instance):
                 self.private_ips == other.private_ips and
                 self.image_id == other.image_id)
 
-    # NB: interface declares -> bool, but neither base nor provider
-    # implementations return a value (wait_for raises on failure); annotate
-    # honestly as -> None without altering behavior.
-    def wait_till_ready(  # type: ignore[override]
+    def wait_till_ready(
             self, timeout: int | None = None,
             interval: int | None = None) -> None:
         self.wait_for(
@@ -458,10 +455,7 @@ class BaseMachineImage(
                 self.label == other.label and
                 self.description == other.description)
 
-    # NB: interface declares -> bool but the implementation does not return a
-    # value (wait_for raises on failure); annotate honestly without altering
-    # behavior.
-    def wait_till_ready(  # type: ignore[override]
+    def wait_till_ready(
             self, timeout: int | None = None,
             interval: int | None = None) -> None:
         self.wait_for(
@@ -505,10 +499,7 @@ class BaseVolume(BaseCloudResource, BaseObjectLifeCycleMixin, Volume):
                 self.state == other.state and
                 self.label == other.label)
 
-    # NB: interface declares -> bool but the implementation does not return a
-    # value (wait_for raises on failure); annotate honestly without altering
-    # behavior.
-    def wait_till_ready(  # type: ignore[override]
+    def wait_till_ready(
             self, timeout: int | None = None,
             interval: int | None = None) -> None:
         self.wait_for(
@@ -517,9 +508,7 @@ class BaseVolume(BaseCloudResource, BaseObjectLifeCycleMixin, Volume):
             timeout=timeout,
             interval=interval)
 
-    # NB: interface declares -> bool but VolumeService.delete returns None;
-    # annotate honestly without altering behavior.
-    def delete(self) -> None:  # type: ignore[override]
+    def delete(self) -> None:
         """
         Delete this volume.
         """
@@ -540,10 +529,7 @@ class BaseSnapshot(BaseCloudResource, BaseObjectLifeCycleMixin, Snapshot):
                 self.state == other.state and
                 self.label == other.label)
 
-    # NB: interface declares -> bool but the implementation does not return a
-    # value (wait_for raises on failure); annotate honestly without altering
-    # behavior.
-    def wait_till_ready(  # type: ignore[override]
+    def wait_till_ready(
             self, timeout: int | None = None,
             interval: int | None = None) -> None:
         self.wait_for(
@@ -552,9 +538,7 @@ class BaseSnapshot(BaseCloudResource, BaseObjectLifeCycleMixin, Snapshot):
             timeout=timeout,
             interval=interval)
 
-    # NB: interface declares -> bool but SnapshotService.delete returns None;
-    # annotate honestly without altering behavior.
-    def delete(self) -> None:  # type: ignore[override]
+    def delete(self) -> None:
         """
         Delete this snapshot.
         """
@@ -597,9 +581,7 @@ class BaseKeyPair(BaseCloudResource, KeyPair):
     def material(self, value: str | None) -> None:
         self._private_material = value
 
-    # NB: interface declares -> bool but the implementation does not return a
-    # value; annotate honestly without altering behavior.
-    def delete(self) -> None:  # type: ignore[override]
+    def delete(self) -> None:
         self._provider.security.key_pairs.delete(self)
 
 
@@ -954,18 +936,14 @@ class BaseBucketObject(BaseCloudResource, BucketObject):
             return io.BytesIO(data)
         return data
 
-    # NB: interface declares -> bool, but the base path returns the completed
-    # BucketObject (multipart) or None (single-shot); annotate honestly.
-    def upload(self, data: str | bytes | IO[bytes],  # type: ignore[override]
+    def upload(self, data: str | bytes | IO[bytes],
                config: UploadConfig | None = None) -> BucketObject | None:
         size = self._data_size(data)
         if size is not None and size > self._multipart_threshold(config):
             return self._upload_multipart(self._as_stream(data), config)
         return self._upload_single_shot(data)
 
-    # NB: interface declares -> None, but the base path returns the completed
-    # BucketObject for the multipart branch; annotate honestly.
-    def upload_from_file(  # type: ignore[override]
+    def upload_from_file(
             self, path: str,
             config: UploadConfig | None = None) -> BucketObject | None:
         if os.path.getsize(path) > self._multipart_threshold(config):
@@ -1116,9 +1094,9 @@ class BaseBucket(BaseCloudResource, Bucket):
                 # check from most to least likely mutables
                 self.name == other.name)
 
-    # NB: interface declares delete(delete_contents=False) -> bool, but this
-    # base implementation takes no args and returns None; annotate honestly
-    # without altering behavior.
+    # NB: interface declares delete(delete_contents=False), but this base
+    # implementation takes no args; the override ignore covers that signature
+    # mismatch without altering behavior.
     def delete(self) -> None:  # type: ignore[override]
         """
         Delete this bucket.
@@ -1153,10 +1131,7 @@ class BaseNetwork(BaseCloudResource, BaseObjectLifeCycleMixin, Network):
 
         return prefix1 == prefix2
 
-    # NB: interface declares -> bool but the implementation does not return a
-    # value (wait_for raises on failure); annotate honestly without altering
-    # behavior.
-    def wait_till_ready(  # type: ignore[override]
+    def wait_till_ready(
             self, timeout: int | None = None,
             interval: int | None = None) -> None:
         self.wait_for(
@@ -1165,9 +1140,7 @@ class BaseNetwork(BaseCloudResource, BaseObjectLifeCycleMixin, Network):
             timeout=timeout,
             interval=interval)
 
-    # NB: interface declares -> bool but NetworkService.delete returns None;
-    # annotate honestly without altering behavior.
-    def delete(self) -> None:  # type: ignore[override]
+    def delete(self) -> None:
         self._provider.networking.networks.delete(self)
 
     def __eq__(self, other: object) -> bool:
@@ -1200,10 +1173,7 @@ class BaseSubnet(BaseCloudResource, BaseObjectLifeCycleMixin, Subnet):
         return cast(
             Network, self._provider.networking.networks.get(self.network_id))
 
-    # NB: interface declares -> bool but the implementation does not return a
-    # value (wait_for raises on failure); annotate honestly without altering
-    # behavior.
-    def wait_till_ready(  # type: ignore[override]
+    def wait_till_ready(
             self, timeout: int | None = None,
             interval: int | None = None) -> None:
         self.wait_for(
@@ -1212,9 +1182,7 @@ class BaseSubnet(BaseCloudResource, BaseObjectLifeCycleMixin, Subnet):
             timeout=timeout,
             interval=interval)
 
-    # NB: interface declares -> bool but SubnetService.delete returns None;
-    # annotate honestly without altering behavior.
-    def delete(self) -> None:  # type: ignore[override]
+    def delete(self) -> None:
         self._provider.networking.subnets.delete(self)
 
 
@@ -1232,10 +1200,7 @@ class BaseFloatingIP(BaseCloudResource, BaseObjectLifeCycleMixin, FloatingIP):
         return (FloatingIpState.IN_USE if self.in_use
                 else FloatingIpState.AVAILABLE)
 
-    # NB: interface declares -> bool but the implementation does not return a
-    # value (wait_for raises on failure); annotate honestly without altering
-    # behavior.
-    def wait_till_ready(  # type: ignore[override]
+    def wait_till_ready(
             self, timeout: int | None = None,
             interval: int | None = None) -> None:
         self.wait_for(
@@ -1250,9 +1215,7 @@ class BaseFloatingIP(BaseCloudResource, BaseObjectLifeCycleMixin, FloatingIP):
                 self._provider == other._provider and
                 self.id == other.id)
 
-    # NB: interface declares -> bool but FloatingIPService.delete returns None;
-    # annotate honestly without altering behavior.
-    def delete(self) -> None:  # type: ignore[override]
+    def delete(self) -> None:
         # For OS where the gateway is necessary, we pass the gateway when
         # deleting, for all others we pass None and it will be ignored
         gw: Any = getattr(self, '_gateway_id', None)
@@ -1273,9 +1236,7 @@ class BaseRouter(BaseCloudResource, Router):
                 self._provider == other._provider and
                 self.id == other.id)
 
-    # NB: interface declares -> bool but RouterService.delete returns None;
-    # annotate honestly without altering behavior.
-    def delete(self) -> None:  # type: ignore[override]
+    def delete(self) -> None:
         self._provider.networking.routers.delete(self)
 
 
@@ -1294,10 +1255,7 @@ class BaseInternetGateway(BaseCloudResource, BaseObjectLifeCycleMixin,
                 self._provider == other._provider and
                 self.id == other.id)
 
-    # NB: interface declares -> bool but the implementation does not return a
-    # value (wait_for raises on failure); annotate honestly without altering
-    # behavior.
-    def wait_till_ready(  # type: ignore[override]
+    def wait_till_ready(
             self, timeout: int | None = None,
             interval: int | None = None) -> None:
         self.wait_for(

--- a/cloudbridge/base/services.py
+++ b/cloudbridge/base/services.py
@@ -2,10 +2,30 @@
 Base implementation for services available through a provider
 """
 import logging
+from typing import Any
+from typing import cast
 
 from cloudbridge.interfaces.exceptions import InvalidParamException
+from cloudbridge.interfaces.provider import CloudProvider
+from cloudbridge.interfaces.resources import Bucket
+from cloudbridge.interfaces.resources import DnsRecord
 from cloudbridge.interfaces.resources import DnsRecordType
+from cloudbridge.interfaces.resources import DnsZone
+from cloudbridge.interfaces.resources import FloatingIP
+from cloudbridge.interfaces.resources import Gateway
+from cloudbridge.interfaces.resources import Instance
+from cloudbridge.interfaces.resources import KeyPair
+from cloudbridge.interfaces.resources import MachineImage
 from cloudbridge.interfaces.resources import Network
+from cloudbridge.interfaces.resources import Region
+from cloudbridge.interfaces.resources import ResultList
+from cloudbridge.interfaces.resources import Router
+from cloudbridge.interfaces.resources import Snapshot
+from cloudbridge.interfaces.resources import Subnet
+from cloudbridge.interfaces.resources import VMFirewall
+from cloudbridge.interfaces.resources import VMFirewallRule
+from cloudbridge.interfaces.resources import VMType
+from cloudbridge.interfaces.resources import Volume
 from cloudbridge.interfaces.services import BucketObjectService
 from cloudbridge.interfaces.services import BucketService
 from cloudbridge.interfaces.services import CloudService
@@ -46,46 +66,47 @@ class BaseCloudService(CloudService):
 
     STANDARD_EVENT_PRIORITY = 2500
 
-    def __init__(self, provider):
+    def __init__(self, provider: CloudProvider) -> None:
         self._service_event_pattern = "provider"
         self._provider = provider
         # discover and register all middleware
         provider.middleware.add(self)
 
     @property
-    def provider(self):
+    def provider(self) -> CloudProvider:
         return self._provider
 
     @property
-    def events(self):
+    def events(self) -> Any:
         return self._provider.middleware.events
 
 
 class BaseSecurityService(SecurityService, BaseCloudService):
 
-    def __init__(self, provider):
+    def __init__(self, provider: CloudProvider) -> None:
         super(BaseSecurityService, self).__init__(provider)
 
 
 class BaseKeyPairService(
-        BasePageableObjectMixin, KeyPairService, BaseCloudService):
+        BasePageableObjectMixin[KeyPair], KeyPairService, BaseCloudService):
 
-    def __init__(self, provider):
+    def __init__(self, provider: CloudProvider) -> None:
         super(BaseKeyPairService, self).__init__(provider)
         self._service_event_pattern += ".security.key_pairs"
 
 
 class BaseVMFirewallService(
-        BasePageableObjectMixin, VMFirewallService, BaseCloudService):
+        BasePageableObjectMixin[VMFirewall], VMFirewallService,
+        BaseCloudService):
 
-    def __init__(self, provider):
+    def __init__(self, provider: CloudProvider) -> None:
         super(BaseVMFirewallService, self).__init__(provider)
         self._service_event_pattern += ".security.vm_firewalls"
 
     @dispatch(event="provider.security.vm_firewalls.find",
               priority=BaseCloudService.STANDARD_EVENT_PRIORITY)
-    def find(self, **kwargs):
-        obj_list = self
+    def find(self, **kwargs: Any) -> ResultList[VMFirewall]:
+        obj_list = list(self)
         filters = ['label']
         matches = cb_helpers.generic_find(filters, kwargs, obj_list)
 
@@ -99,21 +120,26 @@ class BaseVMFirewallService(
                                      matches if matches else [])
 
 
-class BaseVMFirewallRuleService(BasePageableObjectMixin,
-                                VMFirewallRuleService,
-                                BaseCloudService):
+# The pageable mixin's list(limit, marker) intentionally differs from this
+# service's list(firewall, limit, marker); the mixin is reused only for its
+# iteration helpers, so the signature clash is expected.
+class BaseVMFirewallRuleService(  # type: ignore[misc]
+        BasePageableObjectMixin[VMFirewallRule],
+        VMFirewallRuleService,
+        BaseCloudService):
 
-    def __init__(self, provider):
+    def __init__(self, provider: CloudProvider) -> None:
         super(BaseVMFirewallRuleService, self).__init__(provider)
         self._provider = provider
 
     @property
-    def provider(self):
+    def provider(self) -> CloudProvider:
         return self._provider
 
     @dispatch(event="provider.security.vm_firewall_rules.get",
               priority=BaseCloudService.STANDARD_EVENT_PRIORITY)
-    def get(self, firewall, rule_id):
+    def get(self, firewall: VMFirewall,
+            rule_id: str) -> VMFirewallRule | None:
         matches = [rule for rule in firewall.rules if rule.id == rule_id]
         if matches:
             return matches[0]
@@ -122,8 +148,9 @@ class BaseVMFirewallRuleService(BasePageableObjectMixin,
 
     @dispatch(event="provider.security.vm_firewall_rules.find",
               priority=BaseCloudService.STANDARD_EVENT_PRIORITY)
-    def find(self, firewall, **kwargs):
-        obj_list = firewall.rules
+    def find(self, firewall: VMFirewall,
+             **kwargs: Any) -> ResultList[VMFirewallRule]:
+        obj_list = list(firewall.rules)
         filters = ['name', 'direction', 'protocol', 'from_port', 'to_port',
                    'cidr', 'src_dest_fw', 'src_dest_fw_id']
         matches = cb_helpers.generic_find(filters, kwargs, obj_list)
@@ -132,30 +159,30 @@ class BaseVMFirewallRuleService(BasePageableObjectMixin,
 
 class BaseStorageService(StorageService, BaseCloudService):
 
-    def __init__(self, provider):
+    def __init__(self, provider: CloudProvider) -> None:
         super(BaseStorageService, self).__init__(provider)
 
 
 class BaseVolumeService(
-        BasePageableObjectMixin, VolumeService, BaseCloudService):
+        BasePageableObjectMixin[Volume], VolumeService, BaseCloudService):
 
-    def __init__(self, provider):
+    def __init__(self, provider: CloudProvider) -> None:
         super(BaseVolumeService, self).__init__(provider)
         self._service_event_pattern += ".storage.volumes"
 
 
 class BaseSnapshotService(
-        BasePageableObjectMixin, SnapshotService, BaseCloudService):
+        BasePageableObjectMixin[Snapshot], SnapshotService, BaseCloudService):
 
-    def __init__(self, provider):
+    def __init__(self, provider: CloudProvider) -> None:
         super(BaseSnapshotService, self).__init__(provider)
         self._service_event_pattern += ".storage.snapshots"
 
 
 class BaseBucketService(
-        BasePageableObjectMixin, BucketService, BaseCloudService):
+        BasePageableObjectMixin[Bucket], BucketService, BaseCloudService):
 
-    def __init__(self, provider):
+    def __init__(self, provider: CloudProvider) -> None:
         super(BaseBucketService, self).__init__(provider)
         self._service_event_pattern += ".storage.buckets"
 
@@ -163,8 +190,8 @@ class BaseBucketService(
     # provider-specific querying for find method
     @dispatch(event="provider.storage.buckets.find",
               priority=BaseCloudService.STANDARD_EVENT_PRIORITY)
-    def find(self, **kwargs):
-        obj_list = self
+    def find(self, **kwargs: Any) -> ResultList[Bucket]:
+        obj_list = list(self)
         filters = ['name']
         matches = cb_helpers.generic_find(filters, kwargs, obj_list)
 
@@ -180,67 +207,67 @@ class BaseBucketService(
 
 class BaseBucketObjectService(BucketObjectService, BaseCloudService):
 
-    def __init__(self, provider):
+    def __init__(self, provider: CloudProvider) -> None:
         super(BaseBucketObjectService, self).__init__(provider)
         self._service_event_pattern += ".storage._bucket_objects"
-        self._bucket = None
+        self._bucket: Bucket | None = None
 
 
 class BaseComputeService(ComputeService, BaseCloudService):
 
-    def __init__(self, provider):
+    def __init__(self, provider: CloudProvider) -> None:
         super(BaseComputeService, self).__init__(provider)
 
 
 class BaseImageService(
-        BasePageableObjectMixin, ImageService, BaseCloudService):
+        BasePageableObjectMixin[MachineImage], ImageService, BaseCloudService):
 
-    def __init__(self, provider):
+    def __init__(self, provider: CloudProvider) -> None:
         super(BaseImageService, self).__init__(provider)
         self._service_event_pattern += ".compute.images"
 
 
 class BaseInstanceService(
-        BasePageableObjectMixin, InstanceService, BaseCloudService):
+        BasePageableObjectMixin[Instance], InstanceService, BaseCloudService):
 
-    def __init__(self, provider):
+    def __init__(self, provider: CloudProvider) -> None:
         super(BaseInstanceService, self).__init__(provider)
         self._service_event_pattern += ".compute.instances"
 
 
 class BaseVMTypeService(
-        BasePageableObjectMixin, VMTypeService, BaseCloudService):
+        BasePageableObjectMixin[VMType], VMTypeService, BaseCloudService):
 
-    def __init__(self, provider):
+    def __init__(self, provider: CloudProvider) -> None:
         super(BaseVMTypeService, self).__init__(provider)
         self._service_event_pattern += ".compute.vm_types"
 
     @dispatch(event="provider.compute.vm_types.get",
               priority=BaseCloudService.STANDARD_EVENT_PRIORITY)
-    def get(self, vm_type_id):
+    def get(self, vm_type_id: str) -> VMType | None:
         vm_type = (t for t in self if t.id == vm_type_id)
         return next(vm_type, None)
 
     @dispatch(event="provider.compute.vm_types.find",
               priority=BaseCloudService.STANDARD_EVENT_PRIORITY)
-    def find(self, **kwargs):
-        obj_list = self
+    def find(self, **kwargs: Any) -> ResultList[VMType]:
+        obj_list = list(self)
         filters = ['name']
         matches = cb_helpers.generic_find(filters, kwargs, obj_list)
         return ClientPagedResultList(self._provider, list(matches))
 
 
 class BaseRegionService(
-        BasePageableObjectMixin, RegionService, BaseCloudService):
+        BasePageableObjectMixin[Region], RegionService, BaseCloudService):
 
-    def __init__(self, provider):
+    def __init__(self, provider: CloudProvider) -> None:
         super(BaseRegionService, self).__init__(provider)
         self._service_event_pattern += ".compute.regions"
 
     @dispatch(event="provider.compute.regions.find",
               priority=BaseCloudService.STANDARD_EVENT_PRIORITY)
-    def find(self, **kwargs):
-        obj_list = self
+    def find(self, **kwargs: Any) -> ResultList[Region]:
+        obj_list = list(self)
         filters = ['name']
         matches = cb_helpers.generic_find(filters, kwargs, obj_list)
         return ClientPagedResultList(self._provider, list(matches))
@@ -248,23 +275,27 @@ class BaseRegionService(
 
 class BaseNetworkingService(NetworkingService, BaseCloudService):
 
-    def __init__(self, provider):
+    def __init__(self, provider: CloudProvider) -> None:
         super(BaseNetworkingService, self).__init__(provider)
 
 
 class BaseNetworkService(
-        BasePageableObjectMixin, NetworkService, BaseCloudService):
+        BasePageableObjectMixin[Network], NetworkService, BaseCloudService):
 
-    def __init__(self, provider):
+    def __init__(self, provider: CloudProvider) -> None:
         super(BaseNetworkService, self).__init__(provider)
         self._service_event_pattern += ".networking.networks"
 
     @property
-    def subnets(self):
-        return [subnet for subnet in self.provider.subnets
-                if subnet.network_id == self.id]
+    def subnets(self) -> list[Subnet]:  # type: ignore[override]
+        # NOTE: this base implementation is a stub that every provider
+        # overrides; it references attributes that do not exist on the
+        # service, so the accesses are typed through ``Any``.
+        this: Any = self
+        return [subnet for subnet in this.provider.subnets
+                if subnet.network_id == this.id]
 
-    def get_or_create_default(self):
+    def get_or_create_default(self) -> Network:
         networks = self.provider.networking.networks.find(
             label=BaseNetwork.CB_DEFAULT_NETWORK_LABEL)
 
@@ -278,8 +309,8 @@ class BaseNetworkService(
 
     @dispatch(event="provider.networking.networks.find",
               priority=BaseCloudService.STANDARD_EVENT_PRIORITY)
-    def find(self, **kwargs):
-        obj_list = self
+    def find(self, **kwargs: Any) -> ResultList[Network]:
+        obj_list = list(self)
         filters = ['label']
         matches = cb_helpers.generic_find(filters, kwargs, obj_list)
 
@@ -294,15 +325,17 @@ class BaseNetworkService(
 
 
 class BaseSubnetService(
-        BasePageableObjectMixin, SubnetService, BaseCloudService):
+        BasePageableObjectMixin[Subnet], SubnetService, BaseCloudService):
 
-    def __init__(self, provider):
+    def __init__(self, provider: CloudProvider) -> None:
         super(BaseSubnetService, self).__init__(provider)
         self._service_event_pattern += ".networking.subnets"
 
     @dispatch(event="provider.networking.subnets.find",
               priority=BaseCloudService.STANDARD_EVENT_PRIORITY)
-    def find(self, network=None, **kwargs):
+    def find(self, network: Network | None = None,
+             **kwargs: Any) -> ResultList[Subnet]:
+        obj_list: Any
         if not network:
             obj_list = self
         else:
@@ -311,27 +344,30 @@ class BaseSubnetService(
         matches = cb_helpers.generic_find(filters, kwargs, obj_list)
         return ClientPagedResultList(self._provider, list(matches))
 
-    def get_or_create_default(self):
+    def get_or_create_default(self) -> Subnet:
         # Look for a CB-default subnet
-        matches = self.find(label=BaseSubnet.CB_DEFAULT_SUBNET_LABEL)
+        matches: ResultList[Subnet] = self.find(
+            label=BaseSubnet.CB_DEFAULT_SUBNET_LABEL)
         if matches:
             return matches[0]
 
         # No provider-default Subnet exists, try to create it (net + subnets)
-        network = self.provider.networking.networks.get_or_create_default()
+        networks = cast(BaseNetworkService,
+                        self.provider.networking.networks)
+        network = networks.get_or_create_default()
         subnet = self.create(BaseSubnet.CB_DEFAULT_SUBNET_LABEL, network,
                              BaseSubnet.CB_DEFAULT_SUBNET_IPV4RANGE)
         return subnet
 
 
 class BaseRouterService(
-        BasePageableObjectMixin, RouterService, BaseCloudService):
+        BasePageableObjectMixin[Router], RouterService, BaseCloudService):
 
-    def __init__(self, provider):
+    def __init__(self, provider: CloudProvider) -> None:
         super(BaseRouterService, self).__init__(provider)
         self._service_event_pattern += ".networking.routers"
 
-    def get_or_create_default(self, network):
+    def get_or_create_default(self, network: Network | str) -> Router:
         net_id = network.id if isinstance(network, Network) else network
         routers = self.provider.networking.routers.find(
             label=BaseRouter.CB_DEFAULT_ROUTER_LABEL)
@@ -345,19 +381,20 @@ class BaseRouterService(
 
 class BaseGatewayService(GatewayService, BaseCloudService):
 
-    def __init__(self, provider):
+    def __init__(self, provider: CloudProvider) -> None:
         super(BaseGatewayService, self).__init__(provider)
 
 
 class BaseFloatingIPService(FloatingIPService, BaseCloudService):
 
-    def __init__(self, provider):
+    def __init__(self, provider: CloudProvider) -> None:
         super(BaseFloatingIPService, self).__init__(provider)
 
     @dispatch(event="provider.networking.floating_ips.find",
               priority=BaseCloudService.STANDARD_EVENT_PRIORITY)
-    def find(self, gateway, **kwargs):
-        obj_list = gateway.floating_ips
+    def find(self, gateway: Gateway,
+             **kwargs: Any) -> ResultList[FloatingIP]:
+        obj_list = list(gateway.floating_ips)
         filters = ['name', 'public_ip']
         matches = cb_helpers.generic_find(filters, kwargs, obj_list)
         return ClientPagedResultList(self._provider, list(matches))
@@ -365,31 +402,36 @@ class BaseFloatingIPService(FloatingIPService, BaseCloudService):
 
 class BaseDnsService(DnsService, BaseCloudService):
 
-    def __init__(self, provider):
+    def __init__(self, provider: CloudProvider) -> None:
         super(BaseDnsService, self).__init__(provider)
 
 
-class BaseDnsZoneService(BasePageableObjectMixin, DnsZoneService,
+class BaseDnsZoneService(BasePageableObjectMixin[DnsZone], DnsZoneService,
                          BaseCloudService):
 
-    def __init__(self, provider):
+    def __init__(self, provider: CloudProvider) -> None:
         super(BaseDnsZoneService, self).__init__(provider)
 
-    def _get_fully_qualified_dns(self, name):
+    def _get_fully_qualified_dns(self, name: str) -> str:
         # Add a trailing dot to fully qualify
         return name + '.' if not name.endswith('.') else name
 
 
-class BaseDnsRecordService(BasePageableObjectMixin, DnsRecordService,
-                           BaseCloudService):
+# The pageable mixin's list(limit, marker) intentionally differs from this
+# service's list(dns_zone, limit, marker); the mixin is reused only for its
+# iteration helpers, so the signature clash is expected.
+class BaseDnsRecordService(  # type: ignore[misc]
+        BasePageableObjectMixin[DnsRecord],
+        DnsRecordService,
+        BaseCloudService):
 
-    def __init__(self, provider):
+    def __init__(self, provider: CloudProvider) -> None:
         super(BaseDnsRecordService, self).__init__(provider)
 
-    def _get_fully_qualified_dns(self, name):
+    def _get_fully_qualified_dns(self, name: str) -> str:
         # Add a trailing dot to fully qualify
         return name + '.' if not name.endswith('.') else name
 
-    def _standardize_record(self, value, type):
+    def _standardize_record(self, value: str, type: str) -> str:
         return (self._get_fully_qualified_dns(value)
                 if type in (DnsRecordType.CNAME, DnsRecordType.MX) else value)

--- a/cloudbridge/base/services.py
+++ b/cloudbridge/base/services.py
@@ -2,6 +2,7 @@
 Base implementation for services available through a provider
 """
 import logging
+from abc import abstractmethod
 from typing import Any
 from typing import cast
 
@@ -161,6 +162,20 @@ class BaseStorageService(StorageService, BaseCloudService):
 
     def __init__(self, provider: CloudProvider) -> None:
         super(BaseStorageService, self).__init__(provider)
+
+    @property
+    @abstractmethod
+    def _bucket_objects(self) -> BucketObjectService:
+        """
+        Provider-internal service backing bucket-object operations.
+
+        This is the service that ``bucket.objects`` (BucketObjectSubService)
+        and the base multipart-upload code delegate to. It is a base-layer
+        implementation detail, deliberately not part of the public
+        StorageService interface; every provider's storage service implements
+        it.
+        """
+        pass
 
 
 class BaseVolumeService(

--- a/cloudbridge/base/subservices.py
+++ b/cloudbridge/base/subservices.py
@@ -1,5 +1,23 @@
+import builtins
 import logging
+from typing import Any
+from typing import cast
 
+from cloudbridge.interfaces.provider import CloudProvider
+from cloudbridge.interfaces.resources import Bucket
+from cloudbridge.interfaces.resources import BucketObject
+from cloudbridge.interfaces.resources import DnsRecord
+from cloudbridge.interfaces.resources import DnsZone
+from cloudbridge.interfaces.resources import FloatingIP
+from cloudbridge.interfaces.resources import Gateway
+from cloudbridge.interfaces.resources import InternetGateway
+from cloudbridge.interfaces.resources import Network
+from cloudbridge.interfaces.resources import ResultList
+from cloudbridge.interfaces.resources import Subnet
+from cloudbridge.interfaces.resources import TrafficDirection
+from cloudbridge.interfaces.resources import VMFirewall
+from cloudbridge.interfaces.resources import VMFirewallRule
+from cloudbridge.interfaces.services import BucketObjectService
 from cloudbridge.interfaces.subservices import BucketObjectSubService
 from cloudbridge.interfaces.subservices import DnsRecordSubService
 from cloudbridge.interfaces.subservices import FloatingIPSubService
@@ -12,191 +30,216 @@ from .resources import BasePageableObjectMixin
 log = logging.getLogger(__name__)
 
 
-class BaseBucketObjectSubService(BasePageableObjectMixin,
+class BaseBucketObjectSubService(BasePageableObjectMixin[BucketObject],
                                  BucketObjectSubService):
 
-    def __init__(self, provider, bucket):
+    def __init__(self, provider: CloudProvider, bucket: Bucket) -> None:
         self.__provider = provider
         self.bucket = bucket
 
     @property
-    def _provider(self):
+    def _provider(self) -> CloudProvider:
         return self.__provider
 
-    def get(self, name):
-        return self._provider.storage._bucket_objects.get(self.bucket, name)
+    @property
+    def _bucket_objects(self) -> BucketObjectService:
+        # ``_bucket_objects`` is a provider-internal service not declared on
+        # the StorageService interface; reach it through ``Any``.
+        storage: Any = self._provider.storage
+        return cast(BucketObjectService, storage._bucket_objects)
 
-    def list(self, limit=None, marker=None, prefix=None):
-        return self._provider.storage._bucket_objects.list(self.bucket, limit,
-                                                           marker, prefix)
+    def get(self, name: str) -> BucketObject | None:
+        return self._bucket_objects.get(self.bucket, name)
 
-    def find(self, **kwargs):
-        return self._provider.storage._bucket_objects.find(self.bucket,
-                                                           **kwargs)
+    def list(self, limit: int | None = None, marker: str | None = None,
+             prefix: str | None = None) -> ResultList[BucketObject]:
+        return self._bucket_objects.list(self.bucket, limit=limit,
+                                         marker=marker, prefix=prefix)
 
-    def create(self, name):
-        return self._provider.storage._bucket_objects.create(self.bucket, name)
+    def find(self, **kwargs: Any) -> ResultList[BucketObject]:
+        return self._bucket_objects.find(self.bucket, **kwargs)
+
+    def create(self, name: str) -> BucketObject:
+        return self._bucket_objects.create(self.bucket, name)
 
 
-class BaseGatewaySubService(GatewaySubService, BasePageableObjectMixin):
+class BaseGatewaySubService(GatewaySubService,
+                            BasePageableObjectMixin[InternetGateway]):
 
-    def __init__(self, provider, network):
+    def __init__(self, provider: CloudProvider, network: Network) -> None:
         self._network = network
         self.__provider = provider
 
     @property
-    def _provider(self):
+    def _provider(self) -> CloudProvider:
         return self.__provider
 
-    def get_or_create(self):
+    def get_or_create(self) -> InternetGateway:
         return (self._provider.networking
                               ._gateways
                               .get_or_create(self._network))
 
-    def delete(self, gateway):
+    def delete(self, gateway: Gateway) -> None:
         return (self._provider.networking
                               ._gateways
                               .delete(self._network, gateway))
 
-    def list(self, limit=None, marker=None):
+    def list(self, limit: int | None = None,
+             marker: str | None = None) -> ResultList[InternetGateway]:
         return (self._provider.networking
                               ._gateways
                               .list(self._network, limit, marker))
 
 
-class BaseVMFirewallRuleSubService(BasePageableObjectMixin,
+class BaseVMFirewallRuleSubService(BasePageableObjectMixin[VMFirewallRule],
                                    VMFirewallRuleSubService):
 
-    def __init__(self, provider, firewall):
+    def __init__(self, provider: CloudProvider,
+                 firewall: VMFirewall) -> None:
         self.__provider = provider
         self._firewall = firewall
 
     @property
-    def _provider(self):
+    def _provider(self) -> CloudProvider:
         return self.__provider
 
-    def get(self, rule_id):
+    def get(self, rule_id: str) -> VMFirewallRule | None:
         return self._provider.security._vm_firewall_rules.get(self._firewall,
                                                               rule_id)
 
-    def list(self, limit=None, marker=None):
+    def list(self, limit: int | None = None,
+             marker: str | None = None) -> ResultList[VMFirewallRule]:
         return self._provider.security._vm_firewall_rules.list(self._firewall,
                                                                limit, marker)
 
-    def create(self, direction, protocol=None, from_port=None,
-               to_port=None, cidr=None, src_dest_fw=None):
+    def create(self, direction: TrafficDirection, protocol: str | None = None,
+               from_port: int | None = None,
+               to_port: int | None = None,
+               cidr: str | builtins.list[str] | None = None,
+               src_dest_fw: VMFirewall | None = None) -> VMFirewallRule:
         return (self._provider
                     .security
                     ._vm_firewall_rules
                     .create(self._firewall, direction, protocol, from_port,
                             to_port, cidr, src_dest_fw))
 
-    def find(self, **kwargs):
+    def find(self, **kwargs: Any) -> ResultList[VMFirewallRule]:
         return self._provider.security._vm_firewall_rules.find(self._firewall,
                                                                **kwargs)
 
-    def delete(self, rule_id):
+    def delete(self, rule_id: str) -> None:
         return (self._provider
                     .security
                     ._vm_firewall_rules
                     .delete(self._firewall, rule_id))
 
 
-class BaseFloatingIPSubService(FloatingIPSubService, BasePageableObjectMixin):
+class BaseFloatingIPSubService(FloatingIPSubService,
+                               BasePageableObjectMixin[FloatingIP]):
 
-    def __init__(self, provider, gateway):
+    def __init__(self, provider: CloudProvider, gateway: Gateway) -> None:
         self.__provider = provider
         self.gateway = gateway
 
     @property
-    def _provider(self):
+    def _provider(self) -> CloudProvider:
         return self.__provider
 
-    def get(self, fip_id):
+    def get(self, fip_id: str) -> FloatingIP | None:
         return self._provider.networking._floating_ips.get(self.gateway,
                                                            fip_id)
 
-    def list(self, limit=None, marker=None):
+    def list(self, limit: int | None = None,
+             marker: str | None = None) -> ResultList[FloatingIP]:
         return self._provider.networking._floating_ips.list(self.gateway,
                                                             limit, marker)
 
-    def find(self, **kwargs):
+    def find(self, **kwargs: Any) -> ResultList[FloatingIP]:
         return self._provider.networking._floating_ips.find(self.gateway,
                                                             **kwargs)
 
-    def create(self):
+    def create(self) -> FloatingIP:
         return self._provider.networking._floating_ips.create(self.gateway)
 
-    def delete(self, fip):
+    def delete(self, fip: FloatingIP | str) -> None:
         return self._provider.networking._floating_ips.delete(self.gateway,
                                                               fip)
 
 
-class BaseSubnetSubService(SubnetSubService, BasePageableObjectMixin):
+class BaseSubnetSubService(SubnetSubService, BasePageableObjectMixin[Subnet]):
 
-    def __init__(self, provider, network):
+    def __init__(self, provider: CloudProvider, network: Network) -> None:
         self.__provider = provider
         self.network = network
 
     @property
-    def _provider(self):
+    def _provider(self) -> CloudProvider:
         return self.__provider
 
-    def get(self, subnet_id):
+    def get(self, subnet_id: str) -> Subnet | None:
         sn = self._provider.networking.subnets.get(subnet_id)
-        if sn.network_id != self.network.id:
+        if sn and sn.network_id != self.network.id:
             log.warning("The SubnetSubService nested in the network '{}' "
                         "returned subnet '{}' which is attached to another "
                         "network '{}'".format(str(self.network), str(sn),
                                               str(sn.network)))
         return sn
 
-    def list(self, limit=None, marker=None):
+    def list(self, limit: int | None = None,
+             marker: str | None = None) -> ResultList[Subnet]:
         return self._provider.networking.subnets.list(network=self.network,
                                                       limit=limit,
                                                       marker=marker)
 
-    def find(self, **kwargs):
+    def find(self, **kwargs: Any) -> ResultList[Subnet]:
         return self._provider.networking.subnets.find(network=self.network,
                                                       **kwargs)
 
-    def create(self, label, cidr_block):
+    def create(self, label: str, cidr_block: str) -> Subnet:
         return self._provider.networking.subnets.create(label,
                                                         self.network,
                                                         cidr_block)
 
-    def delete(self, subnet):
+    def delete(self, subnet: Subnet | str) -> None:
         return self._provider.networking.subnets.delete(subnet)
 
 
-class BaseDnsRecordSubService(DnsRecordSubService, BasePageableObjectMixin):
+class BaseDnsRecordSubService(DnsRecordSubService,
+                              BasePageableObjectMixin[DnsRecord]):
 
-    def __init__(self, provider, dns_zone):
+    def __init__(self, provider: CloudProvider, dns_zone: DnsZone) -> None:
         self.__provider = provider
         self.dns_zone = dns_zone
 
     @property
-    def _provider(self):
+    def _provider(self) -> CloudProvider:
         return self.__provider
 
-    def get(self, rec_id):
+    def get(self, rec_id: str) -> DnsRecord | None:
         # pylint:disable=protected-access
         return self._provider.dns._records.get(self.dns_zone, rec_id)
 
-    def list(self, limit=None, marker=None):
+    def list(self, limit: int | None = None,
+             marker: str | None = None) -> ResultList[DnsRecord]:
         # pylint:disable=protected-access
         return self._provider.dns._records.list(
             dns_zone=self.dns_zone, limit=limit, marker=marker)
 
-    def find(self, **kwargs):
+    def find(self, **kwargs: Any) -> ResultList[DnsRecord]:
         # pylint:disable=protected-access
-        return self._provider.dns._records.find(
-            dns_zone=self.dns_zone, **kwargs)
+        # find/delete are provider-internal extensions not declared on the
+        # DnsRecordService interface; reach them through ``Any``.
+        records: Any = self._provider.dns._records
+        return cast("ResultList[DnsRecord]",
+                    records.find(dns_zone=self.dns_zone, **kwargs))
 
-    def create(self, name, type, data, ttl=None):
+    def create(self, name: str, type: str, data: str,
+               ttl: int | None = None) -> DnsRecord:
         # pylint:disable=protected-access
         return self._provider.dns._records.create(
             self.dns_zone, name, type, data, ttl)
 
-    def delete(self, rec):
-        return self._provider.dns._records.delete(self.dns_zone, rec)
+    def delete(self, rec: DnsRecord | str) -> None:
+        # pylint:disable=protected-access
+        records: Any = self._provider.dns._records
+        records.delete(self.dns_zone, rec)

--- a/cloudbridge/base/subservices.py
+++ b/cloudbridge/base/subservices.py
@@ -1,6 +1,7 @@
 import builtins
 import logging
 from typing import Any
+from typing import TYPE_CHECKING
 from typing import cast
 
 from cloudbridge.interfaces.provider import CloudProvider
@@ -27,6 +28,9 @@ from cloudbridge.interfaces.subservices import VMFirewallRuleSubService
 
 from .resources import BasePageableObjectMixin
 
+if TYPE_CHECKING:
+    from .services import BaseStorageService
+
 log = logging.getLogger(__name__)
 
 
@@ -43,10 +47,10 @@ class BaseBucketObjectSubService(BasePageableObjectMixin[BucketObject],
 
     @property
     def _bucket_objects(self) -> BucketObjectService:
-        # ``_bucket_objects`` is a provider-internal service not declared on
-        # the StorageService interface; reach it through ``Any``.
-        storage: Any = self._provider.storage
-        return cast(BucketObjectService, storage._bucket_objects)
+        # ``_bucket_objects`` is a base-layer member (BaseStorageService), not
+        # part of the public StorageService interface.
+        storage = cast("BaseStorageService", self._provider.storage)
+        return storage._bucket_objects
 
     def get(self, name: str) -> BucketObject | None:
         return self._bucket_objects.get(self.bucket, name)

--- a/cloudbridge/factory.py
+++ b/cloudbridge/factory.py
@@ -4,7 +4,6 @@ import logging
 import pkgutil
 from collections import defaultdict
 from typing import Any
-from typing import cast
 
 from cloudbridge import providers
 from cloudbridge.interfaces import CloudProvider
@@ -29,7 +28,8 @@ class CloudProviderFactory(object):
     """
 
     def __init__(self) -> None:
-        self.provider_list: defaultdict[str, dict[str, Any]] = defaultdict(dict)
+        self.provider_list: defaultdict[str, dict[str, type[CloudProvider]]] \
+            = defaultdict(dict)
         log.debug("Providers List: %s", self.provider_list)
 
     def register_provider_class(self, cls: type) -> None:
@@ -90,7 +90,7 @@ class CloudProviderFactory(object):
             log.debug("Registering the provider: %s", cls)
             self.register_provider_class(cls)
 
-    def list_providers(self) -> dict[str, dict[str, Any]]:
+    def list_providers(self) -> dict[str, dict[str, type[CloudProvider]]]:
         """
         Get a list of available providers.
 
@@ -153,7 +153,7 @@ class CloudProviderFactory(object):
         impl = self.list_providers().get(name)
         if impl:
             log.debug("Returning provider class for %s", name)
-            return cast("type[CloudProvider]", impl["class"])
+            return impl["class"]
         else:
             log.debug("Provider with the name: %s not found", name)
             return None

--- a/cloudbridge/factory.py
+++ b/cloudbridge/factory.py
@@ -3,6 +3,8 @@ import inspect
 import logging
 import pkgutil
 from collections import defaultdict
+from typing import Any
+from typing import cast
 
 from cloudbridge import providers
 from cloudbridge.interfaces import CloudProvider
@@ -26,11 +28,11 @@ class CloudProviderFactory(object):
     Get info and handle on the available cloud provider implementations.
     """
 
-    def __init__(self):
-        self.provider_list = defaultdict(dict)
+    def __init__(self) -> None:
+        self.provider_list: defaultdict[str, dict[str, Any]] = defaultdict(dict)
         log.debug("Providers List: %s", self.provider_list)
 
-    def register_provider_class(self, cls):
+    def register_provider_class(self, cls: type) -> None:
         """
         Registers a provider class with the factory. The class must
         inherit from cloudbridge.interfaces.CloudProvider
@@ -61,7 +63,7 @@ class CloudProviderFactory(object):
             log.debug("Class: %s does not implement the CloudProvider"
                       "  interface. Ignoring...", cls)
 
-    def discover_providers(self):
+    def discover_providers(self) -> None:
         """
         Discover all available providers within the
         ``cloudbridge.providers`` package.
@@ -74,7 +76,7 @@ class CloudProviderFactory(object):
             except Exception as e:
                 log.debug("Could not import provider: %s", e)
 
-    def _import_provider(self, module_name):
+    def _import_provider(self, module_name: str) -> None:
         """
         Imports and registers providers from the given module name.
         Raises an ImportError if the import does not succeed.
@@ -88,7 +90,7 @@ class CloudProviderFactory(object):
             log.debug("Registering the provider: %s", cls)
             self.register_provider_class(cls)
 
-    def list_providers(self):
+    def list_providers(self) -> dict[str, dict[str, Any]]:
         """
         Get a list of available providers.
 
@@ -108,7 +110,8 @@ class CloudProviderFactory(object):
         log.debug("List of available providers: %s", self.provider_list)
         return self.provider_list
 
-    def create_provider(self, name, config):
+    def create_provider(self, name: str,
+                        config: dict[str, Any]) -> CloudProvider:
         """
         Searches all available providers for a CloudProvider interface with the
         given name, and instantiates it based on the given config dictionary,
@@ -138,7 +141,7 @@ class CloudProviderFactory(object):
         log.debug("Created '%s' provider", name)
         return provider_class(config)
 
-    def get_provider_class(self, name):
+    def get_provider_class(self, name: str) -> type[CloudProvider] | None:
         """
         Return a class for the requested provider.
 
@@ -150,12 +153,13 @@ class CloudProviderFactory(object):
         impl = self.list_providers().get(name)
         if impl:
             log.debug("Returning provider class for %s", name)
-            return impl["class"]
+            return cast("type[CloudProvider]", impl["class"])
         else:
             log.debug("Provider with the name: %s not found", name)
             return None
 
-    def get_all_provider_classes(self, ignore_mocks=False):
+    def get_all_provider_classes(
+            self, ignore_mocks: bool = False) -> list[type[CloudProvider]]:
         """
         Returns a list of classes for all available provider implementations
 
@@ -167,7 +171,7 @@ class CloudProviderFactory(object):
         :return: A list of all available provider classes or an empty list
         if none found.
         """
-        all_providers = []
+        all_providers: list[type[CloudProvider]] = []
         for impl in self.list_providers().values():
             if ignore_mocks:
                 if not issubclass(impl["class"], TestMockHelperMixin):

--- a/cloudbridge/interfaces/exceptions.py
+++ b/cloudbridge/interfaces/exceptions.py
@@ -54,7 +54,7 @@ class InvalidNameException(CloudBridgeBaseException):
     letters, which are not allowed in a resource name.
     """
 
-    def __init__(self, msg):
+    def __init__(self, msg: str) -> None:
         super(InvalidNameException, self).__init__(msg)
 
 
@@ -68,7 +68,7 @@ class InvalidLabelException(InvalidNameException):
     identical.
     """
 
-    def __init__(self, msg):
+    def __init__(self, msg: str) -> None:
         super(InvalidLabelException, self).__init__(msg)
 
 
@@ -79,7 +79,7 @@ class InvalidValueException(CloudBridgeBaseException):
     direction of a firewall rule other than TrafficDirection.INBOUND or
     TrafficDirection.OUTBOUND.
     """
-    def __init__(self, param, value):
+    def __init__(self, param: str, value: object) -> None:
         super(InvalidValueException, self).__init__(
             "Param %s has been given an unrecognised value %s" %
             (param, value))
@@ -100,5 +100,5 @@ class InvalidParamException(InvalidNameException):
     to a service.find() method.
     """
 
-    def __init__(self, msg):
+    def __init__(self, msg: str) -> None:
         super(InvalidParamException, self).__init__(msg)

--- a/cloudbridge/interfaces/provider.py
+++ b/cloudbridge/interfaces/provider.py
@@ -13,6 +13,7 @@ if TYPE_CHECKING:
     from pyeventsystem.middleware import MiddlewareManager
 
     from cloudbridge.interfaces.resources import Configuration
+    from cloudbridge.interfaces.resources import Instance
     from cloudbridge.interfaces.resources import PlacementZone
     from cloudbridge.interfaces.services import ComputeService
     from cloudbridge.interfaces.services import DnsService
@@ -327,11 +328,11 @@ class ContainerProvider(object):
     __metaclass__ = ABCMeta
 
     @abstractmethod
-    def create_container(self) -> Any:
+    def create_container(self) -> None:
         pass
 
     @abstractmethod
-    def delete_container(self) -> Any:
+    def delete_container(self) -> None:
         pass
 
 
@@ -343,7 +344,7 @@ class DeploymentProvider(object):
     __metaclass__ = ABCMeta
 
     @abstractmethod
-    def deploy(self, target: Any) -> Any:
+    def deploy(self, target: Instance) -> None:
         """
         Deploys on given target, where target is an Instance or Container
         """

--- a/cloudbridge/interfaces/provider.py
+++ b/cloudbridge/interfaces/provider.py
@@ -1,9 +1,24 @@
 """
 Specification for a provider interface
 """
+from __future__ import annotations
+
 from abc import ABCMeta
 from abc import abstractmethod
 from abc import abstractproperty
+from typing import Any
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from pyeventsystem.middleware import MiddlewareManager
+
+    from cloudbridge.interfaces.resources import Configuration
+    from cloudbridge.interfaces.resources import PlacementZone
+    from cloudbridge.interfaces.services import ComputeService
+    from cloudbridge.interfaces.services import DnsService
+    from cloudbridge.interfaces.services import NetworkingService
+    from cloudbridge.interfaces.services import SecurityService
+    from cloudbridge.interfaces.services import StorageService
 
 
 class CloudProvider(object):
@@ -13,7 +28,7 @@ class CloudProvider(object):
     __metaclass__ = ABCMeta
 
     @abstractmethod
-    def __init__(self, config):
+    def __init__(self, config: dict[str, Any]) -> None:
         """
         Create a new provider instance given a dictionary of
         configuration attributes.
@@ -31,7 +46,7 @@ class CloudProvider(object):
         pass
 
     @abstractproperty
-    def config(self):
+    def config(self) -> Configuration:
         """
         Returns the config object associated with this provider. This object
         is a subclass of :class:`dict` and will contain the properties
@@ -58,7 +73,7 @@ class CloudProvider(object):
         pass
 
     @abstractproperty
-    def middleware(self):
+    def middleware(self) -> MiddlewareManager:
         """
         Returns the middleware manager associated with this provider. The
         middleware manager can be used to add or remove middleware from
@@ -72,7 +87,7 @@ class CloudProvider(object):
         pass
 
     @abstractmethod
-    def clone(self, zone=None):
+    def clone(self, zone: PlacementZone | None = None) -> CloudProvider:
         """
         Create a clone of this provider. An optional `zone` parameter can be
         used to clone the provider to use a different zone.
@@ -101,7 +116,7 @@ class CloudProvider(object):
         pass
 
     @abstractmethod
-    def authenticate(self):
+    def authenticate(self) -> bool:
         """
         Checks whether a provider can be successfully authenticated with the
         configured settings. Clients are *not* required to call this method
@@ -127,7 +142,7 @@ class CloudProvider(object):
         pass
 
     @abstractmethod
-    def has_service(self, service_type):
+    def has_service(self, service_type: str) -> bool:
         """
         Checks whether this provider supports a given service.
 
@@ -149,7 +164,7 @@ class CloudProvider(object):
         pass
 
     @abstractproperty
-    def region_name(self):
+    def region_name(self) -> str:
         """
         Returns the region that this provider is connected to.
         All provider operations will take place within this region.
@@ -160,7 +175,7 @@ class CloudProvider(object):
         pass
 
     @abstractproperty
-    def zone_name(self):
+    def zone_name(self) -> str | None:
         """
         Returns the placement zone that this provider is connected to.
         All provider operations will take place within this zone. Placement
@@ -183,7 +198,7 @@ class CloudProvider(object):
 #         pass
 
     @abstractproperty
-    def compute(self):
+    def compute(self) -> ComputeService:
         """
         Provides access to all compute related services in this provider.
 
@@ -206,7 +221,7 @@ class CloudProvider(object):
         pass
 
     @abstractproperty
-    def networking(self):
+    def networking(self) -> NetworkingService:
         """
         Provide access to all network related services in this provider.
 
@@ -223,7 +238,7 @@ class CloudProvider(object):
         """
 
     @abstractproperty
-    def security(self):
+    def security(self) -> SecurityService:
         """
         Provides access to key pair management and firewall control
 
@@ -241,7 +256,7 @@ class CloudProvider(object):
         pass
 
     @abstractproperty
-    def storage(self):
+    def storage(self) -> StorageService:
         """
         Provides access to storage related services in this provider.
         This includes the volume, snapshot and bucket services,
@@ -262,7 +277,7 @@ class CloudProvider(object):
         pass
 
     @abstractproperty
-    def dns(self):
+    def dns(self) -> DnsService:
         """
         Provides access to all DNS related services.
 
@@ -288,14 +303,14 @@ class TestMockHelperMixin(object):
     like HTTPretty which take over socket communications.
     """
 
-    def setUpMock(self):
+    def setUpMock(self) -> None:
         """
         Called before a test is started.
         """
         raise NotImplementedError(
             'TestMockHelperMixin.setUpMock not implemented')
 
-    def tearDownMock(self):
+    def tearDownMock(self) -> None:
         """
         Called before test teardown.
         """
@@ -312,11 +327,11 @@ class ContainerProvider(object):
     __metaclass__ = ABCMeta
 
     @abstractmethod
-    def create_container(self):
+    def create_container(self) -> Any:
         pass
 
     @abstractmethod
-    def delete_container(self):
+    def delete_container(self) -> Any:
         pass
 
 
@@ -328,7 +343,7 @@ class DeploymentProvider(object):
     __metaclass__ = ABCMeta
 
     @abstractmethod
-    def deploy(self, target):
+    def deploy(self, target: Any) -> Any:
         """
         Deploys on given target, where target is an Instance or Container
         """

--- a/cloudbridge/interfaces/provider.py
+++ b/cloudbridge/interfaces/provider.py
@@ -165,7 +165,7 @@ class CloudProvider(object):
         pass
 
     @abstractproperty
-    def region_name(self) -> str:
+    def region_name(self) -> str | None:
         """
         Returns the region that this provider is connected to.
         All provider operations will take place within this region.

--- a/cloudbridge/interfaces/resources.py
+++ b/cloudbridge/interfaces/resources.py
@@ -2022,12 +2022,12 @@ class VMFirewall(LabeledCloudResource):
         pass
 
     @abstractproperty
-    def description(self) -> str:
+    def description(self) -> str | None:
         """
         Return the description of this VM firewall.
 
         :rtype: ``str``
-        :return: A description of this VM firewall.
+        :return: A description of this VM firewall, or ``None``.
         """
         pass
 
@@ -2070,13 +2070,13 @@ class VMFirewallRule(CloudResource):
     __metaclass__ = ABCMeta
 
     @abstractproperty
-    def direction(self) -> str:
+    def direction(self) -> TrafficDirection:
         """
         Direction of traffic to which this rule applies.
 
         Either ``TrafficDirection.INBOUND`` or ``TrafficDirection.OUTBOUND``.
 
-        :rtype: ``str``
+        :rtype: :class:`.TrafficDirection`
         :return: Direction of traffic to which this rule applies.
         """
         pass

--- a/cloudbridge/interfaces/resources.py
+++ b/cloudbridge/interfaces/resources.py
@@ -691,7 +691,7 @@ class Instance(ObjectLifeCycleMixin, LabeledCloudResource):
         pass
 
     @abstractproperty
-    def key_pair_id(self) -> str:
+    def key_pair_id(self) -> str | None:
         """
         Get the id of the key pair associated with this instance.
 
@@ -1268,7 +1268,7 @@ class Router(LabeledCloudResource):
         pass
 
     @abstractproperty
-    def subnets(self) -> list[Subnet]:
+    def subnets(self) -> Iterable[Subnet]:
         """
         List of subnets attached to this router.
 
@@ -1490,7 +1490,7 @@ class AttachmentInfo(object):
         pass
 
     @abstractproperty
-    def device(self) -> str:
+    def device(self) -> str | None:
         """
         Get the device the volume is mapped as.
 
@@ -2082,7 +2082,7 @@ class VMFirewallRule(CloudResource):
         pass
 
     @abstractproperty
-    def protocol(self) -> str:
+    def protocol(self) -> str | None:
         """
         IP protocol used. Either ``tcp`` | ``udp`` | ``icmp``.
 

--- a/cloudbridge/interfaces/resources.py
+++ b/cloudbridge/interfaces/resources.py
@@ -25,8 +25,10 @@ if TYPE_CHECKING:
     from cloudbridge.interfaces.subservices import SubnetSubService
     from cloudbridge.interfaces.subservices import VMFirewallRuleSubService
 
-# Element type for pageable collections (services and ResultList).
-T = TypeVar("T")
+# Element type for pageable collections (services and ResultList). Every such
+# element is a CloudResource, so the bound lets paging code read `.id` without
+# casting.
+T = TypeVar("T", bound="CloudResource")
 
 
 class CloudServiceType(object):
@@ -1889,6 +1891,16 @@ class Region(CloudResource):
 
         :rtype: Iterable
         :return: Iterable of available placement zones in this region.
+        """
+        pass
+
+    @abstractproperty
+    def default_zone(self) -> PlacementZone:
+        """
+        Access the default placement zone for this region.
+
+        :rtype: :class:`.PlacementZone`
+        :return: The default placement zone for this region.
         """
         pass
 

--- a/cloudbridge/interfaces/resources.py
+++ b/cloudbridge/interfaces/resources.py
@@ -610,22 +610,16 @@ class Instance(ObjectLifeCycleMixin, LabeledCloudResource):
         pass
 
     @abstractmethod
-    def start(self) -> bool | None:
+    def start(self) -> None:
         """
         Start this instance (using the cloud middleware API)
-
-        :rtype: ``bool``
-        :return: ``True`` if the starting was successful; ``False`` otherwise.
         """
         pass
 
     @abstractmethod
-    def stop(self) -> bool | None:
+    def stop(self) -> None:
         """
         Stop this instance (using the cloud middleware API)
-
-        :rtype: ``bool``
-        :return: ``True`` if the stopping was successful; ``False`` otherwise.
         """
         pass
 

--- a/cloudbridge/interfaces/resources.py
+++ b/cloudbridge/interfaces/resources.py
@@ -137,7 +137,7 @@ class CloudResource(object):
 class LabeledCloudResource(CloudResource):
 
     @abstractproperty
-    def label(self) -> str:
+    def label(self) -> str | None:
         """
         Get the resource label.
 
@@ -326,7 +326,7 @@ class ObjectLifeCycleMixin(object):
 
     @abstractmethod
     def wait_till_ready(self, timeout: int | None = None,
-                        interval: int | None = None) -> bool:
+                        interval: int | None = None) -> None:
         """
         Wait till the current object reaches its ready state.
 
@@ -600,7 +600,7 @@ class Instance(ObjectLifeCycleMixin, LabeledCloudResource):
         pass
 
     @abstractmethod
-    def reboot(self) -> bool:
+    def reboot(self) -> None:
         """
         Reboot this instance (using the cloud middleware API).
 
@@ -610,7 +610,7 @@ class Instance(ObjectLifeCycleMixin, LabeledCloudResource):
         pass
 
     @abstractmethod
-    def start(self) -> bool:
+    def start(self) -> bool | None:
         """
         Start this instance (using the cloud middleware API)
 
@@ -620,7 +620,7 @@ class Instance(ObjectLifeCycleMixin, LabeledCloudResource):
         pass
 
     @abstractmethod
-    def stop(self) -> bool:
+    def stop(self) -> bool | None:
         """
         Stop this instance (using the cloud middleware API)
 
@@ -899,7 +899,7 @@ class MachineImage(ObjectLifeCycleMixin, LabeledCloudResource):
     __metaclass__ = ABCMeta
 
     @abstractproperty
-    def description(self) -> str:
+    def description(self) -> str | None:
         """
         Get the image description.
 
@@ -910,7 +910,7 @@ class MachineImage(ObjectLifeCycleMixin, LabeledCloudResource):
         pass
 
     @abstractproperty
-    def min_disk(self) -> int:
+    def min_disk(self) -> int | None:
         """
         Return the minimum size of the disk that's required to boot this image.
 
@@ -922,7 +922,7 @@ class MachineImage(ObjectLifeCycleMixin, LabeledCloudResource):
         pass
 
     @abstractmethod
-    def delete(self) -> bool:
+    def delete(self) -> None:
         """
         Delete this image.
 
@@ -1001,7 +1001,7 @@ class Network(ObjectLifeCycleMixin, LabeledCloudResource):
         pass
 
     @abstractmethod
-    def delete(self) -> bool:
+    def delete(self) -> None:
         """
         Delete this network.
 
@@ -1108,7 +1108,7 @@ class Subnet(ObjectLifeCycleMixin, LabeledCloudResource):
         pass
 
     @abstractmethod
-    def delete(self) -> bool:
+    def delete(self) -> None:
         """
         Delete this subnet.
 
@@ -1171,7 +1171,7 @@ class FloatingIP(ObjectLifeCycleMixin, CloudResource):
         pass
 
     @abstractmethod
-    def delete(self) -> bool:
+    def delete(self) -> None:
         """
         Delete this address.
 
@@ -1238,7 +1238,7 @@ class Router(LabeledCloudResource):
         pass
 
     @abstractmethod
-    def delete(self) -> bool:
+    def delete(self) -> None:
         """
         Delete this router.
 
@@ -1248,7 +1248,7 @@ class Router(LabeledCloudResource):
         pass
 
     @abstractmethod
-    def attach_subnet(self, subnet: Subnet | str) -> bool:
+    def attach_subnet(self, subnet: Subnet | str) -> None:
         """
         Attach this router to a subnet.
 
@@ -1261,7 +1261,7 @@ class Router(LabeledCloudResource):
         pass
 
     @abstractmethod
-    def detach_subnet(self, subnet: Subnet | str) -> bool:
+    def detach_subnet(self, subnet: Subnet | str) -> None:
         """
         Detach this subnet from a network.
 
@@ -1284,7 +1284,7 @@ class Router(LabeledCloudResource):
         pass
 
     @abstractmethod
-    def attach_gateway(self, gateway: Gateway) -> bool:
+    def attach_gateway(self, gateway: Gateway) -> None:
         """
         Attach a gateway to this router.
 
@@ -1297,7 +1297,7 @@ class Router(LabeledCloudResource):
         pass
 
     @abstractmethod
-    def detach_gateway(self, gateway: Gateway) -> bool:
+    def detach_gateway(self, gateway: Gateway) -> None:
         """
         Detach this router from a gateway.
 
@@ -1375,7 +1375,7 @@ class DnsZone(CloudResource):
     __metaclass__ = ABCMeta
 
     @abstractproperty
-    def admin_email(self) -> str:
+    def admin_email(self) -> str | None:
         """
         Email address of this zone's administrator. Some cloud providers do not
         support this field, and therefore, it may be stored in an extra field
@@ -1450,7 +1450,7 @@ class DnsRecord(CloudResource):
         pass
 
     @abstractproperty
-    def data(self) -> str:
+    def data(self) -> list[str]:
         """
         Dns Record data
 
@@ -1615,7 +1615,7 @@ class Volume(ObjectLifeCycleMixin, LabeledCloudResource):
         pass
 
     @abstractproperty
-    def attachments(self) -> list[AttachmentInfo]:
+    def attachments(self) -> AttachmentInfo | None:
         """
         Get attachment information for this volume.
 
@@ -1625,7 +1625,7 @@ class Volume(ObjectLifeCycleMixin, LabeledCloudResource):
         pass
 
     @abstractmethod
-    def attach(self, instance: str | Instance, device: str) -> bool:
+    def attach(self, instance: str | Instance, device: str) -> None:
         """
         Attach this volume to an instance.
 
@@ -1643,7 +1643,7 @@ class Volume(ObjectLifeCycleMixin, LabeledCloudResource):
         pass
 
     @abstractmethod
-    def detach(self, force: bool = False) -> bool:
+    def detach(self, force: bool = False) -> None:
         """
         Detach this volume from an instance.
 
@@ -1682,7 +1682,7 @@ class Volume(ObjectLifeCycleMixin, LabeledCloudResource):
         pass
 
     @abstractmethod
-    def delete(self) -> bool:
+    def delete(self) -> None:
         """
         Delete this volume.
 
@@ -1841,7 +1841,7 @@ class Snapshot(ObjectLifeCycleMixin, LabeledCloudResource):
 #         pass
 
     @abstractmethod
-    def delete(self) -> bool:
+    def delete(self) -> None:
         """
         Delete this snapshot.
 
@@ -1869,7 +1869,7 @@ class KeyPair(CloudResource):
         pass
 
     @abstractmethod
-    def delete(self) -> bool:
+    def delete(self) -> None:
         """
         Delete this key pair.
 
@@ -2118,7 +2118,7 @@ class VMFirewallRule(CloudResource):
         pass
 
     @abstractproperty
-    def cidr(self) -> str:
+    def cidr(self) -> str | None:
         """
         CIDR block this VM firewall is providing access to.
 
@@ -2128,7 +2128,7 @@ class VMFirewallRule(CloudResource):
         pass
 
     @abstractproperty
-    def src_dest_fw_id(self) -> str:
+    def src_dest_fw_id(self) -> str | None:
         """
         VM firewall id given access permissions by this rule.
 
@@ -2138,7 +2138,7 @@ class VMFirewallRule(CloudResource):
         pass
 
     @abstractproperty
-    def src_dest_fw(self) -> VMFirewall:
+    def src_dest_fw(self) -> VMFirewall | None:
         """
         VM firewall given access permissions by this rule.
 
@@ -2364,7 +2364,7 @@ class BucketObject(CloudResource):
 
     @abstractmethod
     def upload(self, source_stream: IO[bytes],
-               config: UploadConfig | None = None) -> bool:
+               config: UploadConfig | None = None) -> BucketObject | None:
         """
         Set the contents of the object to the data read from the source stream.
 
@@ -2380,7 +2380,7 @@ class BucketObject(CloudResource):
 
     @abstractmethod
     def upload_from_file(self, path: str,
-                         config: UploadConfig | None = None) -> None:
+                         config: UploadConfig | None = None) -> BucketObject | None:
         """
         Store the contents of the file pointed by the "path" variable.
 
@@ -2419,7 +2419,7 @@ class BucketObject(CloudResource):
         pass
 
     @abstractmethod
-    def delete(self) -> bool:
+    def delete(self) -> None:
         """
         Delete this object.
 
@@ -2504,7 +2504,7 @@ class Bucket(CloudResource):
         pass
 
     @abstractmethod
-    def delete(self, delete_contents: bool = False) -> bool:
+    def delete(self, delete_contents: bool = False) -> None:
         """
         Delete this bucket.
 

--- a/cloudbridge/interfaces/resources.py
+++ b/cloudbridge/interfaces/resources.py
@@ -1,10 +1,32 @@
 """
 Specifications for data objects exposed through a ``provider`` or ``service``.
 """
+from __future__ import annotations
+
 from abc import ABCMeta
 from abc import abstractmethod
 from abc import abstractproperty
+from collections.abc import Iterable
+from datetime import datetime
 from enum import Enum
+from typing import Any
+from typing import Generic
+from typing import IO
+from typing import Iterator
+from typing import TYPE_CHECKING
+from typing import TypeVar
+
+if TYPE_CHECKING:
+    from cloudbridge.interfaces.provider import CloudProvider
+    from cloudbridge.interfaces.subservices import BucketObjectSubService
+    from cloudbridge.interfaces.subservices import DnsRecordSubService
+    from cloudbridge.interfaces.subservices import FloatingIPSubService
+    from cloudbridge.interfaces.subservices import GatewaySubService
+    from cloudbridge.interfaces.subservices import SubnetSubService
+    from cloudbridge.interfaces.subservices import VMFirewallRuleSubService
+
+# Element type for pageable collections (services and ResultList).
+T = TypeVar("T")
 
 
 class CloudServiceType(object):
@@ -44,7 +66,7 @@ class CloudResource(object):
     __metaclass__ = ABCMeta
 
     @abstractproperty
-    def _provider(self):
+    def _provider(self) -> CloudProvider:
         """
         Returns the provider instance associated with this resource.
 
@@ -56,7 +78,7 @@ class CloudResource(object):
         pass
 
     @abstractproperty
-    def id(self):
+    def id(self) -> str:
         """
         Get the resource identifier.
 
@@ -70,7 +92,7 @@ class CloudResource(object):
         pass
 
     @abstractproperty
-    def name(self):
+    def name(self) -> str:
         """
         Get the name id for the resource.
 
@@ -105,7 +127,7 @@ class CloudResource(object):
         pass
 
     @abstractmethod
-    def to_json(self):
+    def to_json(self) -> dict[str, Any]:
         """
         Returns a JSON representation of the CloudResource object.
         """
@@ -115,7 +137,7 @@ class CloudResource(object):
 class LabeledCloudResource(CloudResource):
 
     @abstractproperty
-    def label(self):
+    def label(self) -> str:
         """
         Get the resource label.
 
@@ -149,7 +171,7 @@ class Configuration(dict):
     """
 
     @abstractproperty
-    def default_result_limit(self):
+    def default_result_limit(self) -> int:
         """
         Get the default maximum number of results to return for a list method.
 
@@ -161,8 +183,8 @@ class Configuration(dict):
         """
         pass
 
-    @property
-    def default_wait_timeout(self):
+    @abstractproperty
+    def default_wait_timeout(self) -> int:
         """
         Get the default wait timeout for ``LifeCycleObjects``.
 
@@ -175,8 +197,8 @@ class Configuration(dict):
         """
         pass
 
-    @property
-    def default_wait_interval(self):
+    @abstractproperty
+    def default_wait_interval(self) -> int:
         """
         Get the default wait interval for ``LifeCycleObjects``.
 
@@ -189,7 +211,7 @@ class Configuration(dict):
         pass
 
     @abstractproperty
-    def debug_mode(self):
+    def debug_mode(self) -> bool:
         """
         A flag indicating whether CloudBridge is in debug mode.
 
@@ -221,7 +243,7 @@ class ObjectLifeCycleMixin(object):
     __metaclass__ = ABCMeta
 
     @abstractproperty
-    def _provider(self):
+    def _provider(self) -> CloudProvider:
         """
         Obtain the provider associated with this object.
 
@@ -234,7 +256,7 @@ class ObjectLifeCycleMixin(object):
         pass
 
     @abstractproperty
-    def state(self):
+    def state(self) -> str:
         """
         Get the current state of this object.
 
@@ -244,15 +266,17 @@ class ObjectLifeCycleMixin(object):
         pass
 
     @abstractmethod
-    def refresh(self):
+    def refresh(self) -> None:
         """
         Refresh this object's state and synchronize it with the provider.
         """
         pass
 
     @abstractmethod
-    def wait_for(self, target_states, terminal_states=None, timeout=None,
-                 interval=None):
+    def wait_for(self, target_states: list[str],
+                 terminal_states: list[str] | None = None,
+                 timeout: int | None = None,
+                 interval: int | None = None) -> bool:
         """
         Wait for for an object to reach a one of desired target states.
 
@@ -301,7 +325,8 @@ class ObjectLifeCycleMixin(object):
         pass
 
     @abstractmethod
-    def wait_till_ready(self, timeout, interval):
+    def wait_till_ready(self, timeout: int | None = None,
+                        interval: int | None = None) -> bool:
         """
         Wait till the current object reaches its ready state.
 
@@ -327,7 +352,7 @@ class ObjectLifeCycleMixin(object):
         pass
 
 
-class PageableObjectMixin(object):
+class PageableObjectMixin(Generic[T]):
     """
     A marker interface for objects which support paged iteration.
 
@@ -336,7 +361,7 @@ class PageableObjectMixin(object):
     """
 
     @abstractmethod
-    def __iter__(self):
+    def __iter__(self) -> Iterator[T]:
         """
         Enables iteration through this object.
 
@@ -347,7 +372,8 @@ class PageableObjectMixin(object):
         pass
 
     @abstractmethod
-    def list(self, limit=None, marker=None):
+    def list(self, limit: int | None = None,
+             marker: str | None = None) -> ResultList[T]:
         """
         Returns a list of objects up to a maximum limit.
 
@@ -397,7 +423,7 @@ class PageableObjectMixin(object):
         pass
 
 
-class ResultList(list):
+class ResultList(list[T]):
     """
     Provide extra properties to aid with paging through a many results.
 
@@ -425,7 +451,7 @@ class ResultList(list):
     __metaclass__ = ABCMeta
 
     @abstractproperty
-    def marker(self):
+    def marker(self) -> str | None:
         """
         An opaque identifier used in paging through very long lists of objects.
 
@@ -435,14 +461,14 @@ class ResultList(list):
         pass
 
     @abstractproperty
-    def is_truncated(self):
+    def is_truncated(self) -> bool:
         """
         Indicate whether this result list has more results that can be paged.
         """
         pass
 
     @abstractproperty
-    def supports_total(self):
+    def supports_total(self) -> bool:
         """
         Indicate whether can obtain the total number of available results.
 
@@ -452,7 +478,7 @@ class ResultList(list):
         pass
 
     @abstractproperty
-    def total_results(self):
+    def total_results(self) -> int:
         """
         Indicate the total number of results for a particular query.
 
@@ -463,7 +489,7 @@ class ResultList(list):
         pass
 
     @abstractproperty
-    def supports_server_paging(self):
+    def supports_server_paging(self) -> bool:
         """
         Indicate whether this ``ResultList`` supports server side paging.
 
@@ -474,7 +500,7 @@ class ResultList(list):
         pass
 
     @abstractproperty
-    def data(self):
+    def data(self) -> list[T]:
         pass
 
 
@@ -507,9 +533,9 @@ class Instance(ObjectLifeCycleMixin, LabeledCloudResource):
 
     __metaclass__ = ABCMeta
 
-    @LabeledCloudResource.label.setter
+    @LabeledCloudResource.label.setter  # type: ignore[attr-defined]
     @abstractmethod
-    def label(self, value):
+    def label(self, value: str) -> None:
         """
         Set the instance label.
 
@@ -519,7 +545,7 @@ class Instance(ObjectLifeCycleMixin, LabeledCloudResource):
         pass
 
     @abstractproperty
-    def public_ips(self):
+    def public_ips(self) -> list[str]:
         """
         Get all the public IP addresses for this instance.
 
@@ -529,7 +555,7 @@ class Instance(ObjectLifeCycleMixin, LabeledCloudResource):
         pass
 
     @abstractproperty
-    def private_ips(self):
+    def private_ips(self) -> list[str]:
         """
         Get all the private IP addresses for this instance.
 
@@ -539,7 +565,7 @@ class Instance(ObjectLifeCycleMixin, LabeledCloudResource):
         pass
 
     @abstractproperty
-    def vm_type_id(self):
+    def vm_type_id(self) -> str:
         """
         Get the VM type id for this instance.
 
@@ -553,7 +579,7 @@ class Instance(ObjectLifeCycleMixin, LabeledCloudResource):
         pass
 
     @abstractproperty
-    def vm_type(self):
+    def vm_type(self) -> VMType:
         """
         Retrieve full VM type information for this instance.
 
@@ -563,7 +589,7 @@ class Instance(ObjectLifeCycleMixin, LabeledCloudResource):
         pass
 
     @abstractproperty
-    def create_time(self):
+    def create_time(self) -> str | datetime:
         """
         Get the creation data and time for this instance.
 
@@ -574,7 +600,7 @@ class Instance(ObjectLifeCycleMixin, LabeledCloudResource):
         pass
 
     @abstractmethod
-    def reboot(self):
+    def reboot(self) -> bool:
         """
         Reboot this instance (using the cloud middleware API).
 
@@ -584,7 +610,7 @@ class Instance(ObjectLifeCycleMixin, LabeledCloudResource):
         pass
 
     @abstractmethod
-    def start(self):
+    def start(self) -> bool:
         """
         Start this instance (using the cloud middleware API)
 
@@ -594,7 +620,7 @@ class Instance(ObjectLifeCycleMixin, LabeledCloudResource):
         pass
 
     @abstractmethod
-    def stop(self):
+    def stop(self) -> bool:
         """
         Stop this instance (using the cloud middleware API)
 
@@ -604,14 +630,14 @@ class Instance(ObjectLifeCycleMixin, LabeledCloudResource):
         pass
 
     @abstractmethod
-    def delete(self):
+    def delete(self) -> None:
         """
         Permanently delete this instance.
         """
         pass
 
     @abstractproperty
-    def image_id(self):
+    def image_id(self) -> str:
         """
         Get the image ID for this instance.
 
@@ -621,7 +647,7 @@ class Instance(ObjectLifeCycleMixin, LabeledCloudResource):
         pass
 
     @abstractproperty
-    def zone_id(self):
+    def zone_id(self) -> str:
         """
         Get the placement zone ID where this instance is running.
 
@@ -631,7 +657,7 @@ class Instance(ObjectLifeCycleMixin, LabeledCloudResource):
         pass
 
     @abstractproperty
-    def subnet_id(self):
+    def subnet_id(self) -> str:
         """
         Get the subnet ID where this instance is placed.
 
@@ -651,7 +677,7 @@ class Instance(ObjectLifeCycleMixin, LabeledCloudResource):
 #         pass
 
     @abstractproperty
-    def vm_firewalls(self):
+    def vm_firewalls(self) -> list[VMFirewall]:
         """
         Get the firewalls (security groups) associated with this instance.
 
@@ -661,7 +687,7 @@ class Instance(ObjectLifeCycleMixin, LabeledCloudResource):
         pass
 
     @abstractproperty
-    def vm_firewall_ids(self):
+    def vm_firewall_ids(self) -> list[str]:
         """
         Get the IDs of the VM firewalls associated with this instance.
 
@@ -671,7 +697,7 @@ class Instance(ObjectLifeCycleMixin, LabeledCloudResource):
         pass
 
     @abstractproperty
-    def key_pair_id(self):
+    def key_pair_id(self) -> str:
         """
         Get the id of the key pair associated with this instance.
 
@@ -681,7 +707,7 @@ class Instance(ObjectLifeCycleMixin, LabeledCloudResource):
         pass
 
     @abstractmethod
-    def create_image(self, label):
+    def create_image(self, label: str) -> MachineImage:
         """
         Create a new image based on this instance.
 
@@ -691,7 +717,7 @@ class Instance(ObjectLifeCycleMixin, LabeledCloudResource):
         pass
 
     @abstractmethod
-    def add_floating_ip(self, floating_ip):
+    def add_floating_ip(self, floating_ip: FloatingIP | str) -> None:
         """
         Add a public IP address to this instance.
 
@@ -705,7 +731,7 @@ class Instance(ObjectLifeCycleMixin, LabeledCloudResource):
         pass
 
     @abstractmethod
-    def remove_floating_ip(self, floating_ip):
+    def remove_floating_ip(self, floating_ip: FloatingIP | str) -> None:
         """
         Remove a public IP address from this instance.
 
@@ -719,7 +745,7 @@ class Instance(ObjectLifeCycleMixin, LabeledCloudResource):
         pass
 
     @abstractmethod
-    def add_vm_firewall(self, firewall):
+    def add_vm_firewall(self, firewall: VMFirewall) -> None:
         """
         Add a VM firewall to this instance
 
@@ -729,7 +755,7 @@ class Instance(ObjectLifeCycleMixin, LabeledCloudResource):
         pass
 
     @abstractmethod
-    def remove_vm_firewall(self, firewall):
+    def remove_vm_firewall(self, firewall: VMFirewall) -> None:
         """
         Remove a VM firewall from this instance
 
@@ -776,7 +802,7 @@ class LaunchConfig(object):
     """
 
     @abstractmethod
-    def add_ephemeral_device(self):
+    def add_ephemeral_device(self) -> None:
         """
         Add a new ephemeral block device mapping to the boot configuration.
 
@@ -807,8 +833,9 @@ class LaunchConfig(object):
         pass
 
     @abstractmethod
-    def add_volume_device(self, source=None, is_root=None, size=None,
-                          delete_on_terminate=None):
+    def add_volume_device(self, source: Volume | Snapshot | MachineImage | None = None,
+                          is_root: bool | None = None, size: int | None = None,
+                          delete_on_terminate: bool | None = None) -> None:
         """
         Add a new volume based block device mapping to the boot configuration.
 
@@ -872,7 +899,7 @@ class MachineImage(ObjectLifeCycleMixin, LabeledCloudResource):
     __metaclass__ = ABCMeta
 
     @abstractproperty
-    def description(self):
+    def description(self) -> str:
         """
         Get the image description.
 
@@ -883,7 +910,7 @@ class MachineImage(ObjectLifeCycleMixin, LabeledCloudResource):
         pass
 
     @abstractproperty
-    def min_disk(self):
+    def min_disk(self) -> int:
         """
         Return the minimum size of the disk that's required to boot this image.
 
@@ -895,7 +922,7 @@ class MachineImage(ObjectLifeCycleMixin, LabeledCloudResource):
         pass
 
     @abstractmethod
-    def delete(self):
+    def delete(self) -> bool:
         """
         Delete this image.
 
@@ -929,9 +956,9 @@ class Network(ObjectLifeCycleMixin, LabeledCloudResource):
     """
     __metaclass__ = ABCMeta
 
-    @LabeledCloudResource.label.setter
+    @LabeledCloudResource.label.setter  # type: ignore[attr-defined]
     @abstractmethod
-    def label(self, value):
+    def label(self, value: str) -> None:
         """
         Set the resource label.
 
@@ -941,7 +968,7 @@ class Network(ObjectLifeCycleMixin, LabeledCloudResource):
         pass
 
     @abstractproperty
-    def external(self):
+    def external(self) -> bool:
         """
         A flag to indicate if this network is capable of Internet-connectivity.
 
@@ -951,7 +978,7 @@ class Network(ObjectLifeCycleMixin, LabeledCloudResource):
         pass
 
     @abstractproperty
-    def state(self):
+    def state(self) -> str:
         """
         The state of the network.
 
@@ -962,7 +989,7 @@ class Network(ObjectLifeCycleMixin, LabeledCloudResource):
         pass
 
     @abstractproperty
-    def cidr_block(self):
+    def cidr_block(self) -> str:
         """
         A CIDR block for this network.
 
@@ -974,7 +1001,7 @@ class Network(ObjectLifeCycleMixin, LabeledCloudResource):
         pass
 
     @abstractmethod
-    def delete(self):
+    def delete(self) -> bool:
         """
         Delete this network.
 
@@ -984,7 +1011,7 @@ class Network(ObjectLifeCycleMixin, LabeledCloudResource):
         pass
 
     @abstractproperty
-    def subnets(self):
+    def subnets(self) -> SubnetSubService:
         """
         The associated subnets.
 
@@ -994,7 +1021,7 @@ class Network(ObjectLifeCycleMixin, LabeledCloudResource):
         pass
 
     @abstractproperty
-    def gateways(self):
+    def gateways(self) -> GatewaySubService:
         """
         Provides access to the internet gateways attached to this network.
 
@@ -1027,9 +1054,9 @@ class Subnet(ObjectLifeCycleMixin, LabeledCloudResource):
     """
     __metaclass__ = ABCMeta
 
-    @LabeledCloudResource.label.setter
+    @LabeledCloudResource.label.setter  # type: ignore[attr-defined]
     @abstractmethod
-    def label(self, value):
+    def label(self, value: str) -> None:
         """
         Set the resource label.
 
@@ -1039,7 +1066,7 @@ class Subnet(ObjectLifeCycleMixin, LabeledCloudResource):
         pass
 
     @abstractproperty
-    def cidr_block(self):
+    def cidr_block(self) -> str:
         """
         A CIDR block for this subnet.
 
@@ -1049,7 +1076,7 @@ class Subnet(ObjectLifeCycleMixin, LabeledCloudResource):
         pass
 
     @abstractproperty
-    def network_id(self):
+    def network_id(self) -> str:
         """
         ID of the network associated with this this subnet.
 
@@ -1059,7 +1086,7 @@ class Subnet(ObjectLifeCycleMixin, LabeledCloudResource):
         pass
 
     @abstractproperty
-    def network(self):
+    def network(self) -> Network:
         """
         The parent network object associated with this this subnet.
 
@@ -1069,7 +1096,7 @@ class Subnet(ObjectLifeCycleMixin, LabeledCloudResource):
         pass
 
     @abstractproperty
-    def zone(self):
+    def zone(self) -> PlacementZone | None:
         """
         Placement zone of the subnet.
 
@@ -1081,7 +1108,7 @@ class Subnet(ObjectLifeCycleMixin, LabeledCloudResource):
         pass
 
     @abstractmethod
-    def delete(self):
+    def delete(self) -> bool:
         """
         Delete this subnet.
 
@@ -1114,7 +1141,7 @@ class FloatingIP(ObjectLifeCycleMixin, CloudResource):
     __metaclass__ = ABCMeta
 
     @abstractproperty
-    def public_ip(self):
+    def public_ip(self) -> str:
         """
         Public IP address.
 
@@ -1124,7 +1151,7 @@ class FloatingIP(ObjectLifeCycleMixin, CloudResource):
         pass
 
     @abstractproperty
-    def private_ip(self):
+    def private_ip(self) -> str | None:
         """
         Private IP address this address is attached to.
 
@@ -1134,7 +1161,7 @@ class FloatingIP(ObjectLifeCycleMixin, CloudResource):
         pass
 
     @abstractproperty
-    def in_use(self):
+    def in_use(self) -> bool:
         """
         Whether the address is in use or not.
 
@@ -1144,7 +1171,7 @@ class FloatingIP(ObjectLifeCycleMixin, CloudResource):
         pass
 
     @abstractmethod
-    def delete(self):
+    def delete(self) -> bool:
         """
         Delete this address.
 
@@ -1179,9 +1206,9 @@ class Router(LabeledCloudResource):
     """
     __metaclass__ = ABCMeta
 
-    @LabeledCloudResource.label.setter
+    @LabeledCloudResource.label.setter  # type: ignore[attr-defined]
     @abstractmethod
-    def label(self, value):
+    def label(self, value: str) -> None:
         """
         Set the resource label.
 
@@ -1191,7 +1218,7 @@ class Router(LabeledCloudResource):
         pass
 
     @abstractproperty
-    def state(self):
+    def state(self) -> str:
         """
         Router state: attached or detached to a network.
 
@@ -1201,7 +1228,7 @@ class Router(LabeledCloudResource):
         pass
 
     @abstractproperty
-    def network_id(self):
+    def network_id(self) -> str | None:
         """
         ID of the network to which the router is attached.
 
@@ -1211,7 +1238,7 @@ class Router(LabeledCloudResource):
         pass
 
     @abstractmethod
-    def delete(self):
+    def delete(self) -> bool:
         """
         Delete this router.
 
@@ -1221,7 +1248,7 @@ class Router(LabeledCloudResource):
         pass
 
     @abstractmethod
-    def attach_subnet(self, subnet):
+    def attach_subnet(self, subnet: Subnet | str) -> bool:
         """
         Attach this router to a subnet.
 
@@ -1234,7 +1261,7 @@ class Router(LabeledCloudResource):
         pass
 
     @abstractmethod
-    def detach_subnet(self, subnet):
+    def detach_subnet(self, subnet: Subnet | str) -> bool:
         """
         Detach this subnet from a network.
 
@@ -1247,7 +1274,7 @@ class Router(LabeledCloudResource):
         pass
 
     @abstractproperty
-    def subnets(self):
+    def subnets(self) -> list[Subnet]:
         """
         List of subnets attached to this router.
 
@@ -1257,7 +1284,7 @@ class Router(LabeledCloudResource):
         pass
 
     @abstractmethod
-    def attach_gateway(self, gateway):
+    def attach_gateway(self, gateway: Gateway) -> bool:
         """
         Attach a gateway to this router.
 
@@ -1270,7 +1297,7 @@ class Router(LabeledCloudResource):
         pass
 
     @abstractmethod
-    def detach_gateway(self, gateway):
+    def detach_gateway(self, gateway: Gateway) -> bool:
         """
         Detach this router from a gateway.
 
@@ -1303,7 +1330,7 @@ class Gateway(CloudResource):
     __metaclass__ = ABCMeta
 
     @abstractproperty
-    def network_id(self):
+    def network_id(self) -> str | None:
         """
         ID of the network to which the gateway is attached.
 
@@ -1313,7 +1340,7 @@ class Gateway(CloudResource):
         pass
 
     @abstractmethod
-    def delete(self):
+    def delete(self) -> None:
         """
         Delete this gateway. On some providers, if the gateway
         is public/a singleton, this operation will do nothing.
@@ -1321,7 +1348,7 @@ class Gateway(CloudResource):
         pass
 
     @abstractproperty
-    def floating_ips(self):
+    def floating_ips(self) -> FloatingIPSubService:
         """
         Provides access to floating IPs connected to this internet gateway.
 
@@ -1347,8 +1374,8 @@ class DnsZone(CloudResource):
     """
     __metaclass__ = ABCMeta
 
-    @property
-    def admin_email(self):
+    @abstractproperty
+    def admin_email(self) -> str:
         """
         Email address of this zone's administrator. Some cloud providers do not
         support this field, and therefore, it may be stored in an extra field
@@ -1360,14 +1387,14 @@ class DnsZone(CloudResource):
         pass
 
     @abstractmethod
-    def delete(self):
+    def delete(self) -> None:
         """
         Delete this zone.
         """
         pass
 
     @abstractproperty
-    def records(self):
+    def records(self) -> DnsRecordSubService:
         """
         List of DNS records in this zone.
 
@@ -1403,7 +1430,7 @@ class DnsRecord(CloudResource):
     __metaclass__ = ABCMeta
 
     @abstractproperty
-    def zone_id(self):
+    def zone_id(self) -> str:
         """
         The containing zone for this dns record
 
@@ -1413,7 +1440,7 @@ class DnsRecord(CloudResource):
         pass
 
     @abstractproperty
-    def type(self):
+    def type(self) -> str:
         """
         Dns Record type which could be A, CNAME, MX, AAAA, PTR
 
@@ -1423,7 +1450,7 @@ class DnsRecord(CloudResource):
         pass
 
     @abstractproperty
-    def data(self):
+    def data(self) -> str:
         """
         Dns Record data
 
@@ -1433,7 +1460,7 @@ class DnsRecord(CloudResource):
         pass
 
     @abstractproperty
-    def ttl(self):
+    def ttl(self) -> int:
         """
         ttl for this record
 
@@ -1449,7 +1476,7 @@ class AttachmentInfo(object):
     """
 
     @abstractproperty
-    def volume(self):
+    def volume(self) -> Volume:
         """
         Get the volume instance related to this attachment.
 
@@ -1459,7 +1486,7 @@ class AttachmentInfo(object):
         pass
 
     @abstractproperty
-    def instance_id(self):
+    def instance_id(self) -> str:
         """
         Get the instance_id related to this attachment.
 
@@ -1469,7 +1496,7 @@ class AttachmentInfo(object):
         pass
 
     @abstractproperty
-    def device(self):
+    def device(self) -> str:
         """
         Get the device the volume is mapped as.
 
@@ -1508,16 +1535,16 @@ class Volume(ObjectLifeCycleMixin, LabeledCloudResource):
 
     __metaclass__ = ABCMeta
 
-    @LabeledCloudResource.label.setter
+    @LabeledCloudResource.label.setter  # type: ignore[attr-defined]
     @abstractmethod
-    def label(self, value):
+    def label(self, value: str) -> None:
         """
         Set the volume label.
         """
         pass
 
     @abstractproperty
-    def description(self):
+    def description(self) -> str:
         """
         Get the volume description.
 
@@ -1532,7 +1559,7 @@ class Volume(ObjectLifeCycleMixin, LabeledCloudResource):
 
     @description.setter
     @abstractmethod
-    def description(self, value):
+    def description(self, value: str) -> None:
         """
         Set the volume description.
 
@@ -1543,7 +1570,7 @@ class Volume(ObjectLifeCycleMixin, LabeledCloudResource):
         pass
 
     @abstractproperty
-    def size(self):
+    def size(self) -> int:
         """
         Get the volume size (in GB).
 
@@ -1553,7 +1580,7 @@ class Volume(ObjectLifeCycleMixin, LabeledCloudResource):
         pass
 
     @abstractproperty
-    def create_time(self):
+    def create_time(self) -> str | datetime:
         """
         Get the creation data and time for this volume.
 
@@ -1564,7 +1591,7 @@ class Volume(ObjectLifeCycleMixin, LabeledCloudResource):
         pass
 
     @abstractproperty
-    def zone_id(self):
+    def zone_id(self) -> str:
         """
         Get the placement zone id that this volume belongs to.
 
@@ -1575,7 +1602,7 @@ class Volume(ObjectLifeCycleMixin, LabeledCloudResource):
         pass
 
     @abstractproperty
-    def source(self):
+    def source(self) -> Snapshot | MachineImage | None:
         """
         If available, get the source that this volume is based on.
 
@@ -1588,7 +1615,7 @@ class Volume(ObjectLifeCycleMixin, LabeledCloudResource):
         pass
 
     @abstractproperty
-    def attachments(self):
+    def attachments(self) -> list[AttachmentInfo]:
         """
         Get attachment information for this volume.
 
@@ -1598,7 +1625,7 @@ class Volume(ObjectLifeCycleMixin, LabeledCloudResource):
         pass
 
     @abstractmethod
-    def attach(self, instance, device):
+    def attach(self, instance: str | Instance, device: str) -> bool:
         """
         Attach this volume to an instance.
 
@@ -1616,7 +1643,7 @@ class Volume(ObjectLifeCycleMixin, LabeledCloudResource):
         pass
 
     @abstractmethod
-    def detach(self, force=False):
+    def detach(self, force: bool = False) -> bool:
         """
         Detach this volume from an instance.
 
@@ -1637,7 +1664,8 @@ class Volume(ObjectLifeCycleMixin, LabeledCloudResource):
         pass
 
     @abstractmethod
-    def create_snapshot(self, label, description=None):
+    def create_snapshot(self, label: str,
+                        description: str | None = None) -> Snapshot:
         """
         Create a snapshot of this Volume.
 
@@ -1654,7 +1682,7 @@ class Volume(ObjectLifeCycleMixin, LabeledCloudResource):
         pass
 
     @abstractmethod
-    def delete(self):
+    def delete(self) -> bool:
         """
         Delete this volume.
 
@@ -1689,16 +1717,16 @@ class Snapshot(ObjectLifeCycleMixin, LabeledCloudResource):
 
     __metaclass__ = ABCMeta
 
-    @LabeledCloudResource.label.setter
+    @LabeledCloudResource.label.setter  # type: ignore[attr-defined]
     @abstractmethod
-    def label(self, value):
+    def label(self, value: str) -> None:
         """
         Set the snapshot label.
         """
         pass
 
     @abstractproperty
-    def description(self):
+    def description(self) -> str:
         """
         Get the snapshot description.
 
@@ -1713,7 +1741,7 @@ class Snapshot(ObjectLifeCycleMixin, LabeledCloudResource):
 
     @description.setter
     @abstractmethod
-    def description(self, value):
+    def description(self, value: str) -> None:
         """
         Set the snapshot description.
 
@@ -1727,7 +1755,7 @@ class Snapshot(ObjectLifeCycleMixin, LabeledCloudResource):
         pass
 
     @abstractproperty
-    def size(self):
+    def size(self) -> int:
         """
         Get the snapshot size (in GB).
 
@@ -1737,7 +1765,7 @@ class Snapshot(ObjectLifeCycleMixin, LabeledCloudResource):
         pass
 
     @abstractproperty
-    def volume_id(self):
+    def volume_id(self) -> str | None:
         """
         Get the id of the volume that this snapshot is based on.
 
@@ -1749,7 +1777,7 @@ class Snapshot(ObjectLifeCycleMixin, LabeledCloudResource):
         pass
 
     @abstractproperty
-    def create_time(self):
+    def create_time(self) -> str | datetime:
         """
         Get the creation data and time for this snapshot.
 
@@ -1760,7 +1788,9 @@ class Snapshot(ObjectLifeCycleMixin, LabeledCloudResource):
         pass
 
     @abstractmethod
-    def create_volume(self, size=None, volume_type=None, iops=None):
+    def create_volume(self, size: int | None = None,
+                      volume_type: str | None = None,
+                      iops: int | None = None) -> Volume:
         """
         Create a new Volume from this Snapshot.
 
@@ -1811,7 +1841,7 @@ class Snapshot(ObjectLifeCycleMixin, LabeledCloudResource):
 #         pass
 
     @abstractmethod
-    def delete(self):
+    def delete(self) -> bool:
         """
         Delete this snapshot.
 
@@ -1829,7 +1859,7 @@ class KeyPair(CloudResource):
     __metaclass__ = ABCMeta
 
     @abstractproperty
-    def material(self):
+    def material(self) -> str | None:
         """
         Unencrypted private key.
 
@@ -1839,7 +1869,7 @@ class KeyPair(CloudResource):
         pass
 
     @abstractmethod
-    def delete(self):
+    def delete(self) -> bool:
         """
         Delete this key pair.
 
@@ -1859,7 +1889,7 @@ class Region(CloudResource):
     __metaclass__ = ABCMeta
 
     @abstractproperty
-    def zones(self):
+    def zones(self) -> Iterable[PlacementZone]:
         """
         Access information about placement zones within this region.
 
@@ -1878,7 +1908,7 @@ class PlacementZone(CloudResource):
     __metaclass__ = ABCMeta
 
     @abstractproperty
-    def region_name(self):
+    def region_name(self) -> str:
         """
         A region this placement zone is associated with.
 
@@ -1895,7 +1925,7 @@ class VMType(CloudResource):
     __metaclass__ = ABCMeta
 
     @abstractproperty
-    def family(self):
+    def family(self) -> str | None:
         """
         The family/group that this VM type belongs to.
 
@@ -1908,7 +1938,7 @@ class VMType(CloudResource):
         pass
 
     @abstractproperty
-    def vcpus(self):
+    def vcpus(self) -> int:
         """
         The number of VCPUs supported by this VM type.
 
@@ -1918,7 +1948,7 @@ class VMType(CloudResource):
         pass
 
     @abstractproperty
-    def ram(self):
+    def ram(self) -> float:
         """
         The amount of RAM (in GB) supported by this VM type.
 
@@ -1928,7 +1958,7 @@ class VMType(CloudResource):
         pass
 
     @abstractproperty
-    def size_root_disk(self):
+    def size_root_disk(self) -> int:
         """
         The size of this VM types's root disk (in GB).
 
@@ -1938,7 +1968,7 @@ class VMType(CloudResource):
         pass
 
     @abstractproperty
-    def size_ephemeral_disks(self):
+    def size_ephemeral_disks(self) -> int:
         """
         The size of this VM types's total ephemeral storage (in GB).
 
@@ -1948,7 +1978,7 @@ class VMType(CloudResource):
         pass
 
     @abstractproperty
-    def num_ephemeral_disks(self):
+    def num_ephemeral_disks(self) -> int:
         """
         The total number of ephemeral disks on this VM type.
 
@@ -1958,7 +1988,7 @@ class VMType(CloudResource):
         pass
 
     @abstractproperty
-    def size_total_disk(self):
+    def size_total_disk(self) -> int:
         """
         The total disk space available on this VM type
         (root_disk + ephemeral).
@@ -1969,7 +1999,7 @@ class VMType(CloudResource):
         pass
 
     @abstractproperty
-    def extra_data(self):
+    def extra_data(self) -> dict[str, Any]:
         """
         A dictionary of extra data about this instance. May contain
         nested dictionaries, but all key value pairs are strings or integers.
@@ -1989,16 +2019,16 @@ class VMFirewall(LabeledCloudResource):
 
     __metaclass__ = ABCMeta
 
-    @LabeledCloudResource.label.setter
+    @LabeledCloudResource.label.setter  # type: ignore[attr-defined]
     @abstractmethod
-    def label(self, value):
+    def label(self, value: str) -> None:
         """
         Set the resource label.
         """
         pass
 
     @abstractproperty
-    def description(self):
+    def description(self) -> str:
         """
         Return the description of this VM firewall.
 
@@ -2008,7 +2038,7 @@ class VMFirewall(LabeledCloudResource):
         pass
 
     @abstractproperty
-    def network_id(self):
+    def network_id(self) -> str | None:
         """
         Network ID with which this VM firewall is associated.
 
@@ -2018,7 +2048,7 @@ class VMFirewall(LabeledCloudResource):
         pass
 
     @abstractproperty
-    def rules(self):
+    def rules(self) -> VMFirewallRuleSubService:
         """
         Get access to the rules belonging to this VM firewall.
 
@@ -2046,7 +2076,7 @@ class VMFirewallRule(CloudResource):
     __metaclass__ = ABCMeta
 
     @abstractproperty
-    def direction(self):
+    def direction(self) -> str:
         """
         Direction of traffic to which this rule applies.
 
@@ -2058,7 +2088,7 @@ class VMFirewallRule(CloudResource):
         pass
 
     @abstractproperty
-    def protocol(self):
+    def protocol(self) -> str:
         """
         IP protocol used. Either ``tcp`` | ``udp`` | ``icmp``.
 
@@ -2068,7 +2098,7 @@ class VMFirewallRule(CloudResource):
         pass
 
     @abstractproperty
-    def from_port(self):
+    def from_port(self) -> int:
         """
         Lowest port number opened as part of this rule.
 
@@ -2078,7 +2108,7 @@ class VMFirewallRule(CloudResource):
         pass
 
     @abstractproperty
-    def to_port(self):
+    def to_port(self) -> int:
         """
         Highest port number opened as part of this rule.
 
@@ -2088,7 +2118,7 @@ class VMFirewallRule(CloudResource):
         pass
 
     @abstractproperty
-    def cidr(self):
+    def cidr(self) -> str:
         """
         CIDR block this VM firewall is providing access to.
 
@@ -2098,7 +2128,7 @@ class VMFirewallRule(CloudResource):
         pass
 
     @abstractproperty
-    def src_dest_fw_id(self):
+    def src_dest_fw_id(self) -> str:
         """
         VM firewall id given access permissions by this rule.
 
@@ -2108,7 +2138,7 @@ class VMFirewallRule(CloudResource):
         pass
 
     @abstractproperty
-    def src_dest_fw(self):
+    def src_dest_fw(self) -> VMFirewall:
         """
         VM firewall given access permissions by this rule.
 
@@ -2118,7 +2148,7 @@ class VMFirewallRule(CloudResource):
         pass
 
     @abstractmethod
-    def delete(self):
+    def delete(self) -> None:
         """
         Delete this rule.
         """
@@ -2135,7 +2165,9 @@ class UploadConfig(object):
     Each provider maps these fields onto its native transfer mechanism.
     """
 
-    def __init__(self, threshold=None, part_size=None, max_concurrency=None):
+    def __init__(self, threshold: int | None = None,
+                 part_size: int | None = None,
+                 max_concurrency: int | None = None) -> None:
         """
         :type threshold: ``int``
         :param threshold: Size in bytes above which the upload is split into
@@ -2152,7 +2184,7 @@ class UploadConfig(object):
         self.part_size = part_size
         self.max_concurrency = max_concurrency
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return ("<CB-UploadConfig: threshold={0}, part_size={1}, "
                 "max_concurrency={2}>".format(
                     self.threshold, self.part_size, self.max_concurrency))
@@ -2170,7 +2202,7 @@ class UploadPart(object):
     __metaclass__ = ABCMeta
 
     @abstractproperty
-    def part_number(self):
+    def part_number(self) -> int:
         """
         The 1-based index of this part within the upload.
 
@@ -2180,7 +2212,7 @@ class UploadPart(object):
         pass
 
     @abstractproperty
-    def etag(self):
+    def etag(self) -> object:
         """
         Opaque provider handle identifying the stored part.
 
@@ -2206,7 +2238,7 @@ class MultipartUpload(CloudResource):
     __metaclass__ = ABCMeta
 
     @abstractproperty
-    def bucket(self):
+    def bucket(self) -> Bucket:
         """
         The bucket this upload targets.
 
@@ -2216,7 +2248,7 @@ class MultipartUpload(CloudResource):
         pass
 
     @abstractproperty
-    def object_name(self):
+    def object_name(self) -> str:
         """
         The key of the object being uploaded.
 
@@ -2226,7 +2258,8 @@ class MultipartUpload(CloudResource):
         pass
 
     @abstractmethod
-    def upload_part(self, part_number, data):
+    def upload_part(self, part_number: int,
+                    data: bytes | IO[bytes]) -> UploadPart:
         """
         Upload a single part of this multipart upload.
 
@@ -2245,7 +2278,7 @@ class MultipartUpload(CloudResource):
         pass
 
     @abstractmethod
-    def complete(self, parts):
+    def complete(self, parts: list[UploadPart]) -> BucketObject:
         """
         Finalize the upload, assembling parts in ascending ``part_number``.
 
@@ -2259,7 +2292,7 @@ class MultipartUpload(CloudResource):
         pass
 
     @abstractmethod
-    def abort(self):
+    def abort(self) -> None:
         """
         Cancel the upload, releasing any staged parts or temporary objects.
 
@@ -2277,7 +2310,7 @@ class BucketObject(CloudResource):
     __metaclass__ = ABCMeta
 
     @abstractproperty
-    def name(self):
+    def name(self) -> str:
         """
         Retrieve the name of the current object.
 
@@ -2292,7 +2325,7 @@ class BucketObject(CloudResource):
         pass
 
     @abstractproperty
-    def size(self):
+    def size(self) -> int:
         """
         Get this object's size.
 
@@ -2302,7 +2335,7 @@ class BucketObject(CloudResource):
         pass
 
     @abstractproperty
-    def last_modified(self):
+    def last_modified(self) -> str:
         """
         Get the date and time this object was last modified.
 
@@ -2312,7 +2345,7 @@ class BucketObject(CloudResource):
         pass
 
     @abstractmethod
-    def iter_content(self):
+    def iter_content(self) -> Iterable[bytes]:
         """
         Returns this object's content as an iterable.
 
@@ -2323,14 +2356,15 @@ class BucketObject(CloudResource):
         pass
 
     @abstractmethod
-    def save_content(self, target_stream):
+    def save_content(self, target_stream: IO[bytes]) -> None:
         """
         Save this object and write its contents to the ``target_stream``.
         """
         pass
 
     @abstractmethod
-    def upload(self, source_stream, config=None):
+    def upload(self, source_stream: IO[bytes],
+               config: UploadConfig | None = None) -> bool:
         """
         Set the contents of the object to the data read from the source stream.
 
@@ -2345,7 +2379,8 @@ class BucketObject(CloudResource):
         pass
 
     @abstractmethod
-    def upload_from_file(self, path, config=None):
+    def upload_from_file(self, path: str,
+                         config: UploadConfig | None = None) -> None:
         """
         Store the contents of the file pointed by the "path" variable.
 
@@ -2363,7 +2398,7 @@ class BucketObject(CloudResource):
         pass
 
     @abstractmethod
-    def create_multipart_upload(self):
+    def create_multipart_upload(self) -> MultipartUpload:
         """
         Begin an explicit, multi-part upload to this object.
 
@@ -2384,7 +2419,7 @@ class BucketObject(CloudResource):
         pass
 
     @abstractmethod
-    def delete(self):
+    def delete(self) -> bool:
         """
         Delete this object.
 
@@ -2394,7 +2429,7 @@ class BucketObject(CloudResource):
         pass
 
     @abstractmethod
-    def generate_url(self, expires_in, writable=False):
+    def generate_url(self, expires_in: int, writable: bool = False) -> str:
         """
         Generate a signed URL to this object.
 
@@ -2415,7 +2450,7 @@ class BucketObject(CloudResource):
         pass
 
     @abstractmethod
-    def refresh(self):
+    def refresh(self) -> None:
         """
         Refresh this object's state and synchronize it with the underlying
         service provider.
@@ -2431,7 +2466,7 @@ class Bucket(CloudResource):
     __metaclass__ = ABCMeta
 
     @abstractproperty
-    def name(self):
+    def name(self) -> str:
         """
         Retrieve the name of the current bucket.
 
@@ -2441,7 +2476,7 @@ class Bucket(CloudResource):
         pass
 
     @abstractproperty
-    def objects(self):
+    def objects(self) -> BucketObjectSubService:
         """
         Get a container for the objects belonging to this Bucket.
 
@@ -2469,7 +2504,7 @@ class Bucket(CloudResource):
         pass
 
     @abstractmethod
-    def delete(self, delete_contents=False):
+    def delete(self, delete_contents: bool = False) -> bool:
         """
         Delete this bucket.
 

--- a/cloudbridge/interfaces/resources.py
+++ b/cloudbridge/interfaces/resources.py
@@ -165,7 +165,7 @@ class LabeledCloudResource(CloudResource):
         pass
 
 
-class Configuration(dict):
+class Configuration(dict[str, Any]):
     """
     Represents a CloudBridge configuration object
     """

--- a/cloudbridge/interfaces/services.py
+++ b/cloudbridge/interfaces/services.py
@@ -322,6 +322,16 @@ class InstanceService(PageableObjectMixin[Instance], CloudService):
         """
         pass
 
+    @abstractmethod
+    def delete(self, instance: Instance | str) -> None:
+        """
+        Permanently delete an instance.
+
+        :type instance: :class:`.Instance` or ``str``
+        :param instance: The object or ID of the instance to be deleted.
+        """
+        pass
+
 
 class VolumeService(PageableObjectMixin[Volume], CloudService):
     """
@@ -1175,6 +1185,16 @@ class BucketService(PageableObjectMixin[Bucket], CloudService):
 
         :return:  a Bucket object
         :rtype: ``object`` of :class:`.Bucket`
+        """
+        pass
+
+    @abstractmethod
+    def delete(self, bucket: Bucket | str) -> None:
+        """
+        Delete a bucket.
+
+        :type bucket: :class:`.Bucket` or ``str``
+        :param bucket: The object or ID of the bucket to be deleted.
         """
         pass
 

--- a/cloudbridge/interfaces/services.py
+++ b/cloudbridge/interfaces/services.py
@@ -1,9 +1,41 @@
 """
 Specifications for services available through a provider
 """
-from abc import ABCMeta, abstractmethod, abstractproperty
+from __future__ import annotations
 
+import builtins
+from abc import ABCMeta, abstractmethod, abstractproperty
+from collections.abc import Iterator
+from typing import Any, IO, TYPE_CHECKING
+
+from cloudbridge.interfaces.resources import Bucket
+from cloudbridge.interfaces.resources import BucketObject
+from cloudbridge.interfaces.resources import DnsRecord
+from cloudbridge.interfaces.resources import DnsZone
+from cloudbridge.interfaces.resources import FloatingIP
+from cloudbridge.interfaces.resources import Gateway
+from cloudbridge.interfaces.resources import Instance
+from cloudbridge.interfaces.resources import InternetGateway
+from cloudbridge.interfaces.resources import KeyPair
+from cloudbridge.interfaces.resources import LaunchConfig
+from cloudbridge.interfaces.resources import MachineImage
+from cloudbridge.interfaces.resources import MultipartUpload
+from cloudbridge.interfaces.resources import Network
 from cloudbridge.interfaces.resources import PageableObjectMixin
+from cloudbridge.interfaces.resources import Region
+from cloudbridge.interfaces.resources import ResultList
+from cloudbridge.interfaces.resources import Router
+from cloudbridge.interfaces.resources import Snapshot
+from cloudbridge.interfaces.resources import Subnet
+from cloudbridge.interfaces.resources import TrafficDirection
+from cloudbridge.interfaces.resources import UploadPart
+from cloudbridge.interfaces.resources import VMFirewall
+from cloudbridge.interfaces.resources import VMFirewallRule
+from cloudbridge.interfaces.resources import VMType
+from cloudbridge.interfaces.resources import Volume
+
+if TYPE_CHECKING:
+    from cloudbridge.interfaces.provider import CloudProvider
 
 
 class CloudService(object):
@@ -16,7 +48,7 @@ class CloudService(object):
     __metaclass__ = ABCMeta
 
     @abstractproperty
-    def provider(self):
+    def provider(self) -> CloudProvider:
         """
         Returns the provider instance associated with this service.
 
@@ -37,7 +69,7 @@ class ComputeService(CloudService):
     __metaclass__ = ABCMeta
 
     @abstractproperty
-    def images(self):
+    def images(self) -> ImageService:
         """
         Provides access to all Image related services in this provider.
         (e.g. Glance in OpenStack)
@@ -64,7 +96,7 @@ class ComputeService(CloudService):
         pass
 
     @abstractproperty
-    def vm_types(self):
+    def vm_types(self) -> VMTypeService:
         """
         Provides access to all VM type related services in this provider.
 
@@ -86,7 +118,7 @@ class ComputeService(CloudService):
         pass
 
     @abstractproperty
-    def instances(self):
+    def instances(self) -> InstanceService:
         """
         Provides access to all Instance related services in this provider.
 
@@ -106,7 +138,7 @@ class ComputeService(CloudService):
         pass
 
     @abstractproperty
-    def regions(self):
+    def regions(self) -> RegionService:
         """
         Provides access to all Region related services in this provider.
 
@@ -125,7 +157,7 @@ class ComputeService(CloudService):
         pass
 
 
-class InstanceService(PageableObjectMixin, CloudService):
+class InstanceService(PageableObjectMixin[Instance], CloudService):
     """
     Provides access to instances in a provider, including creating,
     listing and deleting instances.
@@ -133,7 +165,7 @@ class InstanceService(PageableObjectMixin, CloudService):
     __metaclass__ = ABCMeta
 
     @abstractmethod
-    def __iter__(self):
+    def __iter__(self) -> Iterator[Instance]:
         """
         Iterate through the  list of instances.
 
@@ -149,7 +181,7 @@ class InstanceService(PageableObjectMixin, CloudService):
         pass
 
     @abstractmethod
-    def get(self, instance_id):
+    def get(self, instance_id: str) -> Instance | None:
         """
         Returns an instance given its id. Returns None
         if the object does not exist.
@@ -160,7 +192,7 @@ class InstanceService(PageableObjectMixin, CloudService):
         pass
 
     @abstractmethod
-    def find(self, **kwargs):
+    def find(self, **kwargs: Any) -> ResultList[Instance]:
         """
         Searches for an instance by a given list of attributes.
 
@@ -178,7 +210,8 @@ class InstanceService(PageableObjectMixin, CloudService):
         pass
 
     @abstractmethod
-    def list(self, limit=None, marker=None):
+    def list(self, limit: int | None = None,
+             marker: str | None = None) -> ResultList[Instance]:
         """
         List available instances.
 
@@ -213,9 +246,13 @@ class InstanceService(PageableObjectMixin, CloudService):
         pass
 
     @abstractmethod
-    def create(self, label, image, vm_type, subnet, key_pair=None,
-               vm_firewalls=None, user_data=None, launch_config=None,
-               **kwargs):
+    def create(self, label: str, image: MachineImage | str,
+               vm_type: VMType | str, subnet: Subnet | str,
+               key_pair: KeyPair | str | None = None,
+               vm_firewalls: builtins.list[VMFirewall] | builtins.list[str] | None = None,
+               user_data: str | None = None,
+               launch_config: LaunchConfig | None = None,
+               **kwargs: Any) -> Instance:
         """
         Creates a new virtual machine instance.
 
@@ -273,7 +310,8 @@ class InstanceService(PageableObjectMixin, CloudService):
         """
         pass
 
-    def create_launch_config(self):
+    @abstractmethod
+    def create_launch_config(self) -> LaunchConfig:
         """
         Creates a ``LaunchConfig`` object which can be used
         to set additional options when launching an instance, such as
@@ -285,14 +323,14 @@ class InstanceService(PageableObjectMixin, CloudService):
         pass
 
 
-class VolumeService(PageableObjectMixin, CloudService):
+class VolumeService(PageableObjectMixin[Volume], CloudService):
     """
     Base interface for a Volume Service.
     """
     __metaclass__ = ABCMeta
 
     @abstractmethod
-    def get(self, volume_id):
+    def get(self, volume_id: str) -> Volume | None:
         """
         Returns a volume given its id.
 
@@ -302,7 +340,7 @@ class VolumeService(PageableObjectMixin, CloudService):
         pass
 
     @abstractmethod
-    def find(self, **kwargs):
+    def find(self, **kwargs: Any) -> ResultList[Volume]:
         """
         Searches for a volume by a given list of attributes.
 
@@ -314,7 +352,8 @@ class VolumeService(PageableObjectMixin, CloudService):
         pass
 
     @abstractmethod
-    def list(self, limit=None, marker=None):
+    def list(self, limit: int | None = None,
+             marker: str | None = None) -> ResultList[Volume]:
         """
         List all volumes.
 
@@ -324,7 +363,8 @@ class VolumeService(PageableObjectMixin, CloudService):
         pass
 
     @abstractmethod
-    def create(self, label, size, snapshot=None, description=None):
+    def create(self, label: str, size: int, snapshot: Snapshot | str | None = None,
+               description: str | None = None) -> Volume:
         """
         Creates a new volume.
 
@@ -348,7 +388,7 @@ class VolumeService(PageableObjectMixin, CloudService):
         """
         pass
 
-    def delete(self, volume):
+    def delete(self, volume: Volume | str) -> None:
         """
         Delete an existing volume.
 
@@ -358,14 +398,14 @@ class VolumeService(PageableObjectMixin, CloudService):
         pass
 
 
-class SnapshotService(PageableObjectMixin, CloudService):
+class SnapshotService(PageableObjectMixin[Snapshot], CloudService):
     """
     Base interface for a Snapshot Service.
     """
     __metaclass__ = ABCMeta
 
     @abstractmethod
-    def get(self, snapshot_id):
+    def get(self, snapshot_id: str) -> Snapshot | None:
         """
         Returns a snapshot given its id.
 
@@ -375,7 +415,7 @@ class SnapshotService(PageableObjectMixin, CloudService):
         pass
 
     @abstractmethod
-    def find(self, **kwargs):
+    def find(self, **kwargs: Any) -> ResultList[Snapshot]:
         """
         Searches for a snapshot by a given list of attributes.
 
@@ -387,7 +427,8 @@ class SnapshotService(PageableObjectMixin, CloudService):
         pass
 
     @abstractmethod
-    def list(self, limit=None, marker=None):
+    def list(self, limit: int | None = None,
+             marker: str | None = None) -> ResultList[Snapshot]:
         """
         List all snapshots.
 
@@ -397,7 +438,8 @@ class SnapshotService(PageableObjectMixin, CloudService):
         pass
 
     @abstractmethod
-    def create(self, label, volume, description=None):
+    def create(self, label: str, volume: Volume | str,
+               description: str | None = None) -> Snapshot:
         """
         Creates a new snapshot off a volume.
 
@@ -417,7 +459,7 @@ class SnapshotService(PageableObjectMixin, CloudService):
         """
         pass
 
-    def delete(self, snapshot):
+    def delete(self, snapshot: Snapshot | str) -> None:
         """
         Delete an existing snapshot.
 
@@ -437,7 +479,7 @@ class StorageService(CloudService):
     __metaclass__ = ABCMeta
 
     @abstractproperty
-    def volumes(self):
+    def volumes(self) -> VolumeService:
         """
         Provides access to volumes (i.e., block storage) for this provider.
 
@@ -459,7 +501,7 @@ class StorageService(CloudService):
         pass
 
     @abstractproperty
-    def snapshots(self):
+    def snapshots(self) -> SnapshotService:
         """
         Provides access to volume snapshots for this provider.
 
@@ -481,7 +523,7 @@ class StorageService(CloudService):
         pass
 
     @abstractproperty
-    def buckets(self):
+    def buckets(self) -> BucketService:
         """
         Provides access to object storage services in this provider.
 
@@ -503,7 +545,7 @@ class StorageService(CloudService):
         pass
 
 
-class ImageService(PageableObjectMixin, CloudService):
+class ImageService(PageableObjectMixin[MachineImage], CloudService):
 
     """
     Base interface for an Image Service
@@ -511,7 +553,7 @@ class ImageService(PageableObjectMixin, CloudService):
     __metaclass__ = ABCMeta
 
     @abstractmethod
-    def get(self, image_id):
+    def get(self, image_id: str) -> MachineImage | None:
         """
         Returns an Image given its id. Returns None if the Image does not
         exist.
@@ -522,7 +564,7 @@ class ImageService(PageableObjectMixin, CloudService):
         pass
 
     @abstractmethod
-    def find(self, **kwargs):
+    def find(self, **kwargs: Any) -> ResultList[MachineImage]:
         """
         Searches for an image by a given list of attributes
 
@@ -534,7 +576,11 @@ class ImageService(PageableObjectMixin, CloudService):
         pass
 
     @abstractmethod
-    def list(self, filter_by_owner=True, limit=None, marker=None):
+    # Intentionally extends the base list() with a leading filter_by_owner
+    # parameter (see the matching arguments-differ suppression elsewhere).
+    def list(self,  # type: ignore[override]
+             filter_by_owner: bool = True, limit: int | None = None,
+             marker: str | None = None) -> ResultList[MachineImage]:
         """
         List all images.
 
@@ -561,7 +607,7 @@ class NetworkingService(CloudService):
     __metaclass__ = ABCMeta
 
     @abstractproperty
-    def networks(self):
+    def networks(self) -> NetworkService:
         """
         Provides access to all Network related services.
 
@@ -571,7 +617,7 @@ class NetworkingService(CloudService):
         pass
 
     @abstractproperty
-    def subnets(self):
+    def subnets(self) -> SubnetService:
         """
         Provides access to all Subnet related services.
 
@@ -581,7 +627,7 @@ class NetworkingService(CloudService):
         pass
 
     @abstractproperty
-    def routers(self):
+    def routers(self) -> RouterService:
         """
         Provides access to all Router related services.
 
@@ -591,7 +637,7 @@ class NetworkingService(CloudService):
         pass
 
     @abstractproperty
-    def _floating_ips(self):
+    def _floating_ips(self) -> FloatingIPService:
         """
         Provides access to floating ips for this provider.
         This service is not iterable.
@@ -602,7 +648,7 @@ class NetworkingService(CloudService):
         pass
 
     @abstractproperty
-    def _gateways(self):
+    def _gateways(self) -> GatewayService:
         """
         Provides access to internet gateways for this provider.
         This service is not iterable.
@@ -613,7 +659,7 @@ class NetworkingService(CloudService):
         pass
 
 
-class NetworkService(PageableObjectMixin, CloudService):
+class NetworkService(PageableObjectMixin[Network], CloudService):
 
     """
     Base interface for a Network Service.
@@ -621,7 +667,7 @@ class NetworkService(PageableObjectMixin, CloudService):
     __metaclass__ = ABCMeta
 
     @abstractmethod
-    def get(self, network_id):
+    def get(self, network_id: str) -> Network | None:
         """
         Returns a Network given its ID or ``None`` if not found.
 
@@ -634,7 +680,8 @@ class NetworkService(PageableObjectMixin, CloudService):
         pass
 
     @abstractmethod
-    def list(self, limit=None, marker=None):
+    def list(self, limit: int | None = None,
+             marker: str | None = None) -> ResultList[Network]:
         """
         List all networks.
 
@@ -644,7 +691,7 @@ class NetworkService(PageableObjectMixin, CloudService):
         pass
 
     @abstractmethod
-    def find(self, **kwargs):
+    def find(self, **kwargs: Any) -> ResultList[Network]:
         """
         Searches for a network by a given list of attributes.
 
@@ -656,7 +703,7 @@ class NetworkService(PageableObjectMixin, CloudService):
         pass
 
     @abstractmethod
-    def create(self, label, cidr_block):
+    def create(self, label: str, cidr_block: str) -> Network:
         """
         Create a new network.
 
@@ -679,7 +726,7 @@ class NetworkService(PageableObjectMixin, CloudService):
         pass
 
     @abstractmethod
-    def delete(self, network):
+    def delete(self, network: Network | str) -> None:
         """
         Delete an existing Network.
 
@@ -689,7 +736,7 @@ class NetworkService(PageableObjectMixin, CloudService):
         pass
 
     @abstractproperty
-    def subnets(self):
+    def subnets(self) -> SubnetService:
         """
         Provides access to subnets.
 
@@ -711,7 +758,7 @@ class NetworkService(PageableObjectMixin, CloudService):
         pass
 
 
-class SubnetService(PageableObjectMixin, CloudService):
+class SubnetService(PageableObjectMixin[Subnet], CloudService):
 
     """
     Base interface for a Subnet Service.
@@ -719,7 +766,7 @@ class SubnetService(PageableObjectMixin, CloudService):
     __metaclass__ = ABCMeta
 
     @abstractmethod
-    def get(self, subnet_id):
+    def get(self, subnet_id: str) -> Subnet | None:
         """
         Returns a Subnet given its ID or ``None`` if not found.
 
@@ -733,7 +780,10 @@ class SubnetService(PageableObjectMixin, CloudService):
 
     @abstractmethod
     # pylint:disable=arguments-differ
-    def list(self, network=None, limit=None, marker=None):
+    def list(self,  # type: ignore[override]
+             network: Network | str | None = None,
+             limit: int | None = None,
+             marker: str | None = None) -> ResultList[Subnet]:
         """
         List all subnets or filter them by the supplied network ID.
 
@@ -746,7 +796,7 @@ class SubnetService(PageableObjectMixin, CloudService):
         pass
 
     @abstractmethod
-    def find(self, **kwargs):
+    def find(self, **kwargs: Any) -> ResultList[Subnet]:
         """
         Searches for a subnet by a given list of attributes.
 
@@ -758,7 +808,8 @@ class SubnetService(PageableObjectMixin, CloudService):
         pass
 
     @abstractmethod
-    def create(self, label, network, cidr_block):
+    def create(self, label: str, network: Network | str,
+               cidr_block: str) -> Subnet:
         """
         Create a new subnet within the supplied network.
 
@@ -778,7 +829,7 @@ class SubnetService(PageableObjectMixin, CloudService):
         pass
 
     @abstractmethod
-    def get_or_create_default(self):
+    def get_or_create_default(self) -> Subnet:
         """
         Return a default subnet for the account or create one if not found.
         This provides a convenience method for obtaining a network if you
@@ -793,7 +844,7 @@ class SubnetService(PageableObjectMixin, CloudService):
         pass
 
     @abstractmethod
-    def delete(self, subnet):
+    def delete(self, subnet: Subnet | str) -> None:
         """
         Delete an existing Subnet.
 
@@ -803,14 +854,14 @@ class SubnetService(PageableObjectMixin, CloudService):
         pass
 
 
-class RouterService(PageableObjectMixin, CloudService):
+class RouterService(PageableObjectMixin[Router], CloudService):
     """
     Manage networking router actions and resources.
     """
     __metaclass__ = ABCMeta
 
     @abstractmethod
-    def get(self, router_id):
+    def get(self, router_id: str) -> Router | None:
         """
         Returns a Router object given its ID.
 
@@ -823,7 +874,8 @@ class RouterService(PageableObjectMixin, CloudService):
         pass
 
     @abstractmethod
-    def list(self, limit=None, marker=None):
+    def list(self, limit: int | None = None,
+             marker: str | None = None) -> ResultList[Router]:
         """
         List all routers.
 
@@ -833,7 +885,7 @@ class RouterService(PageableObjectMixin, CloudService):
         pass
 
     @abstractmethod
-    def find(self, **kwargs):
+    def find(self, **kwargs: Any) -> ResultList[Router]:
         """
         Searches for a router by a given list of attributes.
 
@@ -845,7 +897,7 @@ class RouterService(PageableObjectMixin, CloudService):
         pass
 
     @abstractmethod
-    def create(self, label, network):
+    def create(self, label: str, network: Network | str) -> Router:
         """
         Create a new router.
 
@@ -861,7 +913,7 @@ class RouterService(PageableObjectMixin, CloudService):
         pass
 
     @abstractmethod
-    def delete(self, router):
+    def delete(self, router: Router | str) -> None:
         """
         Delete an existing Router.
 
@@ -881,7 +933,7 @@ class DnsService(CloudService):
     __metaclass__ = ABCMeta
 
     @abstractproperty
-    def host_zones(self):
+    def host_zones(self) -> DnsZoneService:
         """
         Provides access to all dns zones.
 
@@ -891,7 +943,7 @@ class DnsService(CloudService):
         pass
 
     @abstractproperty
-    def _records(self):
+    def _records(self) -> DnsRecordService:
         """
         Provides access to dns records for this service.
         This service is not iterable.
@@ -902,7 +954,7 @@ class DnsService(CloudService):
         pass
 
 
-class DnsZoneService(PageableObjectMixin, CloudService):
+class DnsZoneService(PageableObjectMixin[DnsZone], CloudService):
     """
     Manage DNS Zone actions and resources. This service is optional and
     the :func:`CloudProvider.has_service()` method should be used to verify its
@@ -911,7 +963,7 @@ class DnsZoneService(PageableObjectMixin, CloudService):
     __metaclass__ = ABCMeta
 
     @abstractmethod
-    def get(self, dns_zone_id):
+    def get(self, dns_zone_id: str) -> DnsZone | None:
         """
         Returns a DnsZone object given its ID.
 
@@ -924,7 +976,8 @@ class DnsZoneService(PageableObjectMixin, CloudService):
         pass
 
     @abstractmethod
-    def list(self, limit=None, marker=None):
+    def list(self, limit: int | None = None,
+             marker: str | None = None) -> ResultList[DnsZone]:
         """
         List all host zones.
 
@@ -934,7 +987,7 @@ class DnsZoneService(PageableObjectMixin, CloudService):
         pass
 
     @abstractmethod
-    def find(self, **kwargs):
+    def find(self, **kwargs: Any) -> ResultList[DnsZone]:
         """
         Searches for a host zone by a given list of attributes.
 
@@ -946,7 +999,7 @@ class DnsZoneService(PageableObjectMixin, CloudService):
         pass
 
     @abstractmethod
-    def create(self, label, admin_email):
+    def create(self, label: str, admin_email: str) -> DnsZone:
         """
         Create a new host zone.
 
@@ -962,7 +1015,7 @@ class DnsZoneService(PageableObjectMixin, CloudService):
         pass
 
     @abstractmethod
-    def delete(self, dns_zone):
+    def delete(self, dns_zone: DnsZone | str) -> None:
         """
         Delete an existing DnsHostZone.
 
@@ -981,7 +1034,8 @@ class DnsRecordService(CloudService):
     __metaclass__ = ABCMeta
 
     @abstractmethod
-    def get(self, dns_zone, rec_id):
+    def get(self, dns_zone: DnsZone | str,
+            rec_id: str) -> DnsRecord | None:
         """
         Returns a record given its ID and the dns_zone containing
         it. Returns ``None`` if the record does not exist.
@@ -992,7 +1046,8 @@ class DnsRecordService(CloudService):
         pass
 
     @abstractmethod
-    def list(self, dns_zone, limit=None, marker=None):
+    def list(self, dns_zone: DnsZone | str, limit: int | None = None,
+             marker: str | None = None) -> ResultList[DnsRecord]:
         """
         List all records within a dns zone.
 
@@ -1002,7 +1057,8 @@ class DnsRecordService(CloudService):
         pass
 
     @abstractmethod
-    def create(self, dns_zone, name, type, data, ttl=None):
+    def create(self, dns_zone: DnsZone | str, name: str, type: str,
+               data: str, ttl: int | None = None) -> DnsRecord:
         """
         Create a new record within a zone.
 
@@ -1027,7 +1083,7 @@ class DnsRecordService(CloudService):
         pass
 
 
-class BucketService(PageableObjectMixin, CloudService):
+class BucketService(PageableObjectMixin[Bucket], CloudService):
 
     """
     The Bucket Service interface provides access to the underlying
@@ -1038,7 +1094,7 @@ class BucketService(PageableObjectMixin, CloudService):
     __metaclass__ = ABCMeta
 
     @abstractmethod
-    def get(self, bucket_id):
+    def get(self, bucket_id: str) -> Bucket | None:
         """
         Returns a bucket given its ID. Returns ``None`` if the bucket
         does not exist. On some providers, such as AWS and OpenStack,
@@ -1057,7 +1113,7 @@ class BucketService(PageableObjectMixin, CloudService):
         pass
 
     @abstractmethod
-    def find(self, **kwargs):
+    def find(self, **kwargs: Any) -> ResultList[Bucket]:
         """
         Searches for a bucket by a given list of attributes.
 
@@ -1077,7 +1133,8 @@ class BucketService(PageableObjectMixin, CloudService):
         pass
 
     @abstractmethod
-    def list(self, limit=None, marker=None):
+    def list(self, limit: int | None = None,
+             marker: str | None = None) -> ResultList[Bucket]:
         """
         List all buckets.
 
@@ -1095,7 +1152,7 @@ class BucketService(PageableObjectMixin, CloudService):
         pass
 
     @abstractmethod
-    def create(self, name, location=None):
+    def create(self, name: str, location: Region | str | None = None) -> Bucket:
         """
         Create a new bucket.
 
@@ -1133,7 +1190,8 @@ class BucketObjectService(CloudService):
     __metaclass__ = ABCMeta
 
     @abstractmethod
-    def get(self, bucket, object_id):
+    def get(self, bucket: Bucket | str,
+            object_id: str) -> BucketObject | None:
         """
         Returns a bucket object given its ID and the ID of bucket containing
         it. Returns ``None`` if the bucket object or bucket does not exist.
@@ -1156,7 +1214,8 @@ class BucketObjectService(CloudService):
         pass
 
     @abstractmethod
-    def find(self, bucket, **kwargs):
+    def find(self, bucket: Bucket | str,
+             **kwargs: Any) -> ResultList[BucketObject]:
         """
         Searches for a bucket object in a bucket by a given list of attributes.
 
@@ -1179,7 +1238,9 @@ class BucketObjectService(CloudService):
         pass
 
     @abstractmethod
-    def list(self, bucket, prefix=None, limit=None, marker=None):
+    def list(self, bucket: Bucket | str, prefix: str | None = None,
+             limit: int | None = None,
+             marker: str | None = None) -> ResultList[BucketObject]:
         """
         List all bucket objects within a bucket.
 
@@ -1199,7 +1260,8 @@ class BucketObjectService(CloudService):
         pass
 
     @abstractmethod
-    def create(self, bucket, object_name):
+    def create(self, bucket: Bucket | str,
+               object_name: str) -> BucketObject:
         """
         Create a new bucket object within a bucket.
 
@@ -1226,7 +1288,8 @@ class BucketObjectService(CloudService):
         pass
 
     @abstractmethod
-    def create_multipart_upload(self, bucket, object_name):
+    def create_multipart_upload(self, bucket: Bucket | str,
+                                object_name: str) -> MultipartUpload:
         """
         Begin an explicit, multi-part upload of an object to a bucket.
 
@@ -1242,7 +1305,8 @@ class BucketObjectService(CloudService):
         pass
 
     @abstractmethod
-    def upload_part(self, bucket, upload, part_number, data):
+    def upload_part(self, bucket: Bucket | str, upload: MultipartUpload,
+                    part_number: int, data: bytes | IO[bytes]) -> UploadPart:
         """
         Upload a single part of an in-progress multipart upload.
 
@@ -1265,7 +1329,9 @@ class BucketObjectService(CloudService):
         pass
 
     @abstractmethod
-    def complete_multipart_upload(self, bucket, upload, parts):
+    def complete_multipart_upload(self, bucket: Bucket | str,
+                                  upload: MultipartUpload,
+                                  parts: builtins.list[UploadPart]) -> BucketObject:
         """
         Finalize a multipart upload, assembling parts in part-number order.
 
@@ -1284,7 +1350,8 @@ class BucketObjectService(CloudService):
         pass
 
     @abstractmethod
-    def abort_multipart_upload(self, bucket, upload):
+    def abort_multipart_upload(self, bucket: Bucket | str,
+                               upload: MultipartUpload) -> None:
         """
         Cancel a multipart upload and release any staged parts.
 
@@ -1306,7 +1373,7 @@ class SecurityService(CloudService):
     __metaclass__ = ABCMeta
 
     @abstractproperty
-    def key_pairs(self):
+    def key_pairs(self) -> KeyPairService:
         """
         Provides access to key pairs for this provider.
 
@@ -1328,7 +1395,7 @@ class SecurityService(CloudService):
         pass
 
     @abstractproperty
-    def vm_firewalls(self):
+    def vm_firewalls(self) -> VMFirewallService:
         """
         Provides access to firewalls (security groups) for this provider.
 
@@ -1350,7 +1417,7 @@ class SecurityService(CloudService):
         pass
 
     @abstractproperty
-    def _vm_firewall_rules(self):
+    def _vm_firewall_rules(self) -> VMFirewallRuleService:
         """
         Provides access to firewall (security group) rules for this provider.
         This service is not iterable.
@@ -1361,7 +1428,7 @@ class SecurityService(CloudService):
         pass
 
 
-class KeyPairService(PageableObjectMixin, CloudService):
+class KeyPairService(PageableObjectMixin[KeyPair], CloudService):
 
     """
     Base interface for key pairs.
@@ -1369,7 +1436,7 @@ class KeyPairService(PageableObjectMixin, CloudService):
     __metaclass__ = ABCMeta
 
     @abstractmethod
-    def get(self, key_pair_id):
+    def get(self, key_pair_id: str) -> KeyPair | None:
         """
         Return a KeyPair given its ID or ``None`` if not found.
 
@@ -1389,7 +1456,8 @@ class KeyPairService(PageableObjectMixin, CloudService):
         pass
 
     @abstractmethod
-    def list(self, limit=None, marker=None):
+    def list(self, limit: int | None = None,
+             marker: str | None = None) -> ResultList[KeyPair]:
         """
         List all key pairs associated with this account.
 
@@ -1399,7 +1467,7 @@ class KeyPairService(PageableObjectMixin, CloudService):
         pass
 
     @abstractmethod
-    def find(self, **kwargs):
+    def find(self, **kwargs: Any) -> ResultList[KeyPair]:
         """
         Searches for a key pair by a given list of attributes.
 
@@ -1411,7 +1479,8 @@ class KeyPairService(PageableObjectMixin, CloudService):
         pass
 
     @abstractmethod
-    def create(self, name, public_key_material=None):
+    def create(self, name: str,
+               public_key_material: str | None = None) -> KeyPair:
         """
         Create a new key pair or raise an exception if one already exists.
         If the public_key_material is provided, the material will be imported
@@ -1431,7 +1500,7 @@ class KeyPairService(PageableObjectMixin, CloudService):
         pass
 
     @abstractmethod
-    def delete(self, key_pair):
+    def delete(self, key_pair: KeyPair | str) -> bool:
         """
         Delete an existing keypair.
 
@@ -1446,7 +1515,7 @@ class KeyPairService(PageableObjectMixin, CloudService):
         pass
 
 
-class VMFirewallService(PageableObjectMixin, CloudService):
+class VMFirewallService(PageableObjectMixin[VMFirewall], CloudService):
 
     """
     Base interface for VM firewalls.
@@ -1454,7 +1523,7 @@ class VMFirewallService(PageableObjectMixin, CloudService):
     __metaclass__ = ABCMeta
 
     @abstractmethod
-    def get(self, vm_firewall_id):
+    def get(self, vm_firewall_id: str) -> VMFirewall | None:
         """
         Returns a VMFirewall given its ID. Returns ``None`` if the
         VMFirewall does not exist.
@@ -1472,7 +1541,8 @@ class VMFirewallService(PageableObjectMixin, CloudService):
         pass
 
     @abstractmethod
-    def list(self, limit=None, marker=None):
+    def list(self, limit: int | None = None,
+             marker: str | None = None) -> ResultList[VMFirewall]:
         """
         List all VM firewalls associated with this account.
 
@@ -1482,7 +1552,8 @@ class VMFirewallService(PageableObjectMixin, CloudService):
         pass
 
     @abstractmethod
-    def create(self, label, network, description=None):
+    def create(self, label: str, network: Network | str,
+               description: str | None = None) -> VMFirewall:
         """
         Create a new VMFirewall.
 
@@ -1501,7 +1572,7 @@ class VMFirewallService(PageableObjectMixin, CloudService):
         pass
 
     @abstractmethod
-    def find(self, **kwargs):
+    def find(self, **kwargs: Any) -> ResultList[VMFirewall]:
         """
         Get VM firewalls associated with your account filtered by name.
 
@@ -1517,7 +1588,7 @@ class VMFirewallService(PageableObjectMixin, CloudService):
         pass
 
     @abstractmethod
-    def delete(self, vm_firewall):
+    def delete(self, vm_firewall: VMFirewall | str) -> None:
         """
         Delete an existing VMFirewall.
 
@@ -1534,7 +1605,8 @@ class VMFirewallRuleService(CloudService):
     __metaclass__ = ABCMeta
 
     @abstractmethod
-    def get(self, firewall, rule_id):
+    def get(self, firewall: VMFirewall,
+            rule_id: str) -> VMFirewallRule | None:
         """
         Return a firewall rule given its ID.
 
@@ -1560,7 +1632,8 @@ class VMFirewallRuleService(CloudService):
         pass
 
     @abstractmethod
-    def list(self, firewall, limit=None, marker=None):
+    def list(self, firewall: VMFirewall, limit: int | None = None,
+             marker: str | None = None) -> ResultList[VMFirewallRule]:
         """
         List all firewall rules associated with this firewall.
 
@@ -1573,8 +1646,11 @@ class VMFirewallRuleService(CloudService):
         pass
 
     @abstractmethod
-    def create(self, firewall,  direction, protocol=None, from_port=None,
-               to_port=None, cidr=None, src_dest_fw=None):
+    def create(self, firewall: VMFirewall, direction: TrafficDirection,
+               protocol: str | None = None, from_port: int | None = None,
+               to_port: int | None = None,
+               cidr: str | builtins.list[str] | None = None,
+               src_dest_fw: VMFirewall | None = None) -> VMFirewallRule:
         """
         Create a VM firewall rule.
 
@@ -1628,7 +1704,8 @@ class VMFirewallRuleService(CloudService):
         pass
 
     @abstractmethod
-    def find(self, firewall, **kwargs):
+    def find(self, firewall: VMFirewall,
+             **kwargs: Any) -> ResultList[VMFirewallRule]:
         """
         Find a firewall rule filtered by the given parameters.
 
@@ -1667,7 +1744,7 @@ class VMFirewallRuleService(CloudService):
         pass
 
     @abstractmethod
-    def delete(self, firewall, rule_id):
+    def delete(self, firewall: VMFirewall, rule_id: str) -> None:
         """
         Delete an existing VMFirewall rule.
 
@@ -1680,11 +1757,11 @@ class VMFirewallRuleService(CloudService):
         pass
 
 
-class VMTypeService(PageableObjectMixin, CloudService):
+class VMTypeService(PageableObjectMixin[VMType], CloudService):
     __metaclass__ = ABCMeta
 
     @abstractmethod
-    def get(self, vm_type_id):
+    def get(self, vm_type_id: str) -> VMType | None:
         """
         Returns an VMType given its ID. Returns ``None`` if the
         VMType does not exist.
@@ -1702,7 +1779,8 @@ class VMTypeService(PageableObjectMixin, CloudService):
         pass
 
     @abstractmethod
-    def list(self, limit=None, marker=None):
+    def list(self, limit: int | None = None,
+             marker: str | None = None) -> ResultList[VMType]:
         """
         List all VM types.
 
@@ -1712,7 +1790,7 @@ class VMTypeService(PageableObjectMixin, CloudService):
         pass
 
     @abstractmethod
-    def find(self, **kwargs):
+    def find(self, **kwargs: Any) -> ResultList[VMType]:
         """
         Searches for instances by a given list of attributes.
 
@@ -1724,7 +1802,7 @@ class VMTypeService(PageableObjectMixin, CloudService):
         pass
 
 
-class RegionService(PageableObjectMixin, CloudService):
+class RegionService(PageableObjectMixin[Region], CloudService):
 
     """
     Base interface for a Region service
@@ -1732,7 +1810,7 @@ class RegionService(PageableObjectMixin, CloudService):
     __metaclass__ = ABCMeta
 
     @abstractproperty
-    def current(self):
+    def current(self) -> Region | None:
         """
         Returns the current region that this provider is connected to.
 
@@ -1744,7 +1822,7 @@ class RegionService(PageableObjectMixin, CloudService):
         pass
 
     @abstractmethod
-    def get(self, region_id):
+    def get(self, region_id: str) -> Region | None:
         """
         Returns a region given its id. Returns None if the region
         does not exist.
@@ -1755,7 +1833,8 @@ class RegionService(PageableObjectMixin, CloudService):
         pass
 
     @abstractmethod
-    def list(self, limit=None, marker=None):
+    def list(self, limit: int | None = None,
+             marker: str | None = None) -> ResultList[Region]:
         """
         List all regions.
 
@@ -1765,7 +1844,7 @@ class RegionService(PageableObjectMixin, CloudService):
         pass
 
     @abstractmethod
-    def find(self, **kwargs):
+    def find(self, **kwargs: Any) -> ResultList[Region]:
         """
         Searches for a region by a given list of attributes.
 
@@ -1784,7 +1863,7 @@ class GatewayService(CloudService):
     __metaclass__ = ABCMeta
 
     @abstractmethod
-    def get_or_create(self, network):
+    def get_or_create(self, network: Network | str) -> InternetGateway:
         """
         Creates new or returns an existing internet gateway for a network.
 
@@ -1800,7 +1879,7 @@ class GatewayService(CloudService):
         pass
 
     @abstractmethod
-    def delete(self, network, gateway):
+    def delete(self, network: Network | str, gateway: Gateway) -> None:
         """
         Delete a gateway.
 
@@ -1813,7 +1892,8 @@ class GatewayService(CloudService):
         pass
 
     @abstractmethod
-    def list(self, network, limit=None, marker=None):
+    def list(self, network: Network | str, limit: int | None = None,
+             marker: str | None = None) -> ResultList[InternetGateway]:
         """
         List all available internet gateways.
 
@@ -1833,7 +1913,7 @@ class FloatingIPService(CloudService):
     __metaclass__ = ABCMeta
 
     @abstractmethod
-    def get(self, gateway, fip_id):
+    def get(self, gateway: Gateway, fip_id: str) -> FloatingIP | None:
         """
         Returns a FloatingIP given its ID or ``None`` if not found.
 
@@ -1849,7 +1929,8 @@ class FloatingIPService(CloudService):
         pass
 
     @abstractmethod
-    def list(self, gateway, limit=None, marker=None):
+    def list(self, gateway: Gateway, limit: int | None = None,
+             marker: str | None = None) -> ResultList[FloatingIP]:
         """
         List floating (i.e., static) IP addresses.
 
@@ -1862,7 +1943,8 @@ class FloatingIPService(CloudService):
         pass
 
     @abstractmethod
-    def find(self, gateway, **kwargs):
+    def find(self, gateway: Gateway,
+             **kwargs: Any) -> ResultList[FloatingIP]:
         """
         Searches for a FloatingIP by a given list of attributes.
 
@@ -1884,7 +1966,7 @@ class FloatingIPService(CloudService):
         pass
 
     @abstractmethod
-    def create(self, gateway):
+    def create(self, gateway: Gateway) -> FloatingIP:
         """
         Allocate a new floating (i.e., static) IP address.
 
@@ -1897,7 +1979,7 @@ class FloatingIPService(CloudService):
         pass
 
     @abstractmethod
-    def delete(self, gateway, fip):
+    def delete(self, gateway: Gateway, fip: FloatingIP | str) -> None:
         """
         Delete an existing FloatingIP.
 

--- a/cloudbridge/interfaces/services.py
+++ b/cloudbridge/interfaces/services.py
@@ -1500,7 +1500,7 @@ class KeyPairService(PageableObjectMixin[KeyPair], CloudService):
         pass
 
     @abstractmethod
-    def delete(self, key_pair: KeyPair | str) -> bool:
+    def delete(self, key_pair: KeyPair | str) -> None:
         """
         Delete an existing keypair.
 

--- a/cloudbridge/interfaces/subservices.py
+++ b/cloudbridge/interfaces/subservices.py
@@ -1,17 +1,31 @@
+from __future__ import annotations
+
+import builtins
 from abc import ABCMeta
 from abc import abstractmethod
+from typing import Any
 
+from cloudbridge.interfaces.resources import BucketObject
+from cloudbridge.interfaces.resources import DnsRecord
+from cloudbridge.interfaces.resources import FloatingIP
+from cloudbridge.interfaces.resources import Gateway
+from cloudbridge.interfaces.resources import InternetGateway
 from cloudbridge.interfaces.resources import PageableObjectMixin
+from cloudbridge.interfaces.resources import ResultList
+from cloudbridge.interfaces.resources import Subnet
+from cloudbridge.interfaces.resources import TrafficDirection
+from cloudbridge.interfaces.resources import VMFirewall
+from cloudbridge.interfaces.resources import VMFirewallRule
 
 
-class BucketObjectSubService(PageableObjectMixin):
+class BucketObjectSubService(PageableObjectMixin[BucketObject]):
     """
     A container service for objects within a bucket.
     """
     __metaclass__ = ABCMeta
 
     @abstractmethod
-    def get(self, name):
+    def get(self, name: str) -> BucketObject | None:
         """
         Retrieve a given object from this bucket.
 
@@ -25,7 +39,8 @@ class BucketObjectSubService(PageableObjectMixin):
 
     @abstractmethod
     # pylint:disable=arguments-differ
-    def list(self, limit=None, marker=None, prefix=None):
+    def list(self, limit: int | None = None, marker: str | None = None,
+             prefix: str | None = None) -> ResultList[BucketObject]:
         """
         List objects in this bucket.
 
@@ -44,7 +59,7 @@ class BucketObjectSubService(PageableObjectMixin):
         pass
 
     @abstractmethod
-    def find(self, **kwargs):
+    def find(self, **kwargs: Any) -> ResultList[BucketObject]:
         """
         Search for an object by a given list of attributes.
 
@@ -62,7 +77,7 @@ class BucketObjectSubService(PageableObjectMixin):
         pass
 
     @abstractmethod
-    def create(self, name):
+    def create(self, name: str) -> BucketObject:
         """
         Create a new object within this bucket.
 
@@ -72,14 +87,14 @@ class BucketObjectSubService(PageableObjectMixin):
         pass
 
 
-class GatewaySubService(PageableObjectMixin):
+class GatewaySubService(PageableObjectMixin[InternetGateway]):
     """
     Manage internet gateway resources.
     """
     __metaclass__ = ABCMeta
 
     @abstractmethod
-    def get_or_create(self):
+    def get_or_create(self) -> InternetGateway:
         """
         Creates new or returns an existing internet gateway for a network.
 
@@ -92,7 +107,7 @@ class GatewaySubService(PageableObjectMixin):
         pass
 
     @abstractmethod
-    def delete(self, gateway):
+    def delete(self, gateway: Gateway) -> None:
         """
         Delete a gateway.
 
@@ -102,7 +117,8 @@ class GatewaySubService(PageableObjectMixin):
         pass
 
     @abstractmethod
-    def list(self, limit=None, marker=None):
+    def list(self, limit: int | None = None,
+             marker: str | None = None) -> ResultList[InternetGateway]:
         """
         List all available internet gateways.
 
@@ -112,14 +128,14 @@ class GatewaySubService(PageableObjectMixin):
         pass
 
 
-class FloatingIPSubService(PageableObjectMixin):
+class FloatingIPSubService(PageableObjectMixin[FloatingIP]):
     """
     Base interface for a FloatingIP Service.
     """
     __metaclass__ = ABCMeta
 
     @abstractmethod
-    def get(self, fip_id):
+    def get(self, fip_id: str) -> FloatingIP | None:
         """
         Returns a FloatingIP given its ID or ``None`` if not found.
 
@@ -132,7 +148,8 @@ class FloatingIPSubService(PageableObjectMixin):
         pass
 
     @abstractmethod
-    def list(self, limit=None, marker=None):
+    def list(self, limit: int | None = None,
+             marker: str | None = None) -> ResultList[FloatingIP]:
         """
         List floating (i.e., static) IP addresses.
 
@@ -142,7 +159,7 @@ class FloatingIPSubService(PageableObjectMixin):
         pass
 
     @abstractmethod
-    def find(self, **kwargs):
+    def find(self, **kwargs: Any) -> ResultList[FloatingIP]:
         """
         Searches for a FloatingIP by a given list of attributes.
 
@@ -162,7 +179,7 @@ class FloatingIPSubService(PageableObjectMixin):
         pass
 
     @abstractmethod
-    def create(self):
+    def create(self) -> FloatingIP:
         """
         Allocate a new floating (i.e., static) IP address.
 
@@ -172,7 +189,7 @@ class FloatingIPSubService(PageableObjectMixin):
         pass
 
     @abstractmethod
-    def delete(self, fip_id):
+    def delete(self, fip_id: FloatingIP | str) -> None:
         """
         Delete an existing FloatingIP.
 
@@ -182,14 +199,14 @@ class FloatingIPSubService(PageableObjectMixin):
         pass
 
 
-class VMFirewallRuleSubService(PageableObjectMixin):
+class VMFirewallRuleSubService(PageableObjectMixin[VMFirewallRule]):
     """
     Base interface for Firewall rules.
     """
     __metaclass__ = ABCMeta
 
     @abstractmethod
-    def get(self, rule_id):
+    def get(self, rule_id: str) -> VMFirewallRule | None:
         """
         Return a firewall rule given its ID.
 
@@ -212,7 +229,8 @@ class VMFirewallRuleSubService(PageableObjectMixin):
         pass
 
     @abstractmethod
-    def list(self, limit=None, marker=None):
+    def list(self, limit: int | None = None,
+             marker: str | None = None) -> ResultList[VMFirewallRule]:
         """
         List all firewall rules associated with this firewall.
 
@@ -222,8 +240,10 @@ class VMFirewallRuleSubService(PageableObjectMixin):
         pass
 
     @abstractmethod
-    def create(self, direction, protocol=None, from_port=None,
-               to_port=None, cidr=None, src_dest_fw=None):
+    def create(self, direction: TrafficDirection, protocol: str | None = None,
+               from_port: int | None = None, to_port: int | None = None,
+               cidr: str | builtins.list[str] | None = None,
+               src_dest_fw: VMFirewall | None = None) -> VMFirewallRule:
         """
         Create a VM firewall rule.
 
@@ -274,7 +294,7 @@ class VMFirewallRuleSubService(PageableObjectMixin):
         pass
 
     @abstractmethod
-    def find(self, **kwargs):
+    def find(self, **kwargs: Any) -> ResultList[VMFirewallRule]:
         """
         Find a firewall rule filtered by the given parameters.
 
@@ -310,7 +330,7 @@ class VMFirewallRuleSubService(PageableObjectMixin):
         pass
 
     @abstractmethod
-    def delete(self, rule_id):
+    def delete(self, rule_id: str) -> None:
         """
         Delete an existing VMFirewall rule.
 
@@ -320,14 +340,14 @@ class VMFirewallRuleSubService(PageableObjectMixin):
         pass
 
 
-class SubnetSubService(PageableObjectMixin):
+class SubnetSubService(PageableObjectMixin[Subnet]):
     """
     Base interface for a Subnet Service.
     """
     __metaclass__ = ABCMeta
 
     @abstractmethod
-    def get(self, subnet_id):
+    def get(self, subnet_id: str) -> Subnet | None:
         """
         Returns a Subnet given its ID or ``None`` if not found.
 
@@ -340,7 +360,8 @@ class SubnetSubService(PageableObjectMixin):
         pass
 
     @abstractmethod
-    def list(self, limit=None, marker=None):
+    def list(self, limit: int | None = None,
+             marker: str | None = None) -> ResultList[Subnet]:
         """
         List subnets within the network holding this subservice.
 
@@ -350,7 +371,7 @@ class SubnetSubService(PageableObjectMixin):
         pass
 
     @abstractmethod
-    def find(self, **kwargs):
+    def find(self, **kwargs: Any) -> ResultList[Subnet]:
         """
         Searches for a Subnet by a given list of attributes.
 
@@ -370,7 +391,7 @@ class SubnetSubService(PageableObjectMixin):
         pass
 
     @abstractmethod
-    def create(self, label, cidr_block):
+    def create(self, label: str, cidr_block: str) -> Subnet:
         """
         Create a new subnet within the network holding this subservice.
 
@@ -387,7 +408,7 @@ class SubnetSubService(PageableObjectMixin):
         pass
 
     @abstractmethod
-    def delete(self, subnet_id):
+    def delete(self, subnet_id: Subnet | str) -> None:
         """
         Delete an existing Subnet.
 
@@ -397,14 +418,14 @@ class SubnetSubService(PageableObjectMixin):
         pass
 
 
-class DnsRecordSubService(PageableObjectMixin):
+class DnsRecordSubService(PageableObjectMixin[DnsRecord]):
     """
     Base interface for a Dns Record Service.
     """
     __metaclass__ = ABCMeta
 
     @abstractmethod
-    def get(self, record_id):
+    def get(self, record_id: str) -> DnsRecord | None:
         """
         Returns a Dns Record given its ID or ``None`` if not found.
 
@@ -417,7 +438,8 @@ class DnsRecordSubService(PageableObjectMixin):
         pass
 
     @abstractmethod
-    def list(self, limit=None, marker=None):
+    def list(self, limit: int | None = None,
+             marker: str | None = None) -> ResultList[DnsRecord]:
         """
         List Dns Records within the Dns Zone holding this subservice.
 
@@ -427,7 +449,7 @@ class DnsRecordSubService(PageableObjectMixin):
         pass
 
     @abstractmethod
-    def find(self, **kwargs):
+    def find(self, **kwargs: Any) -> ResultList[DnsRecord]:
         """
         Searches for a DnsRecord by a given list of attributes.
 
@@ -447,7 +469,8 @@ class DnsRecordSubService(PageableObjectMixin):
         pass
 
     @abstractmethod
-    def create(self, label, type, data, ttl=None):
+    def create(self, label: str, type: str, data: str,
+               ttl: int | None = None) -> DnsRecord:
         """
         Create a new DnsRecord within the Dns Zone holding this subservice.
 
@@ -469,7 +492,7 @@ class DnsRecordSubService(PageableObjectMixin):
         pass
 
     @abstractmethod
-    def delete(self, record_id):
+    def delete(self, record_id: DnsRecord | str) -> None:
         """
         Delete an existing DnsRecord.
 

--- a/cloudbridge/providers/aws/helpers.py
+++ b/cloudbridge/providers/aws/helpers.py
@@ -1,5 +1,10 @@
 """A set of AWS-specific helper methods used by the framework."""
+from __future__ import annotations
+
 import logging
+from typing import Any
+from typing import TYPE_CHECKING
+from typing import TypeVar
 
 from boto3.resources.params import create_request_parameters
 
@@ -9,12 +14,19 @@ from botocore.utils import merge_dicts
 
 from cloudbridge.base.resources import ClientPagedResultList
 from cloudbridge.base.resources import ServerPagedResultList
+from cloudbridge.interfaces.resources import CloudResource
+from cloudbridge.interfaces.resources import ResultList
+
+if TYPE_CHECKING:
+    from .provider import AWSCloudProvider
 
 
 log = logging.getLogger(__name__)
 
+T = TypeVar("T")
 
-def trim_empty_params(params_dict):
+
+def trim_empty_params(params_dict: dict[str, Any]) -> dict[str, Any]:
     """
     Given a dict containing potentially null values, trims out
     all the null values. This is to please Boto, which throws
@@ -35,7 +47,7 @@ def trim_empty_params(params_dict):
     return {k: v for k, v in params_dict.items() if v is not None}
 
 
-def find_tag_value(tags, key):
+def find_tag_value(tags: list[dict[str, Any]] | None, key: str) -> Any:
     """
     Finds the value associated with a given key from a list of AWS tags.
 
@@ -59,7 +71,9 @@ class BotoGenericService(object):
     resource, collection and paging support to implement
     basic cloudbridge methods.
     """
-    def __init__(self, provider, cb_resource, boto_conn, boto_collection_name):
+    def __init__(self, provider: AWSCloudProvider,
+                 cb_resource: Any, boto_conn: Any,
+                 boto_collection_name: str) -> None:
         """
         :type provider: :class:`AWSCloudProvider`
         :param provider: CloudBridge AWS provider to use
@@ -86,12 +100,12 @@ class BotoGenericService(object):
         self.boto_resource = self._infer_boto_resource(
             boto_conn, self.boto_collection_model)
 
-    def _infer_collection_model(self, conn, collection_name):
+    def _infer_collection_model(self, conn: Any, collection_name: str) -> Any:
         log.debug("Retrieving boto model for collection: %s", collection_name)
         return next(col for col in conn.meta.resource_model.collections
                     if col.name == collection_name)
 
-    def _infer_boto_resource(self, conn, collection_model):
+    def _infer_boto_resource(self, conn: Any, collection_model: Any) -> Any:
         log.debug("Retrieving resource model for collection: %s",
                   collection_model.name)
         resource_model = next(
@@ -99,7 +113,7 @@ class BotoGenericService(object):
             if sr.resource.model.name == collection_model.resource.model.name)
         return getattr(self.boto_conn, resource_model.name)
 
-    def get_raw(self, resource_id):
+    def get_raw(self, resource_id: str) -> Any:
         """
         Returns a single resource.
 
@@ -124,7 +138,7 @@ class BotoGenericService(object):
             else:
                 raise exc
 
-    def get(self, resource_id):
+    def get(self, resource_id: str) -> Any:
         """
         Returns a single resource.
 
@@ -139,7 +153,7 @@ class BotoGenericService(object):
         else:
             return None
 
-    def _get_list_operation(self):
+    def _get_list_operation(self) -> str:
         """
         This function discovers the list operation for a particular resource
         collection. For example, given the resource collection model for
@@ -147,7 +161,8 @@ class BotoGenericService(object):
         """
         return xform_name(self.boto_collection_model.request.operation)
 
-    def _to_boto_resource(self, collection, params, page):
+    def _to_boto_resource(self, collection: Any, params: Any,
+                          page: Any) -> Any:
         """
         This function duplicates some of the logic of the pages() method in
         boto.resources.collection.ResourceCollection. It will convert a raw
@@ -158,7 +173,8 @@ class BotoGenericService(object):
         # pylint:disable=protected-access
         return collection._handler(collection._parent, params, page)
 
-    def _get_paginated_results(self, limit, marker, collection):
+    def _get_paginated_results(self, limit: int | None, marker: str | None,
+                               collection: Any) -> tuple[Any, Any]:
         """
         If a Boto Paginator is available, use it. The results
         are converted back into BotoResources by directly accessing
@@ -177,7 +193,7 @@ class BotoGenericService(object):
         client = self.boto_conn.meta.client
         list_op = self._get_list_operation()
         paginator = client.get_paginator(list_op)
-        PaginationConfig = {}
+        PaginationConfig: dict[str, Any] = {}
         if limit:
             PaginationConfig = {'MaxItems': limit, 'PageSize': limit}
 
@@ -194,7 +210,8 @@ class BotoGenericService(object):
         resume_token = pages.resume_token
         return (resume_token, boto_objs)
 
-    def _make_query(self, collection, limit, marker):
+    def _make_query(self, collection: Any, limit: int | None,
+                    marker: str | None) -> tuple[str, Any, Any]:
         """
         Decide between server or client pagination,
         depending on the availability of a Boto Paginator.
@@ -213,7 +230,9 @@ class BotoGenericService(object):
                       " limit and page results.")
             return 'client', None, collection
 
-    def list(self, limit=None, marker=None, collection=None, **kwargs):
+    def list(self, limit: int | None = None, marker: str | None = None,
+             collection: Any = None,
+             **kwargs: Any) -> ResultList[CloudResource]:
         """
         List a set of resources.
 
@@ -244,8 +263,9 @@ class BotoGenericService(object):
             return ClientPagedResultList(self.provider, results,
                                          limit=limit, marker=marker)
 
-    def find(self, filters, limit=None, marker=None,
-             **kwargs):
+    def find(self, filters: dict[str, Any], limit: int | None = None,
+             marker: str | None = None,
+             **kwargs: Any) -> ResultList[CloudResource]:
         """
         Return a list of resources by filter.
 
@@ -261,7 +281,7 @@ class BotoGenericService(object):
             collection = collection.filter(**kwargs)
         return self.list(limit=limit, marker=marker, collection=collection)
 
-    def create(self, boto_method, **kwargs):
+    def create(self, boto_method: str, **kwargs: Any) -> Any:
         """
         Creates a resource
 
@@ -281,7 +301,7 @@ class BotoGenericService(object):
         else:
             return self.cb_resource(self.provider, result) if result else None
 
-    def delete(self, resource_id):
+    def delete(self, resource_id: str) -> None:
         """
         Deletes a resource by id
 
@@ -298,8 +318,9 @@ class BotoEC2Service(BotoGenericService):
     """
     Boto EC2 service implementation
     """
-    def __init__(self, provider, cb_resource,
-                 boto_collection_name):
+    def __init__(self, provider: AWSCloudProvider,
+                 cb_resource: Any,
+                 boto_collection_name: str) -> None:
         """
         :type provider: :class:`AWSCloudProvider`
         :param provider: CloudBridge AWS provider to use
@@ -320,8 +341,9 @@ class BotoS3Service(BotoGenericService):
     """
     Boto S3 service implementation.
     """
-    def __init__(self, provider, cb_resource,
-                 boto_collection_name):
+    def __init__(self, provider: AWSCloudProvider,
+                 cb_resource: Any,
+                 boto_collection_name: str) -> None:
         """
         :type provider: :class:`AWSCloudProvider`
         :param provider: CloudBridge AWS provider to use

--- a/cloudbridge/providers/aws/provider.py
+++ b/cloudbridge/providers/aws/provider.py
@@ -1,5 +1,6 @@
 """Provider implementation based on boto library for AWS-compatible clouds."""
 import logging
+from typing import Any
 
 import boto3
 
@@ -7,6 +8,11 @@ from botocore.client import Config
 
 from cloudbridge.base import BaseCloudProvider
 from cloudbridge.base.helpers import get_env
+from cloudbridge.interfaces.services import ComputeService
+from cloudbridge.interfaces.services import DnsService
+from cloudbridge.interfaces.services import NetworkingService
+from cloudbridge.interfaces.services import SecurityService
+from cloudbridge.interfaces.services import StorageService
 
 from .services import AWSComputeService
 from .services import AWSDnsService
@@ -20,9 +26,9 @@ log = logging.getLogger(__name__)
 
 class AWSCloudProvider(BaseCloudProvider):
     '''AWS cloud provider interface'''
-    PROVIDER_ID = 'aws'
+    PROVIDER_ID: str = 'aws'
 
-    def __init__(self, config):
+    def __init__(self, config: dict[str, Any]) -> None:
         super(AWSCloudProvider, self).__init__(config)
 
         # Initialize cloud connection fields
@@ -70,59 +76,59 @@ class AWSCloudProvider(BaseCloudProvider):
         self._dns = AWSDnsService(self)
 
     @property
-    def session(self):
+    def session(self) -> Any:
         '''Get a low-level session object or create one if needed'''
         if not self._session:
             if self.config.debug_mode:
-                boto3.set_stream_logger(level=log.DEBUG)
+                boto3.set_stream_logger(level=logging.DEBUG)
             self._session = boto3.session.Session(
                 region_name=self.region_name, **self.session_cfg)
         return self._session
 
     @property
-    def ec2_conn(self):
+    def ec2_conn(self) -> Any:
         if not self._ec2_conn:
             self._ec2_conn = self._connect_ec2()
         return self._ec2_conn
 
     @property
-    def s3_conn(self):
+    def s3_conn(self) -> Any:
         if not self._s3_conn:
             self._s3_conn = self._connect_s3()
         return self._s3_conn
 
     @property
-    def compute(self):
+    def compute(self) -> ComputeService:
         return self._compute
 
     @property
-    def networking(self):
+    def networking(self) -> NetworkingService:
         return self._networking
 
     @property
-    def security(self):
+    def security(self) -> SecurityService:
         return self._security
 
     @property
-    def storage(self):
+    def storage(self) -> StorageService:
         return self._storage
 
     @property
-    def dns(self):
+    def dns(self) -> DnsService:
         return self._dns
 
-    def _connect_ec2(self):
+    def _connect_ec2(self) -> Any:
         """
         Get a boto ec2 connection object.
         """
         return self._connect_ec2_region(region_name=self.region_name)
 
-    def _connect_ec2_region(self, region_name=None):
+    def _connect_ec2_region(self, region_name: str | None = None) -> Any:
         '''Get an EC2 resource object'''
         return self.session.resource(
             'ec2', region_name=region_name, **self.ec2_cfg)
 
-    def _connect_s3(self):
+    def _connect_s3(self) -> Any:
         '''Get an S3 resource object'''
         return self.session.resource(
             's3', region_name=self.region_name, **self.s3_cfg)

--- a/cloudbridge/providers/aws/resources.py
+++ b/cloudbridge/providers/aws/resources.py
@@ -41,6 +41,7 @@ from cloudbridge.base.resources import BaseVMFirewallRule
 from cloudbridge.base.resources import BaseVMType
 from cloudbridge.base.resources import BaseVolume
 from cloudbridge.interfaces.resources import AttachmentInfo
+from cloudbridge.interfaces.resources import BucketObject
 from cloudbridge.interfaces.resources import FloatingIP
 from cloudbridge.interfaces.resources import Gateway
 from cloudbridge.interfaces.resources import GatewayState
@@ -343,21 +344,11 @@ class AWSInstance(BaseInstance):
     def reboot(self) -> None:
         self._ec2_instance.reboot()
 
-    def start(self) -> bool:
-        response = self._ec2_instance.start()
-        states = ['pending', 'running']
-        if response['StartingInstances'][0]['CurrentState']['Name'] in states:
-            return True
-        else:
-            return False
+    def start(self) -> None:
+        self._ec2_instance.start()
 
-    def stop(self) -> bool:
-        response = self._ec2_instance.stop()
-        states = ['stopping', 'stopped']
-        if response['StoppingInstances'][0]['CurrentState']['Name'] in states:
-            return True
-        else:
-            return False
+    def stop(self) -> None:
+        self._ec2_instance.stop()
 
     @property
     def image_id(self) -> str:
@@ -925,15 +916,14 @@ class AWSBucketObject(BaseBucketObject):
     def iter_content(self) -> Iterable[bytes]:
         return self.BucketObjIterator(self._obj.get().get('Body'))
 
-    def _upload_single_shot(self, data: str | bytes | IO[bytes]) -> None:
+    def _upload_single_shot(self,
+                            data: str | bytes | IO[bytes]) -> BucketObject:
         self._obj.put(Body=data)
+        return self
 
-    # The base driver returns the completed BucketObject; boto3's
-    # upload_fileobj performs the multipart upload in place and returns
-    # nothing, so this override returns None.
-    def _upload_multipart(  # type: ignore[override]
+    def _upload_multipart(
             self, stream: IO[bytes],
-            config: UploadConfig | None = None) -> None:
+            config: UploadConfig | None = None) -> BucketObject:
         # boto3's TransferManager uploads parts concurrently with a thread-safe
         # client, so the transparent multipart path delegates to it rather than
         # CloudBridge's generic clone-pool driver.
@@ -942,9 +932,10 @@ class AWSBucketObject(BaseBucketObject):
             multipart_chunksize=self._multipart_part_size(config),
             max_concurrency=self._multipart_max_concurrency(config))
         self._obj.upload_fileobj(stream, Config=transfer_config)
+        return self
 
     def upload_from_file(self, path: str,
-                         config: UploadConfig | None = None) -> None:
+                         config: UploadConfig | None = None) -> BucketObject:
         # boto3's upload_file streams large files in parts via its
         # TransferManager. Drive it with CloudBridge's multipart knobs so that
         # upload_from_file and upload() honour the same configuration rather
@@ -954,6 +945,7 @@ class AWSBucketObject(BaseBucketObject):
             multipart_chunksize=self._multipart_part_size(config),
             max_concurrency=self._multipart_max_concurrency(config))
         self._obj.upload_file(path, Config=transfer_config)
+        return self
 
     def delete(self) -> None:
         self._obj.delete()
@@ -1289,23 +1281,16 @@ class AWSRouter(BaseRouter):
         return [AWSSubnet(cast("AWSCloudProvider", self._provider), rta.subnet)
                 for rta in self._route_table.associations if rta.subnet]
 
-    # AWS returns a bool, but the Router interface declares attach_gateway as
-    # returning None; preserve the AWS-specific bool return.
-    def attach_gateway(self, gateway: Gateway) -> bool:  # type: ignore[override]
+    def attach_gateway(self, gateway: Gateway) -> None:
         gw_id = (gateway.id if isinstance(gateway, AWSInternetGateway)
                  else gateway)
-        if self._route_table.create_route(
-                DestinationCidrBlock='0.0.0.0/0', GatewayId=gw_id):
-            return True
-        return False
+        self._route_table.create_route(
+            DestinationCidrBlock='0.0.0.0/0', GatewayId=gw_id)
 
-    # AWS returns the raw boto3 response dict, but the Router interface declares
-    # detach_gateway as returning None; preserve the AWS-specific dict return.
-    def detach_gateway(  # type: ignore[override]
-            self, gateway: Gateway) -> dict[str, Any]:
+    def detach_gateway(self, gateway: Gateway) -> None:
         gw_id = (gateway.id if isinstance(gateway, AWSInternetGateway)
                  else gateway)
-        return cast("AWSCloudProvider", self._provider).ec2_conn.meta.client \
+        cast("AWSCloudProvider", self._provider).ec2_conn.meta.client \
             .detach_internet_gateway(
                 InternetGatewayId=gw_id, VpcId=self._route_table.vpc_id)
 

--- a/cloudbridge/providers/aws/resources.py
+++ b/cloudbridge/providers/aws/resources.py
@@ -40,6 +40,7 @@ from cloudbridge.base.resources import BaseVMFirewall
 from cloudbridge.base.resources import BaseVMFirewallRule
 from cloudbridge.base.resources import BaseVMType
 from cloudbridge.base.resources import BaseVolume
+from cloudbridge.interfaces.exceptions import ProviderInternalException
 from cloudbridge.interfaces.resources import AttachmentInfo
 from cloudbridge.interfaces.resources import BucketObject
 from cloudbridge.interfaces.resources import FloatingIP
@@ -56,6 +57,7 @@ from cloudbridge.interfaces.resources import Snapshot
 from cloudbridge.interfaces.resources import SnapshotState
 from cloudbridge.interfaces.resources import Subnet
 from cloudbridge.interfaces.resources import SubnetState
+from cloudbridge.interfaces.resources import TrafficDirection
 from cloudbridge.interfaces.resources import UploadConfig
 from cloudbridge.interfaces.resources import VMFirewall
 from cloudbridge.interfaces.resources import VMType
@@ -100,15 +102,13 @@ class AWSMachineImage(BaseMachineImage):
     def id(self) -> str:
         return self._ec2_image.id
 
-    # AWS may fail to read the image name; the CloudResource interface declares
-    # name as ``str``, but this implementation can legitimately return None.
     @property
-    def name(self) -> str | None:  # type: ignore[override]
+    def name(self) -> str:
         try:
             return self._ec2_image.name
         except (AttributeError, ClientError) as e:
             log.warn("Cannot get name for image {0}: {1}".format(self.id, e))
-            return None
+            return ""
 
     @property
     # pylint:disable=arguments-differ
@@ -755,10 +755,7 @@ class AWSVMFirewall(BaseVMFirewall):
         self._vm_firewall.create_tags(Tags=[{'Key': 'Name',
                                              'Value': value or ""}])
 
-    # find_tag_value can return None on a missing tag and the read is also
-    # wrapped to swallow ClientError; the VMFirewall interface declares
-    # description as ``str``, so the optional return is widened here.
-    @property  # type: ignore[override]
+    @property
     def description(self) -> str | None:
         try:
             return find_tag_value(self._vm_firewall.tags, 'Description')
@@ -794,7 +791,7 @@ class AWSVMFirewall(BaseVMFirewall):
 
 class AWSVMFirewallRule(BaseVMFirewallRule):
 
-    def __init__(self, parent_fw: VMFirewall, direction: str,
+    def __init__(self, parent_fw: VMFirewall, direction: TrafficDirection,
                  rule: Any) -> None:
         self._direction = direction
         super(AWSVMFirewallRule, self).__init__(parent_fw, rule)
@@ -809,7 +806,7 @@ class AWSVMFirewallRule(BaseVMFirewallRule):
         return self._id
 
     @property
-    def direction(self) -> str:
+    def direction(self) -> TrafficDirection:
         return self._direction
 
     @property
@@ -1348,12 +1345,14 @@ class AWSDnsZone(BaseDnsZone):
         self._dns_zone = dns_zone
         self._dns_record_container = AWSDnsRecordSubService(provider, self)
 
-    # The zone id is derived from an optional AWS field; the CloudResource
-    # interface declares id as ``str``, but this implementation can return None.
     @property
-    def id(self) -> str | None:  # type: ignore[override]
+    def id(self) -> str:
         # The ID contains a slash, do not allow this
-        return self.escape_zone_id(self.aws_id)
+        zone_id = self.escape_zone_id(self.aws_id)
+        if zone_id is None:
+            raise ProviderInternalException(
+                "DNS zone is missing an AWS HostedZone Id")
+        return zone_id
 
     @property
     def aws_id(self) -> str | None:
@@ -1407,7 +1406,7 @@ class AWSDnsRecord(BaseDnsRecord):
     # The containing zone id is optional on AWSDnsZone, but the DnsRecord
     # interface declares zone_id as ``str``; widen the return to match reality.
     @property
-    def zone_id(self) -> str | None:  # type: ignore[override]
+    def zone_id(self) -> str:
         return self._dns_zone.id
 
     @property

--- a/cloudbridge/providers/aws/resources.py
+++ b/cloudbridge/providers/aws/resources.py
@@ -1,9 +1,17 @@
 """
 DataTypes used by this provider
 """
+from __future__ import annotations
+
 import hashlib
 import inspect
 import logging
+from typing import Any
+from typing import IO
+from typing import Iterable
+from typing import Iterator
+from typing import TYPE_CHECKING
+from typing import cast
 
 from boto3.s3.transfer import TransferConfig
 
@@ -32,14 +40,27 @@ from cloudbridge.base.resources import BaseVMFirewall
 from cloudbridge.base.resources import BaseVMFirewallRule
 from cloudbridge.base.resources import BaseVMType
 from cloudbridge.base.resources import BaseVolume
+from cloudbridge.interfaces.resources import AttachmentInfo
+from cloudbridge.interfaces.resources import FloatingIP
+from cloudbridge.interfaces.resources import Gateway
 from cloudbridge.interfaces.resources import GatewayState
+from cloudbridge.interfaces.resources import Instance
 from cloudbridge.interfaces.resources import InstanceState
+from cloudbridge.interfaces.resources import MachineImage
 from cloudbridge.interfaces.resources import MachineImageState
 from cloudbridge.interfaces.resources import NetworkState
+from cloudbridge.interfaces.resources import PlacementZone
 from cloudbridge.interfaces.resources import RouterState
+from cloudbridge.interfaces.resources import Snapshot
 from cloudbridge.interfaces.resources import SnapshotState
+from cloudbridge.interfaces.resources import Subnet
 from cloudbridge.interfaces.resources import SubnetState
+from cloudbridge.interfaces.resources import UploadConfig
+from cloudbridge.interfaces.resources import VMFirewall
+from cloudbridge.interfaces.resources import VMType
+from cloudbridge.interfaces.resources import Volume
 from cloudbridge.interfaces.resources import VolumeState
+
 from .helpers import find_tag_value
 from .helpers import trim_empty_params
 from .subservices import AWSBucketObjectSubService
@@ -48,6 +69,9 @@ from .subservices import AWSFloatingIPSubService
 from .subservices import AWSGatewaySubService
 from .subservices import AWSSubnetSubService
 from .subservices import AWSVMFirewallRuleSubService
+
+if TYPE_CHECKING:
+    from cloudbridge.providers.aws.provider import AWSCloudProvider
 
 log = logging.getLogger(__name__)
 
@@ -63,56 +87,59 @@ class AWSMachineImage(BaseMachineImage):
         'invalid': MachineImageState.ERROR
     }
 
-    def __init__(self, provider, image):
+    def __init__(self, provider: AWSCloudProvider, image: Any) -> None:
         super(AWSMachineImage, self).__init__(provider)
         if isinstance(image, AWSMachineImage):
             # pylint:disable=protected-access
-            self._ec2_image = image._ec2_image
+            self._ec2_image = cast(Any, image)._ec2_image
         else:
             self._ec2_image = image
 
     @property
-    def id(self):
+    def id(self) -> str:
         return self._ec2_image.id
 
+    # AWS may fail to read the image name; the CloudResource interface declares
+    # name as ``str``, but this implementation can legitimately return None.
     @property
-    def name(self):
+    def name(self) -> str | None:  # type: ignore[override]
         try:
             return self._ec2_image.name
         except (AttributeError, ClientError) as e:
             log.warn("Cannot get name for image {0}: {1}".format(self.id, e))
+            return None
 
     @property
     # pylint:disable=arguments-differ
-    def label(self):
+    def label(self) -> str | None:
         """
         .. note:: an instance must have a (case sensitive) tag ``Name``
         """
         return find_tag_value(self._ec2_image.tags, 'Name')
 
+    @label.setter
+    # pylint:disable=arguments-differ
+    def label(self, value: str) -> None:
+        self.assert_valid_resource_label(value)
+        self._set_label(value)
+
     @tenacity.retry(stop=tenacity.stop_after_attempt(5),
                     retry=tenacity.retry_if_exception_type(ClientError),
                     wait=tenacity.wait_fixed(5),
                     reraise=True)
-    def _set_label(self, value):
+    def _set_label(self, value: str) -> None:
         self._ec2_image.create_tags(Tags=[{'Key': 'Name',
                                            'Value': value or ""}])
 
-    @label.setter
-    # pylint:disable=arguments-differ
-    def label(self, value):
-        self.assert_valid_resource_label(value)
-        self._set_label(value)
-
     @property
-    def description(self):
+    def description(self) -> str | None:
         try:
             return self._ec2_image.description
         except AttributeError:
             return None
 
     @property
-    def min_disk(self):
+    def min_disk(self) -> int | None:
         vols = [bdm.get('Ebs', {}) for bdm in
                 self._ec2_image.block_device_mappings if
                 bdm.get('DeviceName') == self._ec2_image.root_device_name]
@@ -121,7 +148,7 @@ class AWSMachineImage(BaseMachineImage):
         else:
             return None
 
-    def delete(self):
+    def delete(self) -> None:
         snapshot_id = [
             bdm.get('Ebs', {}).get('SnapshotId') for bdm in
             self._ec2_image.block_device_mappings if
@@ -134,7 +161,7 @@ class AWSMachineImage(BaseMachineImage):
             snapshot.delete()
 
     @property
-    def state(self):
+    def state(self) -> str:
         try:
             return AWSMachineImage.IMAGE_STATE_MAP.get(
                 self._ec2_image.state, MachineImageState.UNKNOWN)
@@ -142,52 +169,54 @@ class AWSMachineImage(BaseMachineImage):
             # Ignore all exceptions when querying state
             return MachineImageState.UNKNOWN
 
-    def refresh(self):
+    def refresh(self) -> None:
         self._ec2_image.reload()
 
 
 class AWSPlacementZone(BasePlacementZone):
 
-    def __init__(self, provider, zone, region):
+    def __init__(self, provider: AWSCloudProvider, zone: Any,
+                 region: Any) -> None:
         super(AWSPlacementZone, self).__init__(provider)
         if isinstance(zone, AWSPlacementZone):
             # pylint:disable=protected-access
-            self._aws_zone = zone._aws_zone
+            self._aws_zone = cast(Any, zone)._aws_zone
             # pylint:disable=protected-access
-            self._aws_region = zone._aws_region
+            self._aws_region = cast(Any, zone)._aws_region
         else:
             self._aws_zone = zone
             self._aws_region = region
 
     @property
-    def id(self):
+    def id(self) -> str:
         return self._aws_zone
 
     @property
-    def name(self):
+    def name(self) -> str:
         return self.id
 
     @property
-    def region_name(self):
+    def region_name(self) -> str:
         return self._aws_region
 
 
 class AWSVMType(BaseVMType):
 
-    def __init__(self, provider, instance_dict):
+    def __init__(self, provider: AWSCloudProvider,
+                 instance_dict: dict[str, Any]) -> None:
         super(AWSVMType, self).__init__(provider)
         self._inst_dict = instance_dict
 
     @property
-    def id(self):
+    def id(self) -> str:
         return str(self._inst_dict.get('InstanceType'))
 
     @property
-    def name(self):
+    def name(self) -> str:
         return self.id
 
     @property
-    def family(self):
+    def family(self) -> str | None:
         # Limited to whether CurrentGeneration or not
         curr = self._inst_dict.get('CurrentGeneration')
         if curr:
@@ -195,14 +224,14 @@ class AWSVMType(BaseVMType):
         return None
 
     @property
-    def vcpus(self):
+    def vcpus(self) -> int:
         vcpus = self._inst_dict.get('VCpuInfo')
         if vcpus:
             return vcpus.get('DefaultVCpus', 0)
         return 0
 
     @property
-    def ram(self):
+    def ram(self) -> float:
         ram = self._inst_dict.get('MemoryInfo')
         if ram:
             mib = ram.get('SizeInMiB', 0)
@@ -210,18 +239,18 @@ class AWSVMType(BaseVMType):
         return 0
 
     @property
-    def size_root_disk(self):
+    def size_root_disk(self) -> int:
         return 0
 
     @property
-    def size_ephemeral_disks(self):
+    def size_ephemeral_disks(self) -> int:
         storage = self._inst_dict.get('InstanceStorageInfo')
         if storage:
             return storage.get('TotalSizeInGB', 0)
         return 0
 
     @property
-    def num_ephemeral_disks(self):
+    def num_ephemeral_disks(self) -> int:
         storage = self._inst_dict.get('InstanceStorageInfo')
         if storage:
             disks = storage.get("Disks", [])
@@ -232,7 +261,7 @@ class AWSVMType(BaseVMType):
         return 0
 
     @property
-    def extra_data(self):
+    def extra_data(self) -> dict[str, Any]:
         return {key: val for key, val in self._inst_dict.items()
                 if key not in ["InstanceType", "VCpuInfo", "MemoryInfo"]}
 
@@ -249,71 +278,72 @@ class AWSInstance(BaseInstance):
         'stopped': InstanceState.STOPPED
     }
 
-    def __init__(self, provider, ec2_instance):
+    def __init__(self, provider: AWSCloudProvider,
+                 ec2_instance: Any) -> None:
         super(AWSInstance, self).__init__(provider)
         self._ec2_instance = ec2_instance
         self._unknown_state = False
 
     @property
-    def id(self):
+    def id(self) -> str:
         return self._ec2_instance.id
 
     @property
-    def name(self):
+    def name(self) -> str:
         return self.id
 
     @property
     # pylint:disable=arguments-differ
-    def label(self):
+    def label(self) -> str | None:
         """
         .. note:: an instance must have a (case sensitive) tag ``Name``
         """
         return find_tag_value(self._ec2_instance.tags, 'Name')
 
+    @label.setter
+    # pylint:disable=arguments-differ
+    def label(self, value: str) -> None:
+        self.assert_valid_resource_label(value)
+        self._set_label(value)
+
     @tenacity.retry(stop=tenacity.stop_after_attempt(5),
                     retry=tenacity.retry_if_exception_type(ClientError),
                     wait=tenacity.wait_fixed(5),
                     reraise=True)
-    def _set_label(self, value):
+    def _set_label(self, value: str) -> None:
         self._ec2_instance.create_tags(Tags=[{'Key': 'Name',
                                               'Value': value or ""}])
 
-    @label.setter
-    # pylint:disable=arguments-differ
-    def label(self, value):
-        self.assert_valid_resource_label(value)
-        self._set_label(value)
-
     @property
-    def public_ips(self):
+    def public_ips(self) -> list[str]:
         return ([self._ec2_instance.public_ip_address]
                 if self._ec2_instance.public_ip_address else [])
 
     @property
-    def private_ips(self):
+    def private_ips(self) -> list[str]:
         return ([self._ec2_instance.private_ip_address]
                 if self._ec2_instance.private_ip_address else [])
 
     @property
-    def vm_type_id(self):
+    def vm_type_id(self) -> str:
         return self._ec2_instance.instance_type
 
     @property
-    def vm_type(self):
+    def vm_type(self) -> VMType:
         return self._provider.compute.vm_types.find(
             name=self._ec2_instance.instance_type)[0]
 
     @property
-    def create_time(self):
+    def create_time(self) -> str:
         """
         Get the instance creation time
         """
         return self._ec2_instance.launch_time
 
-    def reboot(self):
+    def reboot(self) -> None:
         self._ec2_instance.reboot()
 
-    def start(self):
+    def start(self) -> bool:
         response = self._ec2_instance.start()
         states = ['pending', 'running']
         if response['StartingInstances'][0]['CurrentState']['Name'] in states:
@@ -321,7 +351,7 @@ class AWSInstance(BaseInstance):
         else:
             return False
 
-    def stop(self):
+    def stop(self) -> bool:
         response = self._ec2_instance.stop()
         states = ['stopping', 'stopped']
         if response['StoppingInstances'][0]['CurrentState']['Name'] in states:
@@ -330,49 +360,50 @@ class AWSInstance(BaseInstance):
             return False
 
     @property
-    def image_id(self):
+    def image_id(self) -> str:
         return self._ec2_instance.image_id
 
     @property
-    def zone_id(self):
+    def zone_id(self) -> str:
         return self._ec2_instance.placement.get('AvailabilityZone')
 
     @property
-    def subnet_id(self):
+    def subnet_id(self) -> str:
         return self._ec2_instance.subnet_id
 
     @property
-    def vm_firewalls(self):
-        return [
+    def vm_firewalls(self) -> list[VMFirewall]:
+        return cast("list[VMFirewall]", [
             self._provider.security.vm_firewalls.get(fw_id)
             for fw_id in self.vm_firewall_ids
-        ]
+        ])
 
     @property
-    def vm_firewall_ids(self):
+    def vm_firewall_ids(self) -> list[str]:
         return list(set([
             group.get('GroupId') for group in
             self._ec2_instance.security_groups
         ]))
 
     @property
-    def key_pair_id(self):
+    def key_pair_id(self) -> str:
         return self._ec2_instance.key_name
 
     @tenacity.retry(stop=tenacity.stop_after_attempt(5),
                     retry=tenacity.retry_if_exception_type(ClientError),
                     wait=tenacity.wait_fixed(5),
                     reraise=True)
-    def _wait_for_image(self, image):
-        self._provider.ec2_conn.meta.client.get_waiter('image_exists').wait(
-            ImageIds=[image.id])
+    def _wait_for_image(self, image: MachineImage) -> None:
+        cast("AWSCloudProvider", self._provider).ec2_conn.meta.client \
+            .get_waiter('image_exists').wait(ImageIds=[image.id])
 
-    def create_image(self, label):
+    def create_image(self, label: str) -> MachineImage:
         self.assert_valid_resource_label(label)
         name = self._generate_name_from_label(label, 'cb-img')
 
-        image = AWSMachineImage(self._provider,
-                                self._ec2_instance.create_image(Name=name))
+        image = AWSMachineImage(
+            cast("AWSCloudProvider", self._provider),
+            self._ec2_instance.create_image(Name=name))
         # Wait for the image to exist
         self._wait_for_image(image)
         # Add image label
@@ -381,44 +412,47 @@ class AWSInstance(BaseInstance):
         image.refresh()
         return image
 
-    def _get_fip(self, floating_ip):
+    def _get_fip(self, floating_ip: str) -> FloatingIP:
         """Get a floating IP object based on the supplied allocation ID."""
-        return self._provider.networking._floating_ips.get(None, floating_ip)
+        return cast("FloatingIP", self._provider.networking._floating_ips.get(
+            cast("Gateway", None), floating_ip))
 
-    def add_floating_ip(self, floating_ip):
+    def add_floating_ip(self, floating_ip: FloatingIP | str) -> None:
         fip = (floating_ip if isinstance(floating_ip, AWSFloatingIP)
-               else self._get_fip(floating_ip))
+               else self._get_fip(cast(str, floating_ip)))
         # pylint:disable=protected-access
         params = trim_empty_params({
             'InstanceId': self.id,
             'PublicIp': None if self._ec2_instance.vpc_id else
             fip.public_ip,
-            'AllocationId': fip._ip.allocation_id})
-        self._provider.ec2_conn.meta.client.associate_address(**params)
+            'AllocationId': cast(AWSFloatingIP, fip)._ip.allocation_id})
+        cast("AWSCloudProvider", self._provider).ec2_conn.meta.client \
+            .associate_address(**params)
         self.refresh()
 
-    def remove_floating_ip(self, floating_ip):
+    def remove_floating_ip(self, floating_ip: FloatingIP | str) -> None:
         fip = (floating_ip if isinstance(floating_ip, AWSFloatingIP)
-               else self._get_fip(floating_ip))
+               else self._get_fip(cast(str, floating_ip)))
         # pylint:disable=protected-access
         params = trim_empty_params({
             'PublicIp': None if self._ec2_instance.vpc_id else
             fip.public_ip,
-            'AssociationId': fip._ip.association_id})
-        self._provider.ec2_conn.meta.client.disassociate_address(**params)
+            'AssociationId': cast(AWSFloatingIP, fip)._ip.association_id})
+        cast("AWSCloudProvider", self._provider).ec2_conn.meta.client \
+            .disassociate_address(**params)
         self.refresh()
 
-    def add_vm_firewall(self, firewall):
+    def add_vm_firewall(self, firewall: VMFirewall) -> None:
         self._ec2_instance.modify_attribute(
             Groups=self.vm_firewall_ids + [firewall.id])
 
-    def remove_vm_firewall(self, firewall):
+    def remove_vm_firewall(self, firewall: VMFirewall) -> None:
         self._ec2_instance.modify_attribute(
             Groups=([fw_id for fw_id in self.vm_firewall_ids
                      if fw_id != firewall.id]))
 
     @property
-    def state(self):
+    def state(self) -> str:
         if self._unknown_state:
             return InstanceState.UNKNOWN
         try:
@@ -428,7 +462,7 @@ class AWSInstance(BaseInstance):
             # Ignore all exceptions when querying state
             return InstanceState.UNKNOWN
 
-    def refresh(self):
+    def refresh(self) -> None:
         try:
             self._ec2_instance.reload()
             self._unknown_state = False
@@ -438,7 +472,8 @@ class AWSInstance(BaseInstance):
             self._unknown_state = True
 
     # pylint:disable=unused-argument
-    def _wait_till_exists(self, timeout=None, interval=None):
+    def _wait_till_exists(self, timeout: int | None = None,
+                          interval: int | None = None) -> None:
         self._ec2_instance.wait_until_exists()
         # refresh again to make sure instance status is in sync
         self._ec2_instance.reload()
@@ -457,70 +492,71 @@ class AWSVolume(BaseVolume):
         'error': VolumeState.ERROR
     }
 
-    def __init__(self, provider, volume):
+    def __init__(self, provider: AWSCloudProvider, volume: Any) -> None:
         super(AWSVolume, self).__init__(provider)
         self._volume = volume
         self._unknown_state = False
 
     @property
-    def id(self):
+    def id(self) -> str:
         return self._volume.id
 
     @property
-    def name(self):
+    def name(self) -> str:
         return self.id
 
     @property
     # pylint:disable=arguments-differ
-    def label(self):
+    def label(self) -> str | None:
         try:
             return find_tag_value(self._volume.tags, 'Name')
         except ClientError as e:
             log.warn("Cannot get label for volume {0}: {1}".format(self.id, e))
+            return None
+
+    @label.setter
+    # pylint:disable=arguments-differ
+    def label(self, value: str) -> None:
+        self.assert_valid_resource_label(value)
+        self._set_label(value)
 
     @tenacity.retry(stop=tenacity.stop_after_attempt(5),
                     retry=tenacity.retry_if_exception_type(ClientError),
                     wait=tenacity.wait_fixed(5),
                     reraise=True)
-    def _set_label(self, value):
+    def _set_label(self, value: str) -> None:
         self._volume.create_tags(Tags=[{'Key': 'Name', 'Value': value or ""}])
 
-    @label.setter
-    # pylint:disable=arguments-differ
-    def label(self, value):
-        self.assert_valid_resource_label(value)
-        self._set_label(value)
-
     @property
-    def description(self):
+    def description(self) -> str:
         return find_tag_value(self._volume.tags, 'Description')
 
     @description.setter
-    def description(self, value):
+    def description(self, value: str) -> None:
         self._volume.create_tags(Tags=[{'Key': 'Description',
                                         'Value': value or ""}])
 
     @property
-    def size(self):
+    def size(self) -> int:
         return self._volume.size
 
     @property
-    def create_time(self):
+    def create_time(self) -> str:
         return self._volume.create_time
 
     @property
-    def zone_id(self):
+    def zone_id(self) -> str:
         return self._volume.availability_zone
 
     @property
-    def source(self):
+    def source(self) -> Snapshot | MachineImage | None:
         if self._volume.snapshot_id:
             return self._provider.storage.snapshots.get(
                 self._volume.snapshot_id)
         return None
 
     @property
-    def attachments(self):
+    def attachments(self) -> AttachmentInfo | None:
         return [
             BaseAttachmentInfo(self,
                                a.get('InstanceId'),
@@ -532,21 +568,22 @@ class AWSVolume(BaseVolume):
                     retry=tenacity.retry_if_exception_type(Exception),
                     wait=tenacity.wait_fixed(5),
                     reraise=True)
-    def _wait_till_volume_attached(self, instance_id):
+    def _wait_till_volume_attached(self, instance_id: str) -> None:
         self.refresh()
-        if not self.attachments.instance_id == instance_id:
+        if not cast(AttachmentInfo,
+                    self.attachments).instance_id == instance_id:
             raise Exception(f"Volume {self.id} is not yet attached to"
                             f"instance {instance_id}")
 
-    def attach(self, instance, device):
+    def attach(self, instance: str | Instance, device: str) -> None:
         instance_id = instance.id if isinstance(
             instance,
             AWSInstance) else instance
         self._volume.attach_to_instance(InstanceId=instance_id,
                                         Device=device)
-        self._wait_till_volume_attached(instance_id)
+        self._wait_till_volume_attached(cast(str, instance_id))
 
-    def detach(self, force=False):
+    def detach(self, force: bool = False) -> None:
         a = self.attachments
         if a:
             self._volume.detach_from_instance(
@@ -554,10 +591,11 @@ class AWSVolume(BaseVolume):
                 Device=a.device,
                 Force=force)
 
-    def create_snapshot(self, label, description=None):
+    def create_snapshot(self, label: str,
+                        description: str | None = None) -> Snapshot:
         self.assert_valid_resource_label(label)
         snap = AWSSnapshot(
-            self._provider,
+            cast("AWSCloudProvider", self._provider),
             self._volume.create_snapshot(
                 TagSpecifications=[{'ResourceType': 'snapshot',
                                     'Tags': [{'Key': 'Name',
@@ -567,7 +605,7 @@ class AWSVolume(BaseVolume):
         return snap
 
     @property
-    def state(self):
+    def state(self) -> str:
         if self._unknown_state:
             return VolumeState.UNKNOWN
         try:
@@ -577,7 +615,7 @@ class AWSVolume(BaseVolume):
             # Ignore all exceptions when querying state
             return VolumeState.UNKNOWN
 
-    def refresh(self):
+    def refresh(self) -> None:
         try:
             self._volume.reload()
             self._unknown_state = False
@@ -597,64 +635,65 @@ class AWSSnapshot(BaseSnapshot):
         'error': SnapshotState.ERROR
     }
 
-    def __init__(self, provider, snapshot):
+    def __init__(self, provider: AWSCloudProvider, snapshot: Any) -> None:
         super(AWSSnapshot, self).__init__(provider)
         self._snapshot = snapshot
         self._unknown_state = False
 
     @property
-    def id(self):
+    def id(self) -> str:
         return self._snapshot.id
 
     @property
-    def name(self):
+    def name(self) -> str:
         return self.id
 
     @property
     # pylint:disable=arguments-differ
-    def label(self):
+    def label(self) -> str | None:
         try:
             return find_tag_value(self._snapshot.tags, 'Name')
         except ClientError as e:
             log.warn("Cannot get label for snap {0}: {1}".format(self.id, e))
+            return None
+
+    @label.setter
+    # pylint:disable=arguments-differ
+    def label(self, value: str) -> None:
+        self.assert_valid_resource_label(value)
+        self._set_label(value)
 
     @tenacity.retry(stop=tenacity.stop_after_attempt(5),
                     retry=tenacity.retry_if_exception_type(ClientError),
                     wait=tenacity.wait_fixed(5),
                     reraise=True)
-    def _set_label(self, value):
+    def _set_label(self, value: str) -> None:
         self._snapshot.create_tags(Tags=[{'Key': 'Name',
                                           'Value': value or ""}])
 
-    @label.setter
-    # pylint:disable=arguments-differ
-    def label(self, value):
-        self.assert_valid_resource_label(value)
-        self._set_label(value)
-
     @property
-    def description(self):
+    def description(self) -> str:
         return find_tag_value(self._snapshot.tags, 'Description')
 
     @description.setter
-    def description(self, value):
+    def description(self, value: str) -> None:
         self._snapshot.create_tags(Tags=[{
             'Key': 'Description', 'Value': value or ""}])
 
     @property
-    def size(self):
+    def size(self) -> int:
         return self._snapshot.volume_size
 
     @property
-    def volume_id(self):
+    def volume_id(self) -> str | None:
         return self._snapshot.volume_id
 
     @property
-    def create_time(self):
+    def create_time(self) -> str:
         return self._snapshot.start_time
 
     @property
-    def state(self):
+    def state(self) -> str:
         if self._unknown_state:
             return SnapshotState.UNKNOWN
         try:
@@ -664,7 +703,7 @@ class AWSSnapshot(BaseSnapshot):
             # Ignore all exceptions when querying state
             return SnapshotState.UNKNOWN
 
-    def refresh(self):
+    def refresh(self) -> None:
         try:
             self._snapshot.reload()
             self._unknown_state = False
@@ -673,11 +712,13 @@ class AWSSnapshot(BaseSnapshot):
             # set the status to unknown
             self._unknown_state = True
 
-    def create_volume(self, size=None, volume_type=None, iops=None):
+    def create_volume(self, size: int | None = None,
+                      volume_type: str | None = None,
+                      iops: int | None = None) -> Volume:
         label = "from-snap-{0}".format(self.label or self.id)
         cb_vol = self._provider.storage.volumes.create(
             label=label,
-            size=size,
+            size=cast(int, size),
             snapshot=self.id)
         cb_vol.wait_till_ready()
         return cb_vol
@@ -685,46 +726,49 @@ class AWSSnapshot(BaseSnapshot):
 
 class AWSKeyPair(BaseKeyPair):
 
-    def __init__(self, provider, key_pair):
+    def __init__(self, provider: AWSCloudProvider, key_pair: Any) -> None:
         super(AWSKeyPair, self).__init__(provider, key_pair)
 
 
 class AWSVMFirewall(BaseVMFirewall):
 
-    def __init__(self, provider, _vm_firewall):
+    def __init__(self, provider: AWSCloudProvider, _vm_firewall: Any) -> None:
         super(AWSVMFirewall, self).__init__(provider, _vm_firewall)
         self._rule_container = AWSVMFirewallRuleSubService(provider, self)
 
     @property
-    def name(self):
+    def name(self) -> str:
         """
         Return the name of this VM firewall.
         """
         return self._vm_firewall.group_name
 
     @property
-    def label(self):
+    def label(self) -> str | None:
         try:
             return find_tag_value(self._vm_firewall.tags, 'Name')
         except ClientError:
             return None
 
+    @label.setter
+    # pylint:disable=arguments-differ
+    def label(self, value: str) -> None:
+        self.assert_valid_resource_label(value)
+        self._set_label(value)
+
     @tenacity.retry(stop=tenacity.stop_after_attempt(5),
                     retry=tenacity.retry_if_exception_type(ClientError),
                     wait=tenacity.wait_fixed(5),
                     reraise=True)
-    def _set_label(self, value):
+    def _set_label(self, value: str) -> None:
         self._vm_firewall.create_tags(Tags=[{'Key': 'Name',
                                              'Value': value or ""}])
 
-    @label.setter
-    # pylint:disable=arguments-differ
-    def label(self, value):
-        self.assert_valid_resource_label(value)
-        self._set_label(value)
-
-    @property
-    def description(self):
+    # find_tag_value can return None on a missing tag and the read is also
+    # wrapped to swallow ClientError; the VMFirewall interface declares
+    # description as ``str``, so the optional return is widened here.
+    @property  # type: ignore[override]
+    def description(self) -> str | None:
         try:
             return find_tag_value(self._vm_firewall.tags, 'Description')
         except ClientError:
@@ -732,22 +776,22 @@ class AWSVMFirewall(BaseVMFirewall):
 
     @description.setter
     # pylint:disable=arguments-differ
-    def description(self, value):
+    def description(self, value: str) -> None:
         self._vm_firewall.create_tags(Tags=[{'Key': 'Description',
                                              'Value': value or ""}])
 
     @property
-    def network_id(self):
+    def network_id(self) -> str | None:
         return self._vm_firewall.vpc_id
 
     @property
-    def rules(self):
+    def rules(self) -> AWSVMFirewallRuleSubService:
         return self._rule_container
 
-    def refresh(self):
+    def refresh(self) -> None:
         self._vm_firewall.reload()
 
-    def to_json(self):
+    def to_json(self) -> dict[str, Any]:
         attr = inspect.getmembers(self, lambda a: not inspect.isroutine(a))
         js = {k: v for (k, v) in attr if not k.startswith('_')}
         json_rules = [r.to_json() for r in self.rules]
@@ -759,7 +803,8 @@ class AWSVMFirewall(BaseVMFirewall):
 
 class AWSVMFirewallRule(BaseVMFirewallRule):
 
-    def __init__(self, parent_fw, direction, rule):
+    def __init__(self, parent_fw: VMFirewall, direction: str,
+                 rule: Any) -> None:
         self._direction = direction
         super(AWSVMFirewallRule, self).__init__(parent_fw, rule)
 
@@ -769,50 +814,52 @@ class AWSVMFirewallRule(BaseVMFirewallRule):
         self._id = md5.hexdigest()
 
     @property
-    def id(self):
+    def id(self) -> str:
         return self._id
 
     @property
-    def direction(self):
+    def direction(self) -> str:
         return self._direction
 
     @property
-    def protocol(self):
+    def protocol(self) -> str:
         return self._rule.get('IpProtocol')
 
     @property
-    def from_port(self):
+    def from_port(self) -> int:
         return self._rule.get('FromPort')
 
     @property
-    def to_port(self):
+    def to_port(self) -> int:
         return self._rule.get('ToPort')
 
     @property
-    def cidr(self):
+    def cidr(self) -> str | None:
         if len(self._rule.get('IpRanges') or []) > 0:
             return self._rule['IpRanges'][0].get('CidrIp')
         return None
 
     @property
-    def src_dest_fw_id(self):
+    def src_dest_fw_id(self) -> str | None:
         if len(self._rule.get('UserIdGroupPairs') or []) > 0:
             return self._rule['UserIdGroupPairs'][0]['GroupId']
         else:
             return None
 
     @property
-    def src_dest_fw(self):
+    def src_dest_fw(self) -> VMFirewall | None:
         if self.src_dest_fw_id:
             return AWSVMFirewall(
-                self._provider,
-                self._provider.ec2_conn.SecurityGroup(self.src_dest_fw_id))
+                cast("AWSCloudProvider", self._provider),
+                cast("AWSCloudProvider", self._provider).ec2_conn
+                .SecurityGroup(self.src_dest_fw_id))
         else:
             return None
 
     @staticmethod
-    def _construct_ip_perms(protocol, from_port, to_port, cidr,
-                            src_dest_fw_id):
+    def _construct_ip_perms(protocol: str | None, from_port: int | None,
+                            to_port: int | None, cidr: str | None,
+                            src_dest_fw_id: str | None) -> dict[str, Any]:
         return {
             'IpProtocol': protocol,
             'FromPort': from_port,
@@ -828,10 +875,10 @@ class AWSBucketObject(BaseBucketObject):
     class BucketObjIterator():
         CHUNK_SIZE = 4096
 
-        def __init__(self, body):
+        def __init__(self, body: Any) -> None:
             self.body = body
 
-        def __iter__(self):
+        def __iter__(self) -> Iterator[bytes]:
             while True:
                 data = self.read(self.CHUNK_SIZE)
                 if data:
@@ -839,47 +886,54 @@ class AWSBucketObject(BaseBucketObject):
                 else:
                     break
 
-        def read(self, length):
+        def read(self, length: int) -> bytes:
             return self.body.read(amt=length)
 
-        def close(self):
+        def close(self) -> Any:
             return self.body.close()
 
-    def __init__(self, provider, obj):
+    def __init__(self, provider: AWSCloudProvider, obj: Any) -> None:
         super(AWSBucketObject, self).__init__(provider)
         self._obj = obj
 
     @property
-    def id(self):
+    def id(self) -> str:
         return self._obj.key
 
     @property
-    def name(self):
+    def name(self) -> str:
         return self.id
 
     @property
-    def size(self):
+    def size(self) -> int:
         try:
             return self._obj.content_length
         except AttributeError:  # we're dealing with s3.ObjectSummary
             return self._obj.size
 
     @property
-    def last_modified(self):
+    def last_modified(self) -> str:
         return self._obj.last_modified.strftime("%Y-%m-%dT%H:%M:%S.%f")
 
     @property
-    def bucket(self):
-        return AWSBucket(self._provider,
-                         self._provider.s3_conn.Bucket(self._obj.bucket_name))
+    def bucket(self) -> AWSBucket:
+        return AWSBucket(
+            cast("AWSCloudProvider", self._provider),
+            cast("AWSCloudProvider", self._provider).s3_conn
+            .Bucket(self._obj.bucket_name))
 
-    def iter_content(self):
+    def iter_content(self) -> Iterable[bytes]:
         return self.BucketObjIterator(self._obj.get().get('Body'))
 
-    def _upload_single_shot(self, data):
+    def _upload_single_shot(self, data: str | bytes | IO[bytes]) -> None:
         self._obj.put(Body=data)
 
-    def _upload_multipart(self, stream, config=None):
+    # The base driver returns the completed BucketObject; boto3's
+    # upload_fileobj performs the multipart upload in place and returns
+    # nothing, so this override returns None.
+    def _upload_multipart(  # type: ignore[override]
+            self, stream: IO[bytes],
+            config: UploadConfig | None = None) -> None:
         # boto3's TransferManager uploads parts concurrently with a thread-safe
         # client, so the transparent multipart path delegates to it rather than
         # CloudBridge's generic clone-pool driver.
@@ -889,7 +943,8 @@ class AWSBucketObject(BaseBucketObject):
             max_concurrency=self._multipart_max_concurrency(config))
         self._obj.upload_fileobj(stream, Config=transfer_config)
 
-    def upload_from_file(self, path, config=None):
+    def upload_from_file(self, path: str,
+                         config: UploadConfig | None = None) -> None:
         # boto3's upload_file streams large files in parts via its
         # TransferManager. Drive it with CloudBridge's multipart knobs so that
         # upload_from_file and upload() honour the same configuration rather
@@ -900,64 +955,66 @@ class AWSBucketObject(BaseBucketObject):
             max_concurrency=self._multipart_max_concurrency(config))
         self._obj.upload_file(path, Config=transfer_config)
 
-    def delete(self):
+    def delete(self) -> None:
         self._obj.delete()
 
-    def generate_url(self, expires_in, writable=False):
-        return self._provider.s3_conn.meta.client.generate_presigned_url(
-            'put_object' if writable else 'get_object',
-            Params={'Bucket': self._obj.bucket_name, 'Key': self.id},
-            ExpiresIn=expires_in)
+    def generate_url(self, expires_in: int, writable: bool = False) -> str:
+        return cast("AWSCloudProvider", self._provider).s3_conn.meta.client \
+            .generate_presigned_url(
+                'put_object' if writable else 'get_object',
+                Params={'Bucket': self._obj.bucket_name, 'Key': self.id},
+                ExpiresIn=expires_in)
 
-    def refresh(self):
+    def refresh(self) -> None:
         self._obj.load()
 
 
 class AWSBucket(BaseBucket):
 
-    def __init__(self, provider, bucket):
+    def __init__(self, provider: AWSCloudProvider, bucket: Any) -> None:
         super(AWSBucket, self).__init__(provider)
         self._bucket = bucket
         self._object_container = AWSBucketObjectSubService(provider, self)
 
     @property
-    def id(self):
+    def id(self) -> str:
         return self._bucket.name
 
     @property
-    def name(self):
+    def name(self) -> str:
         return self.id
 
     @property
-    def objects(self):
+    def objects(self) -> AWSBucketObjectSubService:
         return self._object_container
 
 
 class AWSRegion(BaseRegion):
 
-    def __init__(self, provider, aws_region):
+    def __init__(self, provider: AWSCloudProvider, aws_region: Any) -> None:
         super(AWSRegion, self).__init__(provider)
         self._aws_region = aws_region
 
     @property
-    def id(self):
+    def id(self) -> str:
         return self._aws_region.get('RegionName')
 
     @property
-    def name(self):
+    def name(self) -> str:
         return self.id
 
     @property
-    def zones(self):
+    def zones(self) -> Iterable[PlacementZone]:
+        aws_provider = cast("AWSCloudProvider", self._provider)
         if self.id == self._provider.region_name:  # optimisation
-            conn = self._provider.ec2_conn
+            conn = aws_provider.ec2_conn
         else:
             # pylint:disable=protected-access
-            conn = self._provider._connect_ec2_region(region_name=self.id)
+            conn = aws_provider._connect_ec2_region(region_name=self.id)
 
         zones = (conn.meta.client.describe_availability_zones()
                  .get('AvailabilityZones', []))
-        return [AWSPlacementZone(self._provider, zone.get('ZoneName'),
+        return [AWSPlacementZone(aws_provider, zone.get('ZoneName'),
                                  self.id)
                 for zone in zones]
 
@@ -970,7 +1027,7 @@ class AWSNetwork(BaseNetwork):
         'available': NetworkState.AVAILABLE,
     }
 
-    def __init__(self, provider, network):
+    def __init__(self, provider: AWSCloudProvider, network: Any) -> None:
         super(AWSNetwork, self).__init__(provider)
         self._vpc = network
         self._unknown_state = False
@@ -978,32 +1035,32 @@ class AWSNetwork(BaseNetwork):
         self._subnet_svc = AWSSubnetSubService(provider, self)
 
     @property
-    def id(self):
+    def id(self) -> str:
         return self._vpc.id
 
     @property
-    def name(self):
+    def name(self) -> str:
         return self.id
 
     @property
-    def label(self):
+    def label(self) -> str | None:
         return find_tag_value(self._vpc.tags, 'Name')
+
+    @label.setter
+    # pylint:disable=arguments-differ
+    def label(self, value: str) -> None:
+        self.assert_valid_resource_label(value)
+        self._set_label(value)
 
     @tenacity.retry(stop=tenacity.stop_after_attempt(5),
                     retry=tenacity.retry_if_exception_type(ClientError),
                     wait=tenacity.wait_fixed(5),
                     reraise=True)
-    def _set_label(self, value):
+    def _set_label(self, value: str) -> None:
         self._vpc.create_tags(Tags=[{'Key': 'Name', 'Value': value or ""}])
 
-    @label.setter
-    # pylint:disable=arguments-differ
-    def label(self, value):
-        self.assert_valid_resource_label(value)
-        self._set_label(value)
-
     @property
-    def external(self):
+    def external(self) -> bool:
         """
         For AWS, all VPC networks can be connected to the Internet so always
         return ``True``.
@@ -1011,7 +1068,7 @@ class AWSNetwork(BaseNetwork):
         return True
 
     @property
-    def state(self):
+    def state(self) -> str:
         if self._unknown_state:
             return NetworkState.UNKNOWN
         try:
@@ -1022,14 +1079,14 @@ class AWSNetwork(BaseNetwork):
             return NetworkState.UNKNOWN
 
     @property
-    def cidr_block(self):
+    def cidr_block(self) -> str:
         return self._vpc.cidr_block
 
     @property
-    def subnets(self):
+    def subnets(self) -> AWSSubnetSubService:
         return self._subnet_svc
 
-    def refresh(self):
+    def refresh(self) -> None:
         try:
             self._vpc.reload()
             self._unknown_state = False
@@ -1042,16 +1099,17 @@ class AWSNetwork(BaseNetwork):
                     retry=tenacity.retry_if_exception_type(ClientError),
                     wait=tenacity.wait_fixed(5),
                     reraise=True)
-    def _wait_for_vpc(self):
+    def _wait_for_vpc(self) -> None:
         self._vpc.wait_until_exists()
         self._vpc.wait_until_available()
 
-    def wait_till_ready(self, timeout=None, interval=None):
+    def wait_till_ready(self, timeout: int | None = None,
+                        interval: int | None = None) -> None:
         self._wait_for_vpc()
         self.refresh()
 
     @property
-    def gateways(self):
+    def gateways(self) -> AWSGatewaySubService:
         return self._gtw_container
 
 
@@ -1062,51 +1120,53 @@ class AWSSubnet(BaseSubnet):
         'available': SubnetState.AVAILABLE,
     }
 
-    def __init__(self, provider, subnet):
+    def __init__(self, provider: AWSCloudProvider, subnet: Any) -> None:
         super(AWSSubnet, self).__init__(provider)
         self._subnet = subnet
         self._unknown_state = False
 
     @property
-    def id(self):
+    def id(self) -> str:
         return self._subnet.id
 
     @property
-    def name(self):
+    def name(self) -> str:
         return self.id
 
     @property
-    def label(self):
+    def label(self) -> str | None:
         return find_tag_value(self._subnet.tags, 'Name')
+
+    @label.setter
+    # pylint:disable=arguments-differ
+    def label(self, value: str) -> None:
+        self.assert_valid_resource_label(value)
+        self._set_label(value)
 
     @tenacity.retry(stop=tenacity.stop_after_attempt(5),
                     retry=tenacity.retry_if_exception_type(ClientError),
                     wait=tenacity.wait_fixed(5),
                     reraise=True)
-    def _set_label(self, value):
+    def _set_label(self, value: str) -> None:
         self._subnet.create_tags(Tags=[{'Key': 'Name', 'Value': value or ""}])
 
-    @label.setter
-    # pylint:disable=arguments-differ
-    def label(self, value):
-        self.assert_valid_resource_label(value)
-        self._set_label(value)
-
     @property
-    def cidr_block(self):
+    def cidr_block(self) -> str:
         return self._subnet.cidr_block
 
     @property
-    def network_id(self):
+    def network_id(self) -> str:
         return self._subnet.vpc_id
 
     @property
-    def zone(self):
-        return AWSPlacementZone(self._provider, self._subnet.availability_zone,
-                                self._provider.region_name)
+    def zone(self) -> PlacementZone | None:
+        return AWSPlacementZone(
+            cast("AWSCloudProvider", self._provider),
+            self._subnet.availability_zone,
+            self._provider.region_name)
 
     @property
-    def state(self):
+    def state(self) -> str:
         if self._unknown_state:
             return SubnetState.UNKNOWN
         try:
@@ -1116,7 +1176,7 @@ class AWSSubnet(BaseSubnet):
             # Ignore all exceptions when querying state
             return SubnetState.UNKNOWN
 
-    def refresh(self):
+    def refresh(self) -> None:
         try:
             self._subnet.reload()
             self._unknown_state = False
@@ -1127,83 +1187,83 @@ class AWSSubnet(BaseSubnet):
 
 class AWSFloatingIP(BaseFloatingIP):
 
-    def __init__(self, provider, floating_ip):
+    def __init__(self, provider: AWSCloudProvider, floating_ip: Any) -> None:
         super(AWSFloatingIP, self).__init__(provider)
         self._ip = floating_ip
 
     @property
-    def id(self):
+    def id(self) -> str:
         return self._ip.allocation_id
 
     @property
-    def public_ip(self):
+    def public_ip(self) -> str:
         return self._ip.public_ip
 
     @property
-    def private_ip(self):
+    def private_ip(self) -> str | None:
         return self._ip.private_ip_address
 
     @property
-    def in_use(self):
+    def in_use(self) -> bool:
         return True if self._ip.association_id else False
 
-    def refresh(self):
+    def refresh(self) -> None:
         self._ip.reload()
 
 
 class AWSRouter(BaseRouter):
 
-    def __init__(self, provider, route_table):
+    def __init__(self, provider: AWSCloudProvider, route_table: Any) -> None:
         super(AWSRouter, self).__init__(provider)
         self._route_table = route_table
 
     @property
-    def id(self):
+    def id(self) -> str:
         return self._route_table.id
 
     @property
-    def name(self):
+    def name(self) -> str:
         return self.id
 
     @property
-    def label(self):
+    def label(self) -> str | None:
         return find_tag_value(self._route_table.tags, 'Name')
+
+    @label.setter
+    # pylint:disable=arguments-differ
+    def label(self, value: str) -> None:
+        self.assert_valid_resource_label(value)
+        self._set_label(value)
 
     @tenacity.retry(stop=tenacity.stop_after_attempt(5),
                     retry=tenacity.retry_if_exception_type(ClientError),
                     wait=tenacity.wait_fixed(5),
                     reraise=True)
-    def _set_label(self, value):
+    def _set_label(self, value: str) -> None:
         self._route_table.create_tags(Tags=[{'Key': 'Name',
                                              'Value': value or ""}])
 
-    @label.setter
-    # pylint:disable=arguments-differ
-    def label(self, value):
-        self.assert_valid_resource_label(value)
-        self._set_label(value)
-
-    def refresh(self):
+    def refresh(self) -> None:
         try:
             self._route_table.reload()
         except ClientError:
             self._route_table.associations = None
 
     @property
-    def state(self):
+    def state(self) -> str:
         if self._route_table.associations:
             return RouterState.ATTACHED
         return RouterState.DETACHED
 
     @property
-    def network_id(self):
+    def network_id(self) -> str | None:
         return self._route_table.vpc_id
 
     @tenacity.retry(stop=tenacity.stop_after_attempt(5),
                     retry=tenacity.retry_if_exception_type(Exception),
                     wait=tenacity.wait_fixed(5),
                     reraise=True)
-    def _wait_till_subnet_attached(self, subnet_id):
+    def _wait_till_subnet_attached(self, subnet_id: str) -> None:
         self.refresh()
         association = [a for a in self._route_table.associations
                        if a.subnet_id == subnet_id]
@@ -1211,12 +1271,12 @@ class AWSRouter(BaseRouter):
             raise Exception(
                 f"Subnet {subnet_id} not attached to route table {self.id}")
 
-    def attach_subnet(self, subnet):
+    def attach_subnet(self, subnet: Subnet | str) -> None:
         subnet_id = subnet.id if isinstance(subnet, AWSSubnet) else subnet
         self._route_table.associate_with_subnet(SubnetId=subnet_id)
-        self._wait_till_subnet_attached(subnet_id)
+        self._wait_till_subnet_attached(cast(str, subnet_id))
 
-    def detach_subnet(self, subnet):
+    def detach_subnet(self, subnet: Subnet | str) -> None:
         subnet_id = subnet.id if isinstance(subnet, AWSSubnet) else subnet
         associations = [a for a in self._route_table.associations
                         if a.subnet_id == subnet_id]
@@ -1225,11 +1285,13 @@ class AWSRouter(BaseRouter):
         self.refresh()
 
     @property
-    def subnets(self):
-        return [AWSSubnet(self._provider, rta.subnet)
+    def subnets(self) -> list[Subnet]:
+        return [AWSSubnet(cast("AWSCloudProvider", self._provider), rta.subnet)
                 for rta in self._route_table.associations if rta.subnet]
 
-    def attach_gateway(self, gateway):
+    # AWS returns a bool, but the Router interface declares attach_gateway as
+    # returning None; preserve the AWS-specific bool return.
+    def attach_gateway(self, gateway: Gateway) -> bool:  # type: ignore[override]
         gw_id = (gateway.id if isinstance(gateway, AWSInternetGateway)
                  else gateway)
         if self._route_table.create_route(
@@ -1237,89 +1299,95 @@ class AWSRouter(BaseRouter):
             return True
         return False
 
-    def detach_gateway(self, gateway):
+    # AWS returns the raw boto3 response dict, but the Router interface declares
+    # detach_gateway as returning None; preserve the AWS-specific dict return.
+    def detach_gateway(  # type: ignore[override]
+            self, gateway: Gateway) -> dict[str, Any]:
         gw_id = (gateway.id if isinstance(gateway, AWSInternetGateway)
                  else gateway)
-        return self._provider.ec2_conn.meta.client.detach_internet_gateway(
-            InternetGatewayId=gw_id, VpcId=self._route_table.vpc_id)
+        return cast("AWSCloudProvider", self._provider).ec2_conn.meta.client \
+            .detach_internet_gateway(
+                InternetGatewayId=gw_id, VpcId=self._route_table.vpc_id)
 
 
 class AWSInternetGateway(BaseInternetGateway):
 
-    def __init__(self, provider, gateway):
+    def __init__(self, provider: AWSCloudProvider, gateway: Any) -> None:
         super(AWSInternetGateway, self).__init__(provider)
         self._gateway = gateway
         self._gateway.state = ''
         self._fips_container = AWSFloatingIPSubService(provider, self)
 
     @property
-    def id(self):
+    def id(self) -> str:
         return self._gateway.id
 
     @property
-    def name(self):
+    def name(self) -> str:
         return find_tag_value(self._gateway.tags, 'Name')
 
-    def refresh(self):
+    def refresh(self) -> None:
         try:
             self._gateway.reload()
         except ClientError:
             self._gateway.state = GatewayState.UNKNOWN
 
     @property
-    def state(self):
+    def state(self) -> str:
         if self._gateway.state == GatewayState.UNKNOWN:
             return GatewayState.UNKNOWN
         else:
             return GatewayState.AVAILABLE
 
     @property
-    def network_id(self):
+    def network_id(self) -> str | None:
         if self._gateway.attachments:
             return self._gateway.attachments[0].get('VpcId')
         return None
 
     @property
-    def floating_ips(self):
+    def floating_ips(self) -> AWSFloatingIPSubService:
         return self._fips_container
 
 
 class AWSLaunchConfig(BaseLaunchConfig):
 
-    def __init__(self, provider):
+    def __init__(self, provider: AWSCloudProvider) -> None:
         super(AWSLaunchConfig, self).__init__(provider)
 
 
 class AWSDnsZone(BaseDnsZone):
 
-    def __init__(self, provider, dns_zone):
+    def __init__(self, provider: AWSCloudProvider, dns_zone: Any) -> None:
         super(AWSDnsZone, self).__init__(provider)
         self._dns_zone = dns_zone
         self._dns_record_container = AWSDnsRecordSubService(provider, self)
 
+    # The zone id is derived from an optional AWS field; the CloudResource
+    # interface declares id as ``str``, but this implementation can return None.
     @property
-    def id(self):
+    def id(self) -> str | None:  # type: ignore[override]
         # The ID contains a slash, do not allow this
         return self.escape_zone_id(self.aws_id)
 
     @property
-    def aws_id(self):
+    def aws_id(self) -> str | None:
         return self._dns_zone.get('Id')
 
     @staticmethod
-    def escape_zone_id(value):
+    def escape_zone_id(value: str | None) -> str | None:
         return value.replace("/", "-") if value else None
 
     @staticmethod
-    def unescape_zone_id(value):
+    def unescape_zone_id(value: str | None) -> str | None:
         return value.replace("-", "/") if value else None
 
     @property
-    def name(self):
+    def name(self) -> str:
         return self._dns_zone.get('Name')
 
     @property
-    def admin_email(self):
+    def admin_email(self) -> str | None:
         comment = self._dns_zone.get('Config', {}).get('Comment')
         if comment:
             email_field = comment.split(",")[0].split("=")
@@ -1331,42 +1399,46 @@ class AWSDnsZone(BaseDnsZone):
             return None
 
     @property
-    def records(self):
+    def records(self) -> AWSDnsRecordSubService:
         return self._dns_record_container
 
 
 class AWSDnsRecord(BaseDnsRecord):
 
-    def __init__(self, provider, dns_zone, dns_record):
+    def __init__(self, provider: AWSCloudProvider, dns_zone: AWSDnsZone,
+                 dns_record: Any) -> None:
         super(AWSDnsRecord, self).__init__(provider)
         self._dns_zone = dns_zone
         self._dns_rec = dns_record
 
     @property
-    def id(self):
+    def id(self) -> str:
         return self._dns_rec.get('Name') + ":" + self._dns_rec.get('Type')
 
     @property
-    def name(self):
+    def name(self) -> str:
         return self._dns_rec.get('Name')
 
+    # The containing zone id is optional on AWSDnsZone, but the DnsRecord
+    # interface declares zone_id as ``str``; widen the return to match reality.
     @property
-    def zone_id(self):
+    def zone_id(self) -> str | None:  # type: ignore[override]
         return self._dns_zone.id
 
     @property
-    def type(self):
+    def type(self) -> str:
         return self._dns_rec.get('Type')
 
     @property
-    def data(self):
+    def data(self) -> list[str]:
         return [rec.get('Value') for rec in
                 self._dns_rec.get('ResourceRecords')]
 
     @property
-    def ttl(self):
+    def ttl(self) -> int:
         return self._dns_rec.get('TTL')
 
-    def delete(self):
+    def delete(self) -> None:
         # pylint:disable=protected-access
-        return self._provider.dns._records.delete(self._dns_zone, self)
+        records: Any = self._provider.dns._records
+        records.delete(self._dns_zone, self)

--- a/cloudbridge/providers/aws/services.py
+++ b/cloudbridge/providers/aws/services.py
@@ -850,8 +850,7 @@ class AWSInstanceService(BaseInstanceService):
         vm_firewall_ids: list[str] | None
         if vm_firewalls and isinstance(vm_firewalls, list) and isinstance(
                 vm_firewalls[0], VMFirewall):
-            vm_firewall_ids = [fw.id for fw in
-                               cast("list[VMFirewall]", vm_firewalls)]
+            vm_firewall_ids = [fw.id for fw in vm_firewalls]
         else:
             vm_firewall_ids = cast("list[str] | None", vm_firewalls)
         return subnet.id if subnet else None, zone_id, vm_firewall_ids

--- a/cloudbridge/providers/aws/services.py
+++ b/cloudbridge/providers/aws/services.py
@@ -1,8 +1,15 @@
 """Services implemented by the AWS provider."""
+from __future__ import annotations
+
+import builtins
 import ipaddress
 import logging
 import string
 import uuid
+from typing import Any
+from typing import IO
+from typing import TYPE_CHECKING
+from typing import cast
 
 from botocore.exceptions import ClientError
 
@@ -41,12 +48,29 @@ from cloudbridge.interfaces.exceptions import \
     InvalidConfigurationException
 from cloudbridge.interfaces.exceptions import InvalidParamException
 from cloudbridge.interfaces.exceptions import InvalidValueException
+from cloudbridge.interfaces.resources import Bucket
+from cloudbridge.interfaces.resources import BucketObject
+from cloudbridge.interfaces.resources import DnsRecord
+from cloudbridge.interfaces.resources import DnsZone
+from cloudbridge.interfaces.resources import FloatingIP
+from cloudbridge.interfaces.resources import Gateway
+from cloudbridge.interfaces.resources import Instance
+from cloudbridge.interfaces.resources import InternetGateway
 from cloudbridge.interfaces.resources import KeyPair
+from cloudbridge.interfaces.resources import LaunchConfig
 from cloudbridge.interfaces.resources import MachineImage
+from cloudbridge.interfaces.resources import MultipartUpload
 from cloudbridge.interfaces.resources import Network
+from cloudbridge.interfaces.resources import PlacementZone
+from cloudbridge.interfaces.resources import Region
+from cloudbridge.interfaces.resources import ResultList
+from cloudbridge.interfaces.resources import Router
 from cloudbridge.interfaces.resources import Snapshot
+from cloudbridge.interfaces.resources import Subnet
 from cloudbridge.interfaces.resources import TrafficDirection
+from cloudbridge.interfaces.resources import UploadPart
 from cloudbridge.interfaces.resources import VMFirewall
+from cloudbridge.interfaces.resources import VMFirewallRule
 from cloudbridge.interfaces.resources import VMType
 from cloudbridge.interfaces.resources import Volume
 
@@ -73,12 +97,16 @@ from .resources import AWSVMFirewallRule
 from .resources import AWSVMType
 from .resources import AWSVolume
 
+if TYPE_CHECKING:
+    from cloudbridge.interfaces.provider import CloudProvider
+    from cloudbridge.providers.aws.provider import AWSCloudProvider
+
 log = logging.getLogger(__name__)
 
 
 class AWSSecurityService(BaseSecurityService):
 
-    def __init__(self, provider):
+    def __init__(self, provider: CloudProvider) -> None:
         super(AWSSecurityService, self).__init__(provider)
 
         # Initialize provider services
@@ -87,40 +115,42 @@ class AWSSecurityService(BaseSecurityService):
         self._vm_firewall_rule_svc = AWSVMFirewallRuleService(provider)
 
     @property
-    def key_pairs(self):
+    def key_pairs(self) -> AWSKeyPairService:
         return self._key_pairs
 
     @property
-    def vm_firewalls(self):
+    def vm_firewalls(self) -> AWSVMFirewallService:
         return self._vm_firewalls
 
     @property
-    def _vm_firewall_rules(self):
+    def _vm_firewall_rules(self) -> AWSVMFirewallRuleService:
         return self._vm_firewall_rule_svc
 
 
 class AWSKeyPairService(BaseKeyPairService):
 
-    def __init__(self, provider):
+    def __init__(self, provider: CloudProvider) -> None:
         super(AWSKeyPairService, self).__init__(provider)
-        self.svc = BotoEC2Service(provider=self.provider,
-                                  cb_resource=AWSKeyPair,
-                                  boto_collection_name='key_pairs')
+        self.svc: Any = BotoEC2Service(
+            provider=cast("AWSCloudProvider", self.provider),
+            cb_resource=AWSKeyPair,
+            boto_collection_name='key_pairs')
 
     @dispatch(event="provider.security.key_pairs.get",
               priority=BaseKeyPairService.STANDARD_EVENT_PRIORITY)
-    def get(self, key_pair_id):
+    def get(self, key_pair_id: str) -> KeyPair | None:
         log.debug("Getting Key Pair Service %s", key_pair_id)
         return self.svc.get(key_pair_id)
 
     @dispatch(event="provider.security.key_pairs.list",
               priority=BaseKeyPairService.STANDARD_EVENT_PRIORITY)
-    def list(self, limit=None, marker=None):
+    def list(self, limit: int | None = None,
+             marker: str | None = None) -> ResultList[KeyPair]:
         return self.svc.list(limit=limit, marker=marker)
 
     @dispatch(event="provider.security.key_pairs.find",
               priority=BaseKeyPairService.STANDARD_EVENT_PRIORITY)
-    def find(self, **kwargs):
+    def find(self, **kwargs: Any) -> ResultList[KeyPair]:
         name = kwargs.pop('name', None)
 
         # All kwargs should have been popped at this time.
@@ -134,7 +164,8 @@ class AWSKeyPairService(BaseKeyPairService):
 
     @dispatch(event="provider.security.key_pairs.create",
               priority=BaseKeyPairService.STANDARD_EVENT_PRIORITY)
-    def create(self, name, public_key_material=None):
+    def create(self, name: str,
+               public_key_material: str | None = None) -> KeyPair:
         AWSKeyPair.assert_valid_resource_name(name)
         private_key = None
         if not public_key_material:
@@ -153,7 +184,7 @@ class AWSKeyPairService(BaseKeyPairService):
 
     @dispatch(event="provider.security.key_pairs.delete",
               priority=BaseKeyPairService.STANDARD_EVENT_PRIORITY)
-    def delete(self, key_pair):
+    def delete(self, key_pair: KeyPair | str) -> None:
         key_pair = (key_pair if isinstance(key_pair, AWSKeyPair) else
                     self.get(key_pair))
         if key_pair:
@@ -163,27 +194,30 @@ class AWSKeyPairService(BaseKeyPairService):
 
 class AWSVMFirewallService(BaseVMFirewallService):
 
-    def __init__(self, provider):
+    def __init__(self, provider: CloudProvider) -> None:
         super(AWSVMFirewallService, self).__init__(provider)
-        self.svc = BotoEC2Service(provider=self.provider,
-                                  cb_resource=AWSVMFirewall,
-                                  boto_collection_name='security_groups')
+        self.svc: Any = BotoEC2Service(
+            provider=cast("AWSCloudProvider", self.provider),
+            cb_resource=AWSVMFirewall,
+            boto_collection_name='security_groups')
 
     @dispatch(event="provider.security.vm_firewalls.get",
               priority=BaseVMFirewallService.STANDARD_EVENT_PRIORITY)
-    def get(self, vm_firewall_id):
+    def get(self, vm_firewall_id: str) -> VMFirewall | None:
         log.debug("Getting Firewall Service with the id: %s", vm_firewall_id)
         return self.svc.get(vm_firewall_id)
 
     @dispatch(event="provider.security.vm_firewalls.list",
               priority=BaseVMFirewallService.STANDARD_EVENT_PRIORITY)
-    def list(self, limit=None, marker=None):
+    def list(self, limit: int | None = None,
+             marker: str | None = None) -> ResultList[VMFirewall]:
         return self.svc.list(limit=limit, marker=marker)
 
     @cb_helpers.deprecated_alias(network_id='network')
     @dispatch(event="provider.security.vm_firewalls.create",
               priority=BaseVMFirewallService.STANDARD_EVENT_PRIORITY)
-    def create(self, label, network, description=None):
+    def create(self, label: str, network: Network | str,
+               description: str | None = None) -> VMFirewall:
         AWSVMFirewall.assert_valid_resource_label(label)
         name = AWSVMFirewall._generate_name_from_label(label, 'cb-fw')
         network_id = network.id if isinstance(network, Network) else network
@@ -214,7 +248,7 @@ class AWSVMFirewallService(BaseVMFirewallService):
 
     @dispatch(event="provider.security.vm_firewalls.find",
               priority=BaseVMFirewallService.STANDARD_EVENT_PRIORITY)
-    def find(self, **kwargs):
+    def find(self, **kwargs: Any) -> ResultList[VMFirewall]:
         # Filter by name or label
         label = kwargs.pop('label', None)
         log.debug("Searching for Firewall Service %s", label)
@@ -227,7 +261,7 @@ class AWSVMFirewallService(BaseVMFirewallService):
 
     @dispatch(event="provider.security.vm_firewalls.delete",
               priority=BaseVMFirewallService.STANDARD_EVENT_PRIORITY)
-    def delete(self, vm_firewall):
+    def delete(self, vm_firewall: VMFirewall | str) -> None:
         firewall = (vm_firewall if isinstance(vm_firewall, AWSVMFirewall)
                     else self.get(vm_firewall))
         if firewall:
@@ -237,83 +271,103 @@ class AWSVMFirewallService(BaseVMFirewallService):
 
 class AWSVMFirewallRuleService(BaseVMFirewallRuleService):
 
-    def __init__(self, provider):
+    def __init__(self, provider: CloudProvider) -> None:
         super(AWSVMFirewallRuleService, self).__init__(provider)
 
     @dispatch(event="provider.security.vm_firewall_rules.list",
               priority=BaseVMFirewallRuleService.STANDARD_EVENT_PRIORITY)
-    def list(self, firewall, limit=None, marker=None):
+    def list(self, firewall: VMFirewall, limit: int | None = None,
+             marker: str | None = None) -> ResultList[VMFirewallRule]:
+        # _vm_firewall is an AWS-internal boto handle not on the interface.
+        boto_fw = cast(Any, firewall)._vm_firewall
         # pylint:disable=protected-access
-        rules = [AWSVMFirewallRule(firewall,
-                                   TrafficDirection.INBOUND, r)
-                 for r in firewall._vm_firewall.ip_permissions]
+        # AWSVMFirewallRule.__init__ types direction as str but the codebase
+        # passes (and stores) the TrafficDirection enum; preserve that.
+        rules: list[VMFirewallRule] = [
+            AWSVMFirewallRule(firewall, TrafficDirection.INBOUND,  # type: ignore[arg-type] # noqa: E501
+                              r)
+            for r in boto_fw.ip_permissions]
         # pylint:disable=protected-access
         rules = rules + [
-            AWSVMFirewallRule(
-                firewall, TrafficDirection.OUTBOUND, r)
-            for r in firewall._vm_firewall.ip_permissions_egress]
+            AWSVMFirewallRule(firewall, TrafficDirection.OUTBOUND,  # type: ignore[arg-type] # noqa: E501
+                              r)
+            for r in boto_fw.ip_permissions_egress]
         return ClientPagedResultList(self.provider, rules,
                                      limit=limit, marker=marker)
 
     @dispatch(event="provider.security.vm_firewall_rules.create",
               priority=BaseVMFirewallRuleService.STANDARD_EVENT_PRIORITY)
-    def create(self, firewall,  direction, protocol=None, from_port=None,
-               to_port=None, cidr=None, src_dest_fw=None):
-        src_dest_fw_id = (
+    def create(self, firewall: VMFirewall, direction: TrafficDirection,
+               protocol: str | None = None, from_port: int | None = None,
+               to_port: int | None = None,
+               cidr: str | builtins.list[str] | None = None,
+               src_dest_fw: VMFirewall | None = None) -> VMFirewallRule:
+        src_dest_fw_id = cast(
+            "str | None",
             src_dest_fw.id if isinstance(src_dest_fw, AWSVMFirewall)
             else src_dest_fw)
 
         # pylint:disable=protected-access
         ip_perm_entry = AWSVMFirewallRule._construct_ip_perms(
-            protocol, from_port, to_port, cidr, src_dest_fw_id)
+            protocol, from_port, to_port,
+            cast("str | None", cidr), src_dest_fw_id)
         # Filter out empty values to please Boto
         ip_perms = [trim_empty_params(ip_perm_entry)]
 
+        # _vm_firewall is an AWS-internal boto handle not on the interface.
+        boto_fw = cast(Any, firewall)._vm_firewall
         try:
             if direction == TrafficDirection.INBOUND:
                 # pylint:disable=protected-access
-                firewall._vm_firewall.authorize_ingress(
-                    IpPermissions=ip_perms)
+                boto_fw.authorize_ingress(IpPermissions=ip_perms)
             elif direction == TrafficDirection.OUTBOUND:
                 # pylint:disable=protected-access
-                firewall._vm_firewall.authorize_egress(
-                    IpPermissions=ip_perms)
+                boto_fw.authorize_egress(IpPermissions=ip_perms)
             else:
                 raise InvalidValueException("direction", direction)
-            firewall.refresh()
-            return AWSVMFirewallRule(firewall, direction, ip_perm_entry)
+            cast(Any, firewall).refresh()
+            # AWSVMFirewallRule.__init__ types direction as str, but the
+            # TrafficDirection enum is what is passed and stored here.
+            return AWSVMFirewallRule(
+                firewall, direction, ip_perm_entry)  # type: ignore[arg-type]
         except ClientError as ec2e:
             if ec2e.response['Error']['Code'] == "InvalidPermission.Duplicate":
                 return AWSVMFirewallRule(
-                    firewall, direction, ip_perm_entry)
+                    firewall, direction,  # type: ignore[arg-type]
+                    ip_perm_entry)
             else:
                 raise ec2e
 
+    # The interface declares delete(firewall, rule_id: str), but this impl
+    # operates on a VMFirewallRule object (reading protocol/ports/cidr off it).
     @dispatch(event="provider.security.vm_firewall_rules.delete",
               priority=BaseVMFirewallRuleService.STANDARD_EVENT_PRIORITY)
-    def delete(self, firewall, rule):
+    def delete(self, firewall: VMFirewall,
+               rule: VMFirewallRule) -> None:
+        # rule carries AWS-internal helpers/attributes not on the interface.
+        aws_rule = cast(Any, rule)
         # pylint:disable=protected-access
-        ip_perm_entry = rule._construct_ip_perms(
-            rule.protocol, rule.from_port, rule.to_port,
-            rule.cidr, rule.src_dest_fw_id)
+        ip_perm_entry = aws_rule._construct_ip_perms(
+            aws_rule.protocol, aws_rule.from_port, aws_rule.to_port,
+            aws_rule.cidr, aws_rule.src_dest_fw_id)
 
         # Filter out empty values to please Boto
         ip_perms = [trim_empty_params(ip_perm_entry)]
 
+        # _vm_firewall is an AWS-internal boto handle not on the interface.
+        boto_fw = cast(Any, firewall)._vm_firewall
         # pylint:disable=protected-access
-        if rule.direction == TrafficDirection.INBOUND:
-            firewall._vm_firewall.revoke_ingress(
-                IpPermissions=ip_perms)
+        if aws_rule.direction == TrafficDirection.INBOUND:
+            boto_fw.revoke_ingress(IpPermissions=ip_perms)
         else:
             # pylint:disable=protected-access
-            firewall._vm_firewall.revoke_egress(
-                IpPermissions=ip_perms)
-        firewall.refresh()
+            boto_fw.revoke_egress(IpPermissions=ip_perms)
+        cast(Any, firewall).refresh()
 
 
 class AWSStorageService(BaseStorageService):
 
-    def __init__(self, provider):
+    def __init__(self, provider: CloudProvider) -> None:
         super(AWSStorageService, self).__init__(provider)
 
         # Initialize provider services
@@ -323,38 +377,39 @@ class AWSStorageService(BaseStorageService):
         self._bucket_obj_svc = AWSBucketObjectService(self.provider)
 
     @property
-    def volumes(self):
+    def volumes(self) -> AWSVolumeService:
         return self._volume_svc
 
     @property
-    def snapshots(self):
+    def snapshots(self) -> AWSSnapshotService:
         return self._snapshot_svc
 
     @property
-    def buckets(self):
+    def buckets(self) -> AWSBucketService:
         return self._bucket_svc
 
     @property
-    def _bucket_objects(self):
+    def _bucket_objects(self) -> AWSBucketObjectService:
         return self._bucket_obj_svc
 
 
 class AWSVolumeService(BaseVolumeService):
 
-    def __init__(self, provider):
+    def __init__(self, provider: CloudProvider) -> None:
         super(AWSVolumeService, self).__init__(provider)
-        self.svc = BotoEC2Service(provider=self.provider,
-                                  cb_resource=AWSVolume,
-                                  boto_collection_name='volumes')
+        self.svc: Any = BotoEC2Service(
+            provider=cast("AWSCloudProvider", self.provider),
+            cb_resource=AWSVolume,
+            boto_collection_name='volumes')
 
     @dispatch(event="provider.storage.volumes.get",
               priority=BaseVolumeService.STANDARD_EVENT_PRIORITY)
-    def get(self, volume_id):
+    def get(self, volume_id: str) -> Volume | None:
         return self.svc.get(volume_id)
 
     @dispatch(event="provider.storage.volumes.find",
               priority=BaseVolumeService.STANDARD_EVENT_PRIORITY)
-    def find(self, **kwargs):
+    def find(self, **kwargs: Any) -> ResultList[Volume]:
         label = kwargs.pop('label', None)
 
         # All kwargs should have been popped at this time.
@@ -370,14 +425,17 @@ class AWSVolumeService(BaseVolumeService):
 
     @dispatch(event="provider.storage.volumes.list",
               priority=BaseVolumeService.STANDARD_EVENT_PRIORITY)
-    def list(self, limit=None, marker=None):
+    def list(self, limit: int | None = None,
+             marker: str | None = None) -> ResultList[Volume]:
         return self.svc.find(
             filters={'availability-zone': self.provider.zone_name},
             limit=limit, marker=marker)
 
     @dispatch(event="provider.storage.volumes.create",
               priority=BaseVolumeService.STANDARD_EVENT_PRIORITY)
-    def create(self, label, size, snapshot=None, description=None):
+    def create(self, label: str, size: int,
+               snapshot: Snapshot | str | None = None,
+               description: str | None = None) -> Volume:
         AWSVolume.assert_valid_resource_label(label)
         zone_name = self.provider.zone_name
         snapshot_id = snapshot.id if isinstance(
@@ -408,7 +466,7 @@ class AWSVolumeService(BaseVolumeService):
 
     @dispatch(event="provider.storage.volumes.delete",
               priority=BaseVolumeService.STANDARD_EVENT_PRIORITY)
-    def delete(self, vol):
+    def delete(self, vol: Volume | str) -> None:
         volume = vol if isinstance(vol, AWSVolume) else self.get(vol)
         if volume:
             # pylint:disable=protected-access
@@ -417,20 +475,21 @@ class AWSVolumeService(BaseVolumeService):
 
 class AWSSnapshotService(BaseSnapshotService):
 
-    def __init__(self, provider):
+    def __init__(self, provider: CloudProvider) -> None:
         super(AWSSnapshotService, self).__init__(provider)
-        self.svc = BotoEC2Service(provider=self.provider,
-                                  cb_resource=AWSSnapshot,
-                                  boto_collection_name='snapshots')
+        self.svc: Any = BotoEC2Service(
+            provider=cast("AWSCloudProvider", self.provider),
+            cb_resource=AWSSnapshot,
+            boto_collection_name='snapshots')
 
     @dispatch(event="provider.storage.snapshots.get",
               priority=BaseSnapshotService.STANDARD_EVENT_PRIORITY)
-    def get(self, snapshot_id):
+    def get(self, snapshot_id: str) -> Snapshot | None:
         return self.svc.get(snapshot_id)
 
     @dispatch(event="provider.storage.snapshots.find",
               priority=BaseSnapshotService.STANDARD_EVENT_PRIORITY)
-    def find(self, **kwargs):
+    def find(self, **kwargs: Any) -> ResultList[Snapshot]:
         # Filter by description or label
         label = kwargs.get('label', None)
 
@@ -442,17 +501,20 @@ class AWSSnapshotService(BaseSnapshotService):
         else:
             obj_list = list(self)
         filters = ['label']
-        return cb_helpers.generic_find(filters, kwargs, obj_list)
+        return cast("ResultList[Snapshot]",
+                    cb_helpers.generic_find(filters, kwargs, obj_list))
 
     @dispatch(event="provider.storage.snapshots.list",
               priority=BaseSnapshotService.STANDARD_EVENT_PRIORITY)
-    def list(self, limit=None, marker=None):
+    def list(self, limit: int | None = None,
+             marker: str | None = None) -> ResultList[Snapshot]:
         return self.svc.list(limit=limit, marker=marker,
                              OwnerIds=['self'])
 
     @dispatch(event="provider.storage.snapshots.create",
               priority=BaseSnapshotService.STANDARD_EVENT_PRIORITY)
-    def create(self, label, volume, description=None):
+    def create(self, label: str, volume: Volume | str,
+               description: str | None = None) -> Snapshot:
         AWSSnapshot.assert_valid_resource_label(label)
         volume_id = volume.id if isinstance(volume, AWSVolume) else volume
 
@@ -479,7 +541,7 @@ class AWSSnapshotService(BaseSnapshotService):
 
     @dispatch(event="provider.storage.snapshots.delete",
               priority=BaseSnapshotService.STANDARD_EVENT_PRIORITY)
-    def delete(self, snapshot):
+    def delete(self, snapshot: Snapshot | str) -> None:
         snapshot = (snapshot if isinstance(snapshot, AWSSnapshot) else
                     self.get(snapshot))
         if snapshot:
@@ -489,15 +551,16 @@ class AWSSnapshotService(BaseSnapshotService):
 
 class AWSBucketService(BaseBucketService):
 
-    def __init__(self, provider):
+    def __init__(self, provider: CloudProvider) -> None:
         super(AWSBucketService, self).__init__(provider)
-        self.svc = BotoS3Service(provider=self.provider,
-                                 cb_resource=AWSBucket,
-                                 boto_collection_name='buckets')
+        self.svc: Any = BotoS3Service(
+            provider=cast("AWSCloudProvider", self.provider),
+            cb_resource=AWSBucket,
+            boto_collection_name='buckets')
 
     @dispatch(event="provider.storage.buckets.get",
               priority=BaseBucketService.STANDARD_EVENT_PRIORITY)
-    def get(self, bucket_id):
+    def get(self, bucket_id: str) -> Bucket | None:
         """
         Returns a bucket given its ID. Returns ``None`` if the bucket
         does not exist.
@@ -506,9 +569,9 @@ class AWSBucketService(BaseBucketService):
             # Make a call to make sure the bucket exists. There's an edge case
             # where a 403 response can occur when the bucket exists but the
             # user simply does not have permissions to access it. See below.
-            self.provider.s3_conn.meta.client.head_bucket(Bucket=bucket_id)
-            return AWSBucket(self.provider,
-                             self.provider.s3_conn.Bucket(bucket_id))
+            s3_conn = cast("AWSCloudProvider", self.provider).s3_conn
+            s3_conn.meta.client.head_bucket(Bucket=bucket_id)
+            return AWSBucket(cast("AWSCloudProvider", self.provider), s3_conn.Bucket(bucket_id))
         except ClientError as e:
             # If 403, it means the bucket exists, but the user does not have
             # permissions to access the bucket. However, limited operations
@@ -521,19 +584,21 @@ class AWSBucketService(BaseBucketService):
                             "have enough permissions to list its contents."
                             "Other operations may be available.",
                             bucket_id)
-                return AWSBucket(self.provider,
-                                 self.provider.s3_conn.Bucket(bucket_id))
+                s3_conn = cast("AWSCloudProvider", self.provider).s3_conn
+                return AWSBucket(cast("AWSCloudProvider", self.provider), s3_conn.Bucket(bucket_id))
         # For all other responses, it's assumed that the bucket does not exist.
         return None
 
     @dispatch(event="provider.storage.buckets.list",
               priority=BaseBucketService.STANDARD_EVENT_PRIORITY)
-    def list(self, limit=None, marker=None):
+    def list(self, limit: int | None = None,
+             marker: str | None = None) -> ResultList[Bucket]:
         return self.svc.list(limit=limit, marker=marker)
 
     @dispatch(event="provider.storage.buckets.create",
               priority=BaseBucketService.STANDARD_EVENT_PRIORITY)
-    def create(self, name, location=None):
+    def create(self, name: str,
+               location: Region | str | None = None) -> Bucket:
         AWSBucket.assert_valid_resource_name(name)
         location = location or self.provider.region_name
         # Due to an API issue in S3, specifying us-east-1 as a
@@ -546,7 +611,8 @@ class AWSBucketService(BaseBucketService):
         if location == 'us-east-1':
             try:
                 # check whether bucket already exists
-                self.provider.s3_conn.meta.client.head_bucket(Bucket=name)
+                cast("AWSCloudProvider", self.provider).s3_conn.meta.client \
+                    .head_bucket(Bucket=name)
             except ClientError as e:
                 if e.response['Error']['Code'] == "404":
                     # bucket doesn't exist, go ahead and create it
@@ -568,7 +634,7 @@ class AWSBucketService(BaseBucketService):
 
     @dispatch(event="provider.storage.buckets.delete",
               priority=BaseBucketService.STANDARD_EVENT_PRIORITY)
-    def delete(self, bucket):
+    def delete(self, bucket: Bucket | str) -> None:
         b = bucket if isinstance(bucket, AWSBucket) else self.get(bucket)
         if b:
             # pylint:disable=protected-access
@@ -577,82 +643,109 @@ class AWSBucketService(BaseBucketService):
 
 class AWSBucketObjectService(BaseBucketObjectService):
 
-    def __init__(self, provider):
+    def __init__(self, provider: CloudProvider) -> None:
         super(AWSBucketObjectService, self).__init__(provider)
 
-    def get(self, bucket, object_id):
+    def get(self, bucket: Bucket | str,
+            object_id: str) -> BucketObject | None:
         try:
             # pylint:disable=protected-access
-            obj = bucket._bucket.Object(object_id)
+            obj = cast(Any, bucket)._bucket.Object(object_id)
             # load() throws an error if object does not exist
             obj.load()
-            return AWSBucketObject(self.provider, obj)
+            return AWSBucketObject(cast("AWSCloudProvider", self.provider), obj)
         except ClientError:
             return None
 
-    def list(self, bucket, limit=None, marker=None, prefix=None):
+    # The interface declares list(bucket, prefix, limit, marker); this impl
+    # orders the optional parameters as (limit, marker, prefix).
+    def list(self, bucket: Bucket | str,  # type: ignore[override]
+             limit: int | None = None, marker: str | None = None,
+             prefix: str | None = None) -> ResultList[BucketObject]:
+        aws_provider = cast("AWSCloudProvider", self.provider)
         if prefix:
             # pylint:disable=protected-access
-            boto_objs = bucket._bucket.objects.filter(Prefix=prefix)
+            boto_objs = cast(Any, bucket)._bucket.objects.filter(Prefix=prefix)
         else:
             # pylint:disable=protected-access
-            boto_objs = bucket._bucket.objects.all()
-        objects = [AWSBucketObject(self.provider, obj) for obj in boto_objs]
+            boto_objs = cast(Any, bucket)._bucket.objects.all()
+        objects: builtins.list[BucketObject] = [
+            AWSBucketObject(aws_provider, obj) for obj in boto_objs]
         return ClientPagedResultList(self.provider, objects,
                                      limit=limit, marker=marker)
 
-    def find(self, bucket, **kwargs):
+    def find(self, bucket: Bucket | str,
+             **kwargs: Any) -> ResultList[BucketObject]:
+        aws_provider = cast("AWSCloudProvider", self.provider)
         # pylint:disable=protected-access
-        obj_list = [AWSBucketObject(self.provider, o)
-                    for o in bucket._bucket.objects.all()]
+        obj_list: builtins.list[BucketObject] = [
+            AWSBucketObject(aws_provider, o)
+            for o in cast(Any, bucket)._bucket.objects.all()]
         filters = ['name']
         matches = cb_helpers.generic_find(filters, kwargs, obj_list)
         return ClientPagedResultList(self.provider, list(matches),
                                      limit=None, marker=None)
 
-    def create(self, bucket, name):
+    def create(self, bucket: Bucket | str,
+               object_name: str) -> BucketObject:
         # pylint:disable=protected-access
-        obj = bucket._bucket.Object(name)
-        return AWSBucketObject(self.provider, obj)
+        obj = cast(Any, bucket)._bucket.Object(object_name)
+        return AWSBucketObject(
+            cast("AWSCloudProvider", self.provider), obj)
 
     @dispatch(event="provider.storage._bucket_objects.create_multipart_upload",
               priority=BaseBucketObjectService.STANDARD_EVENT_PRIORITY)
-    def create_multipart_upload(self, bucket, object_name):
-        response = self.provider.s3_conn.meta.client.create_multipart_upload(
-            Bucket=bucket.name, Key=object_name)
-        return BaseMultipartUpload(self.provider, bucket, object_name,
-                                   response['UploadId'])
+    def create_multipart_upload(self, bucket: Bucket | str,
+                                object_name: str) -> MultipartUpload:
+        client = cast("AWSCloudProvider", self.provider).s3_conn.meta.client
+        response = client.create_multipart_upload(
+            Bucket=cast(Any, bucket).name, Key=object_name)
+        return BaseMultipartUpload(
+            cast("AWSCloudProvider", self.provider),
+            cast(Bucket, bucket), object_name, response['UploadId'])
 
     @dispatch(event="provider.storage._bucket_objects.upload_part",
               priority=BaseBucketObjectService.STANDARD_EVENT_PRIORITY)
-    def upload_part(self, bucket, upload, part_number, data):
-        response = self.provider.s3_conn.meta.client.upload_part(
-            Bucket=bucket.name, Key=upload.object_name,
+    def upload_part(self, bucket: Bucket | str, upload: MultipartUpload,
+                    part_number: int,
+                    data: bytes | IO[bytes]) -> UploadPart:
+        client = cast("AWSCloudProvider", self.provider).s3_conn.meta.client
+        response = client.upload_part(
+            Bucket=cast(Any, bucket).name, Key=upload.object_name,
             UploadId=upload.id, PartNumber=part_number, Body=data)
         return BaseUploadPart(part_number, response['ETag'])
 
     @dispatch(event="provider.storage._bucket_objects."
                     "complete_multipart_upload",
               priority=BaseBucketObjectService.STANDARD_EVENT_PRIORITY)
-    def complete_multipart_upload(self, bucket, upload, parts):
+    def complete_multipart_upload(self, bucket: Bucket | str,
+                                  upload: MultipartUpload,
+                                  parts: builtins.list[UploadPart]
+                                  ) -> BucketObject:
         ordered = sorted(parts, key=lambda p: p.part_number)
-        self.provider.s3_conn.meta.client.complete_multipart_upload(
-            Bucket=bucket.name, Key=upload.object_name, UploadId=upload.id,
+        client = cast("AWSCloudProvider", self.provider).s3_conn.meta.client
+        client.complete_multipart_upload(
+            Bucket=cast(Any, bucket).name, Key=upload.object_name,
+            UploadId=upload.id,
             MultipartUpload={'Parts': [
                 {'PartNumber': p.part_number, 'ETag': p.etag}
                 for p in ordered]})
-        return self.get(bucket, upload.object_name)
+        # get() may return None, but the completed object is expected to exist.
+        return cast(BucketObject, self.get(bucket, upload.object_name))
 
     @dispatch(event="provider.storage._bucket_objects.abort_multipart_upload",
               priority=BaseBucketObjectService.STANDARD_EVENT_PRIORITY)
-    def abort_multipart_upload(self, bucket, upload):
-        self.provider.s3_conn.meta.client.abort_multipart_upload(
-            Bucket=bucket.name, Key=upload.object_name, UploadId=upload.id)
+    def abort_multipart_upload(self, bucket: Bucket | str,
+                               upload: MultipartUpload) -> None:
+        client = cast("AWSCloudProvider", self.provider).s3_conn.meta.client
+        client.abort_multipart_upload(
+            Bucket=cast(Any, bucket).name, Key=upload.object_name,
+            UploadId=upload.id)
 
 
 class AWSComputeService(BaseComputeService):
 
-    def __init__(self, provider):
+    def __init__(self, provider: CloudProvider) -> None:
         super(AWSComputeService, self).__init__(provider)
         self._vm_type_svc = AWSVMTypeService(self.provider)
         self._instance_svc = AWSInstanceService(self.provider)
@@ -660,35 +753,36 @@ class AWSComputeService(BaseComputeService):
         self._images_svc = AWSImageService(self.provider)
 
     @property
-    def images(self):
+    def images(self) -> AWSImageService:
         return self._images_svc
 
     @property
-    def vm_types(self):
+    def vm_types(self) -> AWSVMTypeService:
         return self._vm_type_svc
 
     @property
-    def instances(self):
+    def instances(self) -> AWSInstanceService:
         return self._instance_svc
 
     @property
-    def regions(self):
+    def regions(self) -> AWSRegionService:
         return self._region_svc
 
 
 class AWSImageService(BaseImageService):
 
-    def __init__(self, provider):
+    def __init__(self, provider: CloudProvider) -> None:
         super(AWSImageService, self).__init__(provider)
-        self.svc = BotoEC2Service(provider=self.provider,
-                                  cb_resource=AWSMachineImage,
-                                  boto_collection_name='images')
+        self.svc: Any = BotoEC2Service(
+            provider=cast("AWSCloudProvider", self.provider),
+            cb_resource=AWSMachineImage,
+            boto_collection_name='images')
 
-    def get(self, image_id):
+    def get(self, image_id: str) -> MachineImage | None:
         log.debug("Getting AWS Image Service with the id: %s", image_id)
         return self.svc.get(image_id)
 
-    def find(self, **kwargs):
+    def find(self, **kwargs: Any) -> ResultList[MachineImage]:
         # Filter by name or label
         label = kwargs.pop('label', None)
         # Popped here, not used in the generic find
@@ -700,7 +794,7 @@ class AWSImageService(BaseImageService):
                 "Unrecognised parameters for search: %s. Supported "
                 "attributes: %s" % (kwargs, 'label'))
 
-        extra_args = {}
+        extra_args: dict[str, Any] = {}
         if owner:
             extra_args.update(Owners=owner)
 
@@ -708,16 +802,20 @@ class AWSImageService(BaseImageService):
         # and "AMI name" to allow for searches of public images
         if label:
             log.debug("Searching for AWS Image Service %s", label)
-            obj_list = []
+            obj_list: list[MachineImage] = []
             obj_list.extend(
                 self.svc.find(filters={'name': label}, **extra_args))
             obj_list.extend(
                 self.svc.find(filters={'tag:Name': label}, **extra_args))
-            return obj_list
+            return cast("ResultList[MachineImage]", obj_list)
         else:
-            return []
+            return cast("ResultList[MachineImage]", [])
 
-    def list(self, filter_by_owner=True, limit=None, marker=None):
+    # Intentionally extends the base list() with a leading filter_by_owner
+    # parameter (matches the interface's documented arguments-differ override).
+    def list(self,  # type: ignore[override]
+             filter_by_owner: bool = True, limit: int | None = None,
+             marker: str | None = None) -> ResultList[MachineImage]:
         return self.svc.list(Owners=['self'] if filter_by_owner else
                              ['amazon', 'self'],
                              limit=limit, marker=marker)
@@ -725,14 +823,18 @@ class AWSImageService(BaseImageService):
 
 class AWSInstanceService(BaseInstanceService):
 
-    def __init__(self, provider):
+    def __init__(self, provider: CloudProvider) -> None:
         super(AWSInstanceService, self).__init__(provider)
-        self.svc = BotoEC2Service(provider=self.provider,
-                                  cb_resource=AWSInstance,
-                                  boto_collection_name='instances')
+        self.svc: Any = BotoEC2Service(
+            provider=cast("AWSCloudProvider", self.provider),
+            cb_resource=AWSInstance,
+            boto_collection_name='instances')
 
-    def _resolve_launch_options(self, subnet=None, zone_id=None,
-                                vm_firewalls=None):
+    def _resolve_launch_options(
+            self, subnet: Subnet | None = None,
+            zone_id: str | None = None,
+            vm_firewalls: list[VMFirewall] | list[str] | None = None
+    ) -> tuple[str | None, str | None, list[str] | None]:
         """
         Work out interdependent launch options.
 
@@ -755,34 +857,37 @@ class AWSInstanceService(BaseInstanceService):
         """
         if subnet:
             # subnet's zone takes precedence
-            zone_id = subnet.zone.id
+            zone_id = cast("PlacementZone", subnet.zone).id
+        vm_firewall_ids: list[str] | None
         if vm_firewalls and isinstance(vm_firewalls, list) and isinstance(
                 vm_firewalls[0], VMFirewall):
-            vm_firewall_ids = [fw.id for fw in vm_firewalls]
+            vm_firewall_ids = [fw.id for fw in
+                               cast("list[VMFirewall]", vm_firewalls)]
         else:
-            vm_firewall_ids = vm_firewalls
+            vm_firewall_ids = cast("list[str] | None", vm_firewalls)
         return subnet.id if subnet else None, zone_id, vm_firewall_ids
 
-    def _process_block_device_mappings(self, launch_config):
+    def _process_block_device_mappings(
+            self, launch_config: LaunchConfig) -> list[dict[str, Any]]:
         """
         Processes block device mapping information
         and returns a Boto BlockDeviceMapping object. If new volumes
         are requested (source is None and destination is VOLUME), they will be
         created and the relevant volume ids included in the mapping.
         """
-        bdml = []
+        bdml: list[dict[str, Any]] = []
         # Assign letters from f onwards
         # http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/device_naming.html
         next_letter = iter(list(string.ascii_lowercase[6:]))
         # assign ephemeral devices from 0 onwards
         ephemeral_counter = 0
-        for device in launch_config.block_devices:
-            bdm = {}
+        for device in cast(Any, launch_config).block_devices:
+            bdm: dict[str, Any] = {}
             if device.is_volume:
                 # Generate the device path
                 bdm['DeviceName'] = \
                     '/dev/sd' + ('a1' if device.is_root else next(next_letter))
-                ebs_def = {}
+                ebs_def: dict[str, Any] = {}
                 if isinstance(device.source, Snapshot):
                     ebs_def['SnapshotId'] = device.source.id
                 elif isinstance(device.source, Volume):
@@ -813,20 +918,25 @@ class AWSInstanceService(BaseInstanceService):
 
         return bdml
 
-    def create_launch_config(self):
-        return AWSLaunchConfig(self.provider)
+    def create_launch_config(self) -> LaunchConfig:
+        return AWSLaunchConfig(cast("AWSCloudProvider", self.provider))
 
     @dispatch(event="provider.compute.instances.create",
               priority=BaseInstanceService.STANDARD_EVENT_PRIORITY)
-    def create(self, label, image, vm_type, subnet,
-               key_pair=None, vm_firewalls=None, user_data=None,
-               launch_config=None, **kwargs):
+    def create(self, label: str, image: MachineImage | str,
+               vm_type: VMType | str, subnet: Subnet | str,
+               key_pair: KeyPair | str | None = None,
+               vm_firewalls: list[VMFirewall] | list[str] | None = None,
+               user_data: str | None = None,
+               launch_config: LaunchConfig | None = None,
+               **kwargs: Any) -> Instance:
         AWSInstance.assert_valid_resource_label(label)
         image_id = image.id if isinstance(image, MachineImage) else image
         vm_size = vm_type.id if \
             isinstance(vm_type, VMType) else vm_type
-        subnet = (self.provider.networking.subnets.get(subnet)
-                  if isinstance(subnet, str) else subnet)
+        subnet_obj: Subnet | None = (
+            self.provider.networking.subnets.get(subnet)
+            if isinstance(subnet, str) else subnet)
         zone_name = self.provider.zone_name
         key_pair_name = key_pair.name if isinstance(
             key_pair,
@@ -837,7 +947,7 @@ class AWSInstanceService(BaseInstanceService):
             bdm = None
 
         subnet_id, zone_id, vm_firewall_ids = \
-            self._resolve_launch_options(subnet, zone_name, vm_firewalls)
+            self._resolve_launch_options(subnet_obj, zone_name, vm_firewalls)
 
         placement = {'AvailabilityZone': zone_id} if zone_id else None
         inst = self.svc.create(
@@ -875,12 +985,12 @@ class AWSInstanceService(BaseInstanceService):
 
     @dispatch(event="provider.compute.instances.get",
               priority=BaseInstanceService.STANDARD_EVENT_PRIORITY)
-    def get(self, instance_id):
+    def get(self, instance_id: str) -> Instance | None:
         return self.svc.get(instance_id)
 
     @dispatch(event="provider.compute.instances.find",
               priority=BaseInstanceService.STANDARD_EVENT_PRIORITY)
-    def find(self, **kwargs):
+    def find(self, **kwargs: Any) -> ResultList[Instance]:
         label = kwargs.pop('label', None)
 
         # All kwargs should have been popped at this time.
@@ -895,14 +1005,15 @@ class AWSInstanceService(BaseInstanceService):
 
     @dispatch(event="provider.compute.instances.list",
               priority=BaseInstanceService.STANDARD_EVENT_PRIORITY)
-    def list(self, limit=None, marker=None):
+    def list(self, limit: int | None = None,
+             marker: str | None = None) -> ResultList[Instance]:
         return self.svc.find(
             filters={'availability-zone': self.provider.zone_name},
             limit=limit, marker=marker)
 
     @dispatch(event="provider.compute.instances.delete",
               priority=BaseInstanceService.STANDARD_EVENT_PRIORITY)
-    def delete(self, instance):
+    def delete(self, instance: Instance | str) -> None:
         aws_inst = (instance if isinstance(instance, AWSInstance) else
                     self.get(instance))
         if aws_inst:
@@ -912,16 +1023,17 @@ class AWSInstanceService(BaseInstanceService):
 
 class AWSVMTypeService(BaseVMTypeService):
 
-    def __init__(self, provider):
+    def __init__(self, provider: CloudProvider) -> None:
         super(AWSVMTypeService, self).__init__(provider)
 
     @dispatch(event="provider.compute.vm_types.get",
               priority=BaseVMTypeService.STANDARD_EVENT_PRIORITY)
-    def get(self, vm_type):
+    def get(self, vm_type: str) -> VMType | None:
         try:
-            t = self.provider.ec2_conn.meta.client.describe_instance_types(
+            ec2_conn = cast("AWSCloudProvider", self.provider).ec2_conn
+            t = ec2_conn.meta.client.describe_instance_types(
                 InstanceTypes=[vm_type]).get('InstanceTypes')[0]
-            return AWSVMType(self.provider, t)
+            return AWSVMType(cast("AWSCloudProvider", self.provider), t)
         except ClientError as e:
             if 'InvalidInstanceType' in e.response.get('Error',
                                                        {}).get('Code'):
@@ -931,8 +1043,9 @@ class AWSVMTypeService(BaseVMTypeService):
 
     @dispatch(event="provider.compute.vm_types.list",
               priority=BaseVMTypeService.STANDARD_EVENT_PRIORITY)
-    def list(self, limit=None, marker=None):
-        client = self.provider.ec2_conn.meta.client
+    def list(self, limit: int | None = None,
+             marker: str | None = None) -> ResultList[VMType]:
+        client = cast("AWSCloudProvider", self.provider).ec2_conn.meta.client
         vmt_list_resp = client.describe_instance_type_offerings(
             LocationType='availability-zone',
             Filters=[{'Name': 'location',
@@ -961,19 +1074,19 @@ class AWSVMTypeService(BaseVMTypeService):
             raw_chunk = client.describe_instance_types(
                 InstanceTypes=chunk).get('InstanceTypes')
             raw_types.extend(raw_chunk)
-        cb_types = [AWSVMType(self.provider, t) for t in raw_types]
+        cb_types = [AWSVMType(cast("AWSCloudProvider", self.provider), t) for t in raw_types]
         return ClientPagedResultList(self.provider, cb_types,
                                      limit=limit, marker=marker)
 
 
 class AWSRegionService(BaseRegionService):
 
-    def __init__(self, provider):
+    def __init__(self, provider: CloudProvider) -> None:
         super(AWSRegionService, self).__init__(provider)
 
     @dispatch(event="provider.compute.regions.get",
               priority=BaseRegionService.STANDARD_EVENT_PRIORITY)
-    def get(self, region_id):
+    def get(self, region_id: str) -> Region | None:
         log.debug("Getting AWS Region Service with the id: %s",
                   region_id)
         region = [r for r in self if r.id == region_id]
@@ -984,22 +1097,23 @@ class AWSRegionService(BaseRegionService):
 
     @dispatch(event="provider.compute.regions.list",
               priority=BaseRegionService.STANDARD_EVENT_PRIORITY)
-    def list(self, limit=None, marker=None):
+    def list(self, limit: int | None = None,
+             marker: str | None = None) -> ResultList[Region]:
+        ec2_conn = cast("AWSCloudProvider", self.provider).ec2_conn
         regions = [
-            AWSRegion(self.provider, region) for region in
-            self.provider.ec2_conn.meta.client.describe_regions()
-            .get('Regions', [])]
+            AWSRegion(cast("AWSCloudProvider", self.provider), region) for region in
+            ec2_conn.meta.client.describe_regions().get('Regions', [])]
         return ClientPagedResultList(self.provider, regions,
                                      limit=limit, marker=marker)
 
     @property
-    def current(self):
+    def current(self) -> Region | None:
         return self.get(self._provider.region_name)
 
 
 class AWSNetworkingService(BaseNetworkingService):
 
-    def __init__(self, provider):
+    def __init__(self, provider: CloudProvider) -> None:
         super(AWSNetworkingService, self).__init__(provider)
         self._network_service = AWSNetworkService(self.provider)
         self._subnet_service = AWSSubnetService(self.provider)
@@ -1008,47 +1122,49 @@ class AWSNetworkingService(BaseNetworkingService):
         self._floating_ip_service = AWSFloatingIPService(self.provider)
 
     @property
-    def networks(self):
+    def networks(self) -> AWSNetworkService:
         return self._network_service
 
     @property
-    def subnets(self):
+    def subnets(self) -> AWSSubnetService:
         return self._subnet_service
 
     @property
-    def routers(self):
+    def routers(self) -> AWSRouterService:
         return self._router_service
 
     @property
-    def _gateways(self):
+    def _gateways(self) -> AWSGatewayService:
         return self._gateway_service
 
     @property
-    def _floating_ips(self):
+    def _floating_ips(self) -> AWSFloatingIPService:
         return self._floating_ip_service
 
 
 class AWSNetworkService(BaseNetworkService):
 
-    def __init__(self, provider):
+    def __init__(self, provider: CloudProvider) -> None:
         super(AWSNetworkService, self).__init__(provider)
-        self.svc = BotoEC2Service(provider=self.provider,
-                                  cb_resource=AWSNetwork,
-                                  boto_collection_name='vpcs')
+        self.svc: Any = BotoEC2Service(
+            provider=cast("AWSCloudProvider", self.provider),
+            cb_resource=AWSNetwork,
+            boto_collection_name='vpcs')
 
     @dispatch(event="provider.networking.networks.get",
               priority=BaseNetworkService.STANDARD_EVENT_PRIORITY)
-    def get(self, network_id):
+    def get(self, network_id: str) -> Network | None:
         return self.svc.get(network_id)
 
     @dispatch(event="provider.networking.networks.list",
               priority=BaseNetworkService.STANDARD_EVENT_PRIORITY)
-    def list(self, limit=None, marker=None):
+    def list(self, limit: int | None = None,
+             marker: str | None = None) -> ResultList[Network]:
         return self.svc.list(limit=limit, marker=marker)
 
     @dispatch(event="provider.networking.networks.find",
               priority=BaseNetworkService.STANDARD_EVENT_PRIORITY)
-    def find(self, **kwargs):
+    def find(self, **kwargs: Any) -> ResultList[Network]:
         label = kwargs.pop('label', None)
 
         # All kwargs should have been popped at this time.
@@ -1062,7 +1178,7 @@ class AWSNetworkService(BaseNetworkService):
 
     @dispatch(event="provider.networking.networks.create",
               priority=BaseNetworkService.STANDARD_EVENT_PRIORITY)
-    def create(self, label, cidr_block):
+    def create(self, label: str, cidr_block: str) -> Network:
         AWSNetwork.assert_valid_resource_label(label)
         cb_net = self.svc.create('create_vpc', CidrBlock=cidr_block,
                                  TagSpecifications=[
@@ -1078,20 +1194,21 @@ class AWSNetworkService(BaseNetworkService):
                                  ])
         # Wait until ready to tag instance
         cb_net.wait_till_ready()
-        self.provider.ec2_conn.meta.client.modify_vpc_attribute(
-            VpcId=cb_net.id, EnableDnsHostnames={'Value': True})
+        cast("AWSCloudProvider", self.provider).ec2_conn.meta.client \
+            .modify_vpc_attribute(
+                VpcId=cb_net.id, EnableDnsHostnames={'Value': True})
         return cb_net
 
     @dispatch(event="provider.networking.networks.delete",
               priority=BaseNetworkService.STANDARD_EVENT_PRIORITY)
-    def delete(self, network):
+    def delete(self, network: Network | str) -> None:
         network = (network if isinstance(network, AWSNetwork)
                    else self.get(network))
         if network:
             # pylint:disable=protected-access
             network._vpc.delete()
 
-    def get_or_create_default(self):
+    def get_or_create_default(self) -> Network:
         # # Look for provided default network
         # for net in self.provider.networking.networks:
         # pylint:disable=protected-access
@@ -1114,20 +1231,23 @@ class AWSNetworkService(BaseNetworkService):
 
 class AWSSubnetService(BaseSubnetService):
 
-    def __init__(self, provider):
+    def __init__(self, provider: CloudProvider) -> None:
         super(AWSSubnetService, self).__init__(provider)
-        self.svc = BotoEC2Service(provider=self.provider,
-                                  cb_resource=AWSSubnet,
-                                  boto_collection_name='subnets')
+        self.svc: Any = BotoEC2Service(
+            provider=cast("AWSCloudProvider", self.provider),
+            cb_resource=AWSSubnet,
+            boto_collection_name='subnets')
 
     @dispatch(event="provider.networking.subnets.get",
               priority=BaseSubnetService.STANDARD_EVENT_PRIORITY)
-    def get(self, subnet_id):
+    def get(self, subnet_id: str) -> Subnet | None:
         return self.svc.get(subnet_id)
 
     @dispatch(event="provider.networking.subnets.list",
               priority=BaseSubnetService.STANDARD_EVENT_PRIORITY)
-    def list(self, network=None, limit=None, marker=None):
+    def list(self, network: Network | str | None = None,
+             limit: int | None = None,
+             marker: str | None = None) -> ResultList[Subnet]:
         network_id = network.id if isinstance(network, AWSNetwork) else network
         if network_id:
             return self.svc.find(
@@ -1141,7 +1261,8 @@ class AWSSubnetService(BaseSubnetService):
 
     @dispatch(event="provider.networking.subnets.find",
               priority=BaseSubnetService.STANDARD_EVENT_PRIORITY)
-    def find(self, network=None, **kwargs):
+    def find(self, network: Network | None = None,
+             **kwargs: Any) -> ResultList[Subnet]:
         label = kwargs.pop('label', None)
 
         # All kwargs should have been popped at this time.
@@ -1157,7 +1278,8 @@ class AWSSubnetService(BaseSubnetService):
 
     @dispatch(event="provider.networking.subnets.create",
               priority=BaseSubnetService.STANDARD_EVENT_PRIORITY)
-    def create(self, label, network, cidr_block):
+    def create(self, label: str, network: Network | str,
+               cidr_block: str) -> Subnet:
         AWSSubnet.assert_valid_resource_label(label)
         zone_name = self.provider.zone_name
 
@@ -1183,13 +1305,16 @@ class AWSSubnetService(BaseSubnetService):
 
     @dispatch(event="provider.networking.subnets.delete",
               priority=BaseSubnetService.STANDARD_EVENT_PRIORITY)
-    def delete(self, subnet):
+    def delete(self, subnet: Subnet | str) -> None:
         sn = subnet if isinstance(subnet, AWSSubnet) else self.get(subnet)
         if sn:
             # pylint:disable=protected-access
             sn._subnet.delete()
 
-    def get_or_create_default(self):
+    # The base declares -> Subnet, but this impl can return None when no
+    # matching zone is found for the configured availability zone.
+    def get_or_create_default(  # type: ignore[override]
+            self) -> Subnet | None:
         zone_name = self.provider.zone_name
 
         # # Look for provider default subnet in current zone
@@ -1230,7 +1355,8 @@ class AWSSubnetService(BaseSubnetService):
         # Internet connectivity.
 
         # Check if a default net already exists and get it or create on
-        default_net = self.provider.networking.networks.get_or_create_default()
+        default_net = cast(
+            Any, self.provider.networking.networks).get_or_create_default()
 
         # Get/create an internet gateway for the default network and a
         # corresponding router if it does not already exist.
@@ -1252,7 +1378,9 @@ class AWSSubnetService(BaseSubnetService):
         #     default_router = default_routers[0]
 
         # Create a subnet in each of the region's zones
-        region = self.provider.compute.regions.get(self.provider.region_name)
+        region = cast(
+            Region, self.provider.compute.regions.get(
+                self.provider.region_name))
         default_sn = None
 
         # Determine how many subnets we'll need for the default network and the
@@ -1267,7 +1395,7 @@ class AWSSubnetService(BaseSubnetService):
         # more potential subnets than any region has zones.
         ip_net = ipaddress.ip_network(AWSNetwork.CB_DEFAULT_IPV4RANGE)
         for x in range(5):
-            if len(region.zones) <= len(list(ip_net.subnets(
+            if len(list(region.zones)) <= len(list(ip_net.subnets(
                     prefixlen_diff=x))):
                 prefixlen_diff = x
                 break
@@ -1290,20 +1418,21 @@ class AWSSubnetService(BaseSubnetService):
 class AWSRouterService(BaseRouterService):
     """For AWS, a CloudBridge router corresponds to an AWS Route Table."""
 
-    def __init__(self, provider):
+    def __init__(self, provider: CloudProvider) -> None:
         super(AWSRouterService, self).__init__(provider)
-        self.svc = BotoEC2Service(provider=self.provider,
-                                  cb_resource=AWSRouter,
-                                  boto_collection_name='route_tables')
+        self.svc: Any = BotoEC2Service(
+            provider=cast("AWSCloudProvider", self.provider),
+            cb_resource=AWSRouter,
+            boto_collection_name='route_tables')
 
     @dispatch(event="provider.networking.routers.get",
               priority=BaseRouterService.STANDARD_EVENT_PRIORITY)
-    def get(self, router_id):
+    def get(self, router_id: str) -> Router | None:
         return self.svc.get(router_id)
 
     @dispatch(event="provider.networking.routers.find",
               priority=BaseRouterService.STANDARD_EVENT_PRIORITY)
-    def find(self, **kwargs):
+    def find(self, **kwargs: Any) -> ResultList[Router]:
         label = kwargs.pop('label', None)
 
         # All kwargs should have been popped at this time.
@@ -1317,12 +1446,13 @@ class AWSRouterService(BaseRouterService):
 
     @dispatch(event="provider.networking.routers.list",
               priority=BaseRouterService.STANDARD_EVENT_PRIORITY)
-    def list(self, limit=None, marker=None):
+    def list(self, limit: int | None = None,
+             marker: str | None = None) -> ResultList[Router]:
         return self.svc.list(limit=limit, marker=marker)
 
     @dispatch(event="provider.networking.routers.create",
               priority=BaseRouterService.STANDARD_EVENT_PRIORITY)
-    def create(self, label, network):
+    def create(self, label: str, network: Network | str) -> Router:
         network_id = network.id if isinstance(network, AWSNetwork) else network
 
         cb_router = self.svc.create('create_route_table', VpcId=network_id,
@@ -1342,7 +1472,7 @@ class AWSRouterService(BaseRouterService):
 
     @dispatch(event="provider.networking.routers.delete",
               priority=BaseRouterService.STANDARD_EVENT_PRIORITY)
-    def delete(self, router):
+    def delete(self, router: Router | str) -> None:
         r = router if isinstance(router, AWSRouter) else self.get(router)
         if r:
             # pylint:disable=protected-access
@@ -1351,15 +1481,16 @@ class AWSRouterService(BaseRouterService):
 
 class AWSGatewayService(BaseGatewayService):
 
-    def __init__(self, provider):
+    def __init__(self, provider: CloudProvider) -> None:
         super(AWSGatewayService, self).__init__(provider)
-        self.svc = BotoEC2Service(provider=provider,
-                                  cb_resource=AWSInternetGateway,
-                                  boto_collection_name='internet_gateways')
+        self.svc: Any = BotoEC2Service(
+            provider=cast("AWSCloudProvider", provider),
+            cb_resource=AWSInternetGateway,
+            boto_collection_name='internet_gateways')
 
     @dispatch(event="provider.networking.gateways.get_or_create",
               priority=BaseGatewayService.STANDARD_EVENT_PRIORITY)
-    def get_or_create(self, network):
+    def get_or_create(self, network: Network | str) -> InternetGateway:
         network_id = network.id if isinstance(
             network, AWSNetwork) else network
         # Don't filter by label because it may conflict with at least the
@@ -1387,7 +1518,7 @@ class AWSGatewayService(BaseGatewayService):
 
     @dispatch(event="provider.networking.gateways.delete",
               priority=BaseGatewayService.STANDARD_EVENT_PRIORITY)
-    def delete(self, network, gateway):
+    def delete(self, network: Network | str, gateway: Gateway) -> None:
         gw = (gateway if isinstance(gateway, AWSInternetGateway)
               else self.svc.get(gateway))
         try:
@@ -1395,51 +1526,57 @@ class AWSGatewayService(BaseGatewayService):
                 # pylint:disable=protected-access
                 gw._gateway.detach_from_vpc(VpcId=gw.network_id)
         except ClientError as e:
-            log.warn("Error deleting gateway {0}: {1}".format(self.id, e))
+            # NB: self.id is a pre-existing latent bug (a service has no id);
+            # preserved as-is for this typing pass. Only runs on an error path.
+            log.warn("Error deleting gateway {0}: {1}".format(
+                self.id, e))  # type: ignore[attr-defined]
         # pylint:disable=protected-access
         gw._gateway.delete()
 
     @dispatch(event="provider.networking.gateways.list",
               priority=BaseGatewayService.STANDARD_EVENT_PRIORITY)
-    def list(self, network, limit=None, marker=None):
+    def list(self, network: Network | str, limit: int | None = None,
+             marker: str | None = None) -> ResultList[InternetGateway]:
         log.debug("Listing current AWS internet gateways for net %s.",
-                  network.id)
-        fltr = [{'Name': 'attachment.vpc-id', 'Values': [network.id]}]
+                  cast(Any, network).id)
+        fltr = [{'Name': 'attachment.vpc-id', 'Values': [cast(Any, network).id]}]
         return self.svc.list(limit=None, marker=None, Filters=fltr)
 
 
 class AWSFloatingIPService(BaseFloatingIPService):
 
-    def __init__(self, provider):
+    def __init__(self, provider: CloudProvider) -> None:
         super(AWSFloatingIPService, self).__init__(provider)
-        self.svc = BotoEC2Service(provider=self.provider,
-                                  cb_resource=AWSFloatingIP,
-                                  boto_collection_name='vpc_addresses')
+        self.svc: Any = BotoEC2Service(
+            provider=cast("AWSCloudProvider", self.provider),
+            cb_resource=AWSFloatingIP,
+            boto_collection_name='vpc_addresses')
 
     @dispatch(event="provider.networking.floating_ips.get",
               priority=BaseFloatingIPService.STANDARD_EVENT_PRIORITY)
-    def get(self, gateway, fip_id):
+    def get(self, gateway: Gateway, fip_id: str) -> FloatingIP | None:
         log.debug("Getting AWS Floating IP Service with the id: %s", fip_id)
         return self.svc.get(fip_id)
 
     @dispatch(event="provider.networking.floating_ips.list",
               priority=BaseFloatingIPService.STANDARD_EVENT_PRIORITY)
-    def list(self, gateway, limit=None, marker=None):
+    def list(self, gateway: Gateway, limit: int | None = None,
+             marker: str | None = None) -> ResultList[FloatingIP]:
         return self.svc.list(limit, marker)
 
     @dispatch(event="provider.networking.floating_ips.create",
               priority=BaseFloatingIPService.STANDARD_EVENT_PRIORITY)
-    def create(self, gateway):
+    def create(self, gateway: Gateway) -> FloatingIP:
         log.debug("Creating a floating IP under gateway %s", gateway)
-        ip = self.provider.ec2_conn.meta.client.allocate_address(
-            Domain='vpc')
+        aws_provider = cast("AWSCloudProvider", self.provider)
+        ec2_conn = aws_provider.ec2_conn
+        ip = ec2_conn.meta.client.allocate_address(Domain='vpc')
         return AWSFloatingIP(
-            self.provider,
-            self.provider.ec2_conn.VpcAddress(ip.get('AllocationId')))
+            aws_provider, ec2_conn.VpcAddress(ip.get('AllocationId')))
 
     @dispatch(event="provider.networking.floating_ips.delete",
               priority=BaseFloatingIPService.STANDARD_EVENT_PRIORITY)
-    def delete(self, gateway, fip):
+    def delete(self, gateway: Gateway, fip: FloatingIP | str) -> None:
         if isinstance(fip, AWSFloatingIP):
             # pylint:disable=protected-access
             aws_fip = fip._ip
@@ -1450,37 +1587,39 @@ class AWSFloatingIPService(BaseFloatingIPService):
 
 class AWSDnsService(BaseDnsService):
 
-    def __init__(self, provider):
+    def __init__(self, provider: CloudProvider) -> None:
         super(AWSDnsService, self).__init__(provider)
-        self.client = self._provider.session.client(
-            'route53', region_name=self._provider.region_name)
+        aws_provider = cast("AWSCloudProvider", self._provider)
+        self.client = aws_provider.session.client(
+            'route53', region_name=aws_provider.region_name)
 
         # Initialize provider services
         self._zone_svc = AWSDnsZoneService(self.provider)
         self._record_svc = AWSDnsRecordService(self.provider)
 
     @property
-    def host_zones(self):
+    def host_zones(self) -> AWSDnsZoneService:
         return self._zone_svc
 
     @property
-    def _records(self):
+    def _records(self) -> AWSDnsRecordService:
         return self._record_svc
 
 
 class AWSDnsZoneService(BaseDnsZoneService):
 
-    def __init__(self, provider):
+    def __init__(self, provider: CloudProvider) -> None:
         super(AWSDnsZoneService, self).__init__(provider)
 
     @dispatch(event="provider.dns.host_zones.get",
               priority=BaseDnsZoneService.STANDARD_EVENT_PRIORITY)
-    def get(self, dns_zone_id):
+    def get(self, dns_zone_id: str) -> DnsZone | None:
+        client = cast(AWSDnsService, self.provider.dns).client
         try:
-            dns_zone = self.provider.dns.client.get_hosted_zone(
+            dns_zone = client.get_hosted_zone(
                 Id=AWSDnsZone.unescape_zone_id(dns_zone_id))
-            return AWSDnsZone(self.provider, dns_zone.get('HostedZone'))
-        except self.provider.dns.client.exceptions.NoSuchHostedZone:
+            return AWSDnsZone(cast("AWSCloudProvider", self.provider), dns_zone.get('HostedZone'))
+        except client.exceptions.NoSuchHostedZone:
             return None
         except ClientError as exc:
             error_code = exc.response['Error']['Code']
@@ -1493,10 +1632,12 @@ class AWSDnsZoneService(BaseDnsZoneService):
 
     @dispatch(event="provider.dns.host_zones.list",
               priority=BaseDnsZoneService.STANDARD_EVENT_PRIORITY)
-    def list(self, limit=None, marker=None):
-        response = self.provider.dns.client.list_hosted_zones(
+    def list(self, limit: int | None = None,
+             marker: str | None = None) -> ResultList[DnsZone]:
+        client = cast(AWSDnsService, self.provider.dns).client
+        response = client.list_hosted_zones(
             **trim_empty_params({'MaxItems': limit, 'Marker': marker}))
-        cb_objs = [AWSDnsZone(self.provider, zone)
+        cb_objs = [AWSDnsZone(cast("AWSCloudProvider", self.provider), zone)
                    for zone in response.get('HostedZones')]
         return ServerPagedResultList(is_truncated=response.get('IsTruncated'),
                                      marker=response.get('NextMarker'),
@@ -1505,49 +1646,55 @@ class AWSDnsZoneService(BaseDnsZoneService):
 
     @dispatch(event="provider.dns.host_zones.find",
               priority=BaseDnsZoneService.STANDARD_EVENT_PRIORITY)
-    def find(self, **kwargs):
+    def find(self, **kwargs: Any) -> ResultList[DnsZone]:
         filters = ['name']
-        matches = cb_helpers.generic_find(filters, kwargs, self)
+        matches = cb_helpers.generic_find(filters, kwargs, list(self))
         return ClientPagedResultList(self.provider, list(matches),
                                      limit=None, marker=None)
 
     @dispatch(event="provider.dns.host_zones.create",
               priority=BaseDnsZoneService.STANDARD_EVENT_PRIORITY)
-    def create(self, name, admin_email):
+    def create(self, name: str, admin_email: str) -> DnsZone:
         AWSDnsZone.assert_valid_resource_name(name)
 
-        response = self.provider.dns.client.create_hosted_zone(
+        client = cast(AWSDnsService, self.provider.dns).client
+        response = client.create_hosted_zone(
             Name=name, CallerReference=uuid.uuid4().hex,
             HostedZoneConfig={
                 'Comment': 'admin_email=' + admin_email
             }
         )
-        return AWSDnsZone(self.provider, response.get('HostedZone'))
+        return AWSDnsZone(cast("AWSCloudProvider", self.provider), response.get('HostedZone'))
 
     @dispatch(event="provider.dns.host_zones.delete",
               priority=BaseDnsZoneService.STANDARD_EVENT_PRIORITY)
-    def delete(self, dns_zone):
+    def delete(self, dns_zone: DnsZone | str) -> None:
         dns_zone = (dns_zone if isinstance(dns_zone, AWSDnsZone)
                     else self.get(dns_zone))
         if dns_zone:
-            self.provider.dns.client.delete_hosted_zone(Id=dns_zone.aws_id)
+            client = cast(AWSDnsService, self.provider.dns).client
+            client.delete_hosted_zone(Id=dns_zone.aws_id)
 
 
 class AWSDnsRecordService(BaseDnsRecordService):
 
-    def __init__(self, provider):
+    def __init__(self, provider: CloudProvider) -> None:
         super(AWSDnsRecordService, self).__init__(provider)
 
-    def get(self, dns_zone, rec_id):
+    def get(self, dns_zone: DnsZone | str,
+            rec_id: str) -> DnsRecord | None:
         try:
             if rec_id and ":" in rec_id:
                 rec_name, rec_type = rec_id.split(":")
-                response = self.provider.dns.client.list_resource_record_sets(
-                    HostedZoneId=dns_zone.aws_id,
+                client = cast(AWSDnsService, self.provider.dns).client
+                response = client.list_resource_record_sets(
+                    HostedZoneId=cast(Any, dns_zone).aws_id,
                     StartRecordName=rec_name,
                     StartRecordType=rec_type)
-                return AWSDnsRecord(self.provider, dns_zone,
-                                    response.get('ResourceRecordSets')[0])
+                return AWSDnsRecord(
+                    cast("AWSCloudProvider", self.provider),
+                    cast("AWSDnsZone", dns_zone),
+                    response.get('ResourceRecordSets')[0])
             else:
                 return None
         except ClientError as exc:
@@ -1559,28 +1706,36 @@ class AWSDnsRecordService(BaseDnsRecordService):
             else:
                 raise exc
 
-    def list(self, dns_zone, limit=None, marker=None):
-        response = self.provider.dns.client.list_resource_record_sets(
+    def list(self,  # type: ignore[override]
+             dns_zone: DnsZone | str, limit: int | None = None,
+             marker: str | None = None) -> ResultList[DnsRecord]:
+        client = cast(AWSDnsService, self.provider.dns).client
+        response = client.list_resource_record_sets(
             **trim_empty_params({
-                'HostedZoneId': dns_zone.aws_id,
+                'HostedZoneId': cast(Any, dns_zone).aws_id,
                 'MaxItems': limit,
                 'StartRecordIdentifier': marker
             })
         )
-        cb_objs = [AWSDnsRecord(self.provider, dns_zone, rec)
+        cb_objs = [AWSDnsRecord(cast("AWSCloudProvider", self.provider),
+                                cast("AWSDnsZone", dns_zone), rec)
                    for rec in response.get('ResourceRecordSets')]
         return ServerPagedResultList(
             is_truncated=response.get('IsTruncated'),
             marker=response.get('NextRecordIdentifier'),
             supports_total=False, data=cb_objs)
 
-    def find(self, dns_zone, **kwargs):
+    def find(self, dns_zone: DnsZone | str,
+             **kwargs: Any) -> ResultList[DnsRecord]:
         filters = ['name']
-        matches = cb_helpers.generic_find(filters, kwargs, dns_zone.records)
+        matches = cb_helpers.generic_find(filters, kwargs,
+                                          cast(Any, dns_zone).records)
         return ClientPagedResultList(self.provider, list(matches),
                                      limit=None, marker=None)
 
-    def _to_resource_records(self, data, rec_type):
+    def _to_resource_records(self, data: str | builtins.list[str],
+                             rec_type: str
+                             ) -> builtins.list[dict[str, str]]:
         if isinstance(data, list):
             records = data
         else:
@@ -1588,11 +1743,13 @@ class AWSDnsRecordService(BaseDnsRecordService):
         return [{'Value': self._standardize_record(r, rec_type)}
                 for r in records]
 
-    def create(self, dns_zone, name, type, data, ttl=None):
+    def create(self, dns_zone: DnsZone | str, name: str, type: str,
+               data: str, ttl: int | None = None) -> DnsRecord:
         AWSDnsRecord.assert_valid_resource_name(name)
 
-        response = self.provider.dns.client.change_resource_record_sets(
-            HostedZoneId=dns_zone.aws_id,
+        client = cast(AWSDnsService, self.provider.dns).client
+        response = client.change_resource_record_sets(
+            HostedZoneId=cast(Any, dns_zone).aws_id,
             ChangeBatch={
                 'Changes': [{
                     'Action': 'CREATE',
@@ -1608,33 +1765,34 @@ class AWSDnsRecordService(BaseDnsRecordService):
         )
         # FIXME: Since Moto's implementation of route53 doesn't support
         # waiting, this is skipped for mock tests.
-        if not self.provider.PROVIDER_ID == 'mock':
-            waiter = self.provider.dns.client.get_waiter(
-                'resource_record_sets_changed')
+        if not cast("AWSCloudProvider", self.provider).PROVIDER_ID == 'mock':
+            waiter = client.get_waiter('resource_record_sets_changed')
             waiter.wait(Id=response.get('ChangeInfo').get('Id'))
-        return self.get(dns_zone, name + ":" + type)
+        return cast(DnsRecord, self.get(dns_zone, name + ":" + type))
 
-    def delete(self, dns_zone, record):
-        rec_id = record.id if isinstance(record, AWSDnsRecord) else record
+    def delete(self, dns_zone: DnsZone | str,
+               record: DnsRecord | str) -> None:
+        rec_id = cast(
+            str, record.id if isinstance(record, AWSDnsRecord) else record)
 
         rec_name, rec_type = rec_id.split(":")
-        response = self.provider.dns.client.change_resource_record_sets(
-            HostedZoneId=dns_zone.aws_id,
+        client = cast(AWSDnsService, self.provider.dns).client
+        response = client.change_resource_record_sets(
+            HostedZoneId=cast(Any, dns_zone).aws_id,
             ChangeBatch={
                 'Changes': [{
                     'Action': 'DELETE',
                     'ResourceRecordSet': {
                         'Name': rec_name,
                         'Type': rec_type,
-                        'TTL': record.ttl,
+                        'TTL': cast(Any, record).ttl,
                         'ResourceRecords': self._to_resource_records(
-                            record.data, rec_type)
+                            cast(Any, record).data, rec_type)
                     }
                 }]
             })
         # FIXME: Since Moto's implementation of route53 doesn't support
         # waiting, this is skipped for mock tests.
-        if not self.provider.PROVIDER_ID == 'mock':
-            waiter = self.provider.dns.client.get_waiter(
-                'resource_record_sets_changed')
+        if not cast("AWSCloudProvider", self.provider).PROVIDER_ID == 'mock':
+            waiter = client.get_waiter('resource_record_sets_changed')
             waiter.wait(Id=response.get('ChangeInfo').get('Id'))

--- a/cloudbridge/providers/aws/services.py
+++ b/cloudbridge/providers/aws/services.py
@@ -281,16 +281,12 @@ class AWSVMFirewallRuleService(BaseVMFirewallRuleService):
         # _vm_firewall is an AWS-internal boto handle not on the interface.
         boto_fw = cast(Any, firewall)._vm_firewall
         # pylint:disable=protected-access
-        # AWSVMFirewallRule.__init__ types direction as str but the codebase
-        # passes (and stores) the TrafficDirection enum; preserve that.
         rules: list[VMFirewallRule] = [
-            AWSVMFirewallRule(firewall, TrafficDirection.INBOUND,  # type: ignore[arg-type] # noqa: E501
-                              r)
+            AWSVMFirewallRule(firewall, TrafficDirection.INBOUND, r)
             for r in boto_fw.ip_permissions]
         # pylint:disable=protected-access
         rules = rules + [
-            AWSVMFirewallRule(firewall, TrafficDirection.OUTBOUND,  # type: ignore[arg-type] # noqa: E501
-                              r)
+            AWSVMFirewallRule(firewall, TrafficDirection.OUTBOUND, r)
             for r in boto_fw.ip_permissions_egress]
         return ClientPagedResultList(self.provider, rules,
                                      limit=limit, marker=marker)
@@ -326,15 +322,10 @@ class AWSVMFirewallRuleService(BaseVMFirewallRuleService):
             else:
                 raise InvalidValueException("direction", direction)
             cast(Any, firewall).refresh()
-            # AWSVMFirewallRule.__init__ types direction as str, but the
-            # TrafficDirection enum is what is passed and stored here.
-            return AWSVMFirewallRule(
-                firewall, direction, ip_perm_entry)  # type: ignore[arg-type]
+            return AWSVMFirewallRule(firewall, direction, ip_perm_entry)
         except ClientError as ec2e:
             if ec2e.response['Error']['Code'] == "InvalidPermission.Duplicate":
-                return AWSVMFirewallRule(
-                    firewall, direction,  # type: ignore[arg-type]
-                    ip_perm_entry)
+                return AWSVMFirewallRule(firewall, direction, ip_perm_entry)
             else:
                 raise ec2e
 

--- a/cloudbridge/providers/aws/services.py
+++ b/cloudbridge/providers/aws/services.py
@@ -493,7 +493,7 @@ class AWSSnapshotService(BaseSnapshotService):
         # Filter by description or label
         label = kwargs.get('label', None)
 
-        obj_list = []
+        obj_list: list[Snapshot] = []
         if label:
             log.debug("Searching for AWS Snapshot with label %s", label)
             obj_list.extend(self.svc.find(filters={'tag:Name': label},
@@ -501,8 +501,8 @@ class AWSSnapshotService(BaseSnapshotService):
         else:
             obj_list = list(self)
         filters = ['label']
-        return cast("ResultList[Snapshot]",
-                    cb_helpers.generic_find(filters, kwargs, obj_list))
+        return ClientPagedResultList(
+            self.provider, cb_helpers.generic_find(filters, kwargs, obj_list))
 
     @dispatch(event="provider.storage.snapshots.list",
               priority=BaseSnapshotService.STANDARD_EVENT_PRIORITY)
@@ -800,16 +800,14 @@ class AWSImageService(BaseImageService):
 
         # The original list is made by combining both searches by "tag:Name"
         # and "AMI name" to allow for searches of public images
+        obj_list: list[MachineImage] = []
         if label:
             log.debug("Searching for AWS Image Service %s", label)
-            obj_list: list[MachineImage] = []
             obj_list.extend(
                 self.svc.find(filters={'name': label}, **extra_args))
             obj_list.extend(
                 self.svc.find(filters={'tag:Name': label}, **extra_args))
-            return cast("ResultList[MachineImage]", obj_list)
-        else:
-            return cast("ResultList[MachineImage]", [])
+        return ClientPagedResultList(self.provider, obj_list)
 
     # Intentionally extends the base list() with a leading filter_by_owner
     # parameter (matches the interface's documented arguments-differ override).
@@ -1526,10 +1524,7 @@ class AWSGatewayService(BaseGatewayService):
                 # pylint:disable=protected-access
                 gw._gateway.detach_from_vpc(VpcId=gw.network_id)
         except ClientError as e:
-            # NB: self.id is a pre-existing latent bug (a service has no id);
-            # preserved as-is for this typing pass. Only runs on an error path.
-            log.warn("Error deleting gateway {0}: {1}".format(
-                self.id, e))  # type: ignore[attr-defined]
+            log.warn("Error deleting gateway {0}: {1}".format(gw.id, e))
         # pylint:disable=protected-access
         gw._gateway.delete()
 

--- a/cloudbridge/providers/aws/services.py
+++ b/cloudbridge/providers/aws/services.py
@@ -48,6 +48,7 @@ from cloudbridge.interfaces.exceptions import \
     InvalidConfigurationException
 from cloudbridge.interfaces.exceptions import InvalidParamException
 from cloudbridge.interfaces.exceptions import InvalidValueException
+from cloudbridge.interfaces.exceptions import ProviderInternalException
 from cloudbridge.interfaces.resources import Bucket
 from cloudbridge.interfaces.resources import BucketObject
 from cloudbridge.interfaces.resources import DnsRecord
@@ -1366,9 +1367,12 @@ class AWSSubnetService(BaseSubnetService):
         #     default_router = default_routers[0]
 
         # Create a subnet in each of the region's zones
-        region = cast(
-            Region, self.provider.compute.regions.get(
-                self.provider.region_name))
+        region_name = self.provider.region_name
+        if region_name is None:
+            raise ProviderInternalException(
+                "Cannot create default network resources: provider has no "
+                "region")
+        region = cast(Region, self.provider.compute.regions.get(region_name))
         default_sn = None
 
         # Determine how many subnets we'll need for the default network and the

--- a/cloudbridge/providers/aws/subservices.py
+++ b/cloudbridge/providers/aws/subservices.py
@@ -6,41 +6,48 @@ from cloudbridge.base.subservices import BaseFloatingIPSubService
 from cloudbridge.base.subservices import BaseGatewaySubService
 from cloudbridge.base.subservices import BaseSubnetSubService
 from cloudbridge.base.subservices import BaseVMFirewallRuleSubService
+from cloudbridge.interfaces.provider import CloudProvider
+from cloudbridge.interfaces.resources import Bucket
+from cloudbridge.interfaces.resources import DnsZone
+from cloudbridge.interfaces.resources import Gateway
+from cloudbridge.interfaces.resources import Network
+from cloudbridge.interfaces.resources import VMFirewall
 
 log = logging.getLogger(__name__)
 
 
 class AWSBucketObjectSubService(BaseBucketObjectSubService):
 
-    def __init__(self, provider, bucket):
+    def __init__(self, provider: CloudProvider, bucket: Bucket) -> None:
         super(AWSBucketObjectSubService, self).__init__(provider, bucket)
 
 
 class AWSGatewaySubService(BaseGatewaySubService):
 
-    def __init__(self, provider, network):
+    def __init__(self, provider: CloudProvider, network: Network) -> None:
         super(AWSGatewaySubService, self).__init__(provider, network)
 
 
 class AWSVMFirewallRuleSubService(BaseVMFirewallRuleSubService):
 
-    def __init__(self, provider, firewall):
+    def __init__(self, provider: CloudProvider,
+                 firewall: VMFirewall) -> None:
         super(AWSVMFirewallRuleSubService, self).__init__(provider, firewall)
 
 
 class AWSFloatingIPSubService(BaseFloatingIPSubService):
 
-    def __init__(self, provider, gateway):
+    def __init__(self, provider: CloudProvider, gateway: Gateway) -> None:
         super(AWSFloatingIPSubService, self).__init__(provider, gateway)
 
 
 class AWSSubnetSubService(BaseSubnetSubService):
 
-    def __init__(self, provider, network):
+    def __init__(self, provider: CloudProvider, network: Network) -> None:
         super(AWSSubnetSubService, self).__init__(provider, network)
 
 
 class AWSDnsRecordSubService(BaseDnsRecordSubService):
 
-    def __init__(self, provider, dns_zone):
+    def __init__(self, provider: CloudProvider, dns_zone: DnsZone) -> None:
         super(AWSDnsRecordSubService, self).__init__(provider, dns_zone)

--- a/cloudbridge/providers/azure/azure_client.py
+++ b/cloudbridge/providers/azure/azure_client.py
@@ -1,11 +1,8 @@
+from __future__ import annotations
+
 import datetime
 import logging
-
-import tenacity
-from cloudbridge.interfaces.exceptions import (DuplicateResourceException,
-                                               InvalidLabelException,
-                                               ProviderConnectionException,
-                                               WaitStateException)
+from typing import Any
 
 from azure.core.credentials import AzureNamedKeyCredential
 from azure.core.exceptions import (ClientAuthenticationError,
@@ -32,6 +29,13 @@ from azure.mgmt.storage.models import Sku, StorageAccountCreateParameters
 from azure.mgmt.subscription import SubscriptionClient
 from azure.storage.blob import (BlobBlock, BlobSasPermissions,
                                 BlobServiceClient, generate_blob_sas)
+
+import tenacity
+
+from cloudbridge.interfaces.exceptions import (DuplicateResourceException,
+                                               InvalidLabelException,
+                                               ProviderConnectionException,
+                                               WaitStateException)
 
 from . import helpers as azure_helpers
 
@@ -167,27 +171,30 @@ class AzureClient(object):
     """
     Azure client is the wrapper on top of azure python sdk
     """
-    def __init__(self, config):
+    def __init__(self, config: dict[str, Any]) -> None:
         self._config = config
         self.subscription_id = str(config.get('azure_subscription_id'))
+        # config.get() yields Any | None; the typed azure.identity SDK wants
+        # str. These auth keys are always supplied by the provider, so the
+        # None branch is not reachable in practice.
         self._credentials = ClientSecretCredential(
-            tenant_id=config.get('azure_tenant'),
-            client_id=config.get('azure_client_id'),
-            client_secret=config.get('azure_secret')
+            tenant_id=config.get('azure_tenant'),  # type: ignore[arg-type]
+            client_id=config.get('azure_client_id'),  # type: ignore[arg-type]
+            client_secret=config.get('azure_secret')  # type: ignore[arg-type]
         )
 
         self._access_token = config.get('azure_access_token')
-        self._resource_client = None
-        self._storage_client = None
-        self._network_management_client = None
-        self._subscription_client = None
-        self._compute_client = None
-        self._dns_client = None
-        self._access_key_result = None
-        self._block_blob_service = None
-        self._table_service_client = None
-        self._public_key_table_client = None
-        self._storage_account = None
+        self._resource_client: Any = None
+        self._storage_client: Any = None
+        self._network_management_client: Any = None
+        self._subscription_client: Any = None
+        self._compute_client: Any = None
+        self._dns_client: Any = None
+        self._access_key_result: Any = None
+        self._block_blob_service: Any = None
+        self._table_service_client: Any = None
+        self._public_key_table_client: Any = None
+        self._storage_account: Any = None
 
         log.debug("azure subscription : %s", self.subscription_id)
 
@@ -204,7 +211,7 @@ class AzureClient(object):
         retry=tenacity.retry_if_exception_type(WaitStateException),
         reraise=True,
     )
-    def access_key_result(self):
+    def access_key_result(self) -> Any:
         if not self._access_key_result:
             storage_account = self.storage_account
 
@@ -225,27 +232,27 @@ class AzureClient(object):
         return self._access_key_result
 
     @property
-    def resource_group(self):
+    def resource_group(self) -> Any:
         return self._config.get('azure_resource_group')
 
     @property
-    def networking_resource_group(self):
+    def networking_resource_group(self) -> Any:
         return self._config.get('azure_networking_resource_group')
 
     @property
-    def storage_account(self):
+    def storage_account(self) -> Any:
         return self._config.get('azure_storage_account')
 
     @property
-    def region_name(self):
+    def region_name(self) -> Any:
         return self._config.get('azure_region_name')
 
     @property
-    def public_key_storage_table_name(self):
+    def public_key_storage_table_name(self) -> Any:
         return self._config.get('azure_public_key_storage_table_name')
 
     @property
-    def storage_client(self):
+    def storage_client(self) -> Any:
         if not self._storage_client:
             self._storage_client = \
                 StorageManagementClient(self._credentials,
@@ -253,13 +260,13 @@ class AzureClient(object):
         return self._storage_client
 
     @property
-    def subscription_client(self):
+    def subscription_client(self) -> Any:
         if not self._subscription_client:
             self._subscription_client = SubscriptionClient(self._credentials)
         return self._subscription_client
 
     @property
-    def resource_client(self):
+    def resource_client(self) -> Any:
         if not self._resource_client:
             self._resource_client = \
                 ResourceManagementClient(self._credentials,
@@ -267,7 +274,7 @@ class AzureClient(object):
         return self._resource_client
 
     @property
-    def compute_client(self):
+    def compute_client(self) -> Any:
         if not self._compute_client:
             self._compute_client = \
                 ComputeManagementClient(self._credentials,
@@ -275,21 +282,21 @@ class AzureClient(object):
         return self._compute_client
 
     @property
-    def network_management_client(self):
+    def network_management_client(self) -> Any:
         if not self._network_management_client:
             self._network_management_client = NetworkManagementClient(
                 self._credentials, self.subscription_id)
         return self._network_management_client
 
     @property
-    def dns_client(self):
+    def dns_client(self) -> Any:
         if not self._dns_client:
             self._dns_client = DnsManagementClient(
                 self._credentials, self.subscription_id)
         return self._dns_client
 
     @property
-    def blob_service(self):
+    def blob_service(self) -> Any:
         self._get_or_create_storage_account()
         if not self._block_blob_service:
             if self._access_token:
@@ -303,7 +310,7 @@ class AzureClient(object):
         return self._block_blob_service
 
     @property
-    def table_service(self):
+    def table_service(self) -> Any:
         self._get_or_create_storage_account()
         if not self._table_service_client:
             credential = AzureNamedKeyCredential(
@@ -318,21 +325,21 @@ class AzureClient(object):
                     table_name=self.public_key_storage_table_name)
         return self._public_key_table_client
 
-    def blob_client(self, container_name, blob_name):
+    def blob_client(self, container_name: str, blob_name: str) -> Any:
         return self.blob_service.get_blob_client(container=container_name, blob=blob_name)
 
-    def get_resource_group(self, name):
+    def get_resource_group(self, name: str) -> Any:
         return self.resource_client.resource_groups.get(name)
 
-    def create_resource_group(self, name, parameters):
+    def create_resource_group(self, name: str, parameters: dict[str, Any]) -> Any:
         return self.resource_client.resource_groups. \
             create_or_update(name, ResourceGroup(**parameters))
 
-    def get_storage_account(self, storage_account):
+    def get_storage_account(self, storage_account: str) -> Any:
         return self.storage_client.storage_accounts. \
             get_properties(self.resource_group, storage_account)
 
-    def create_storage_account(self, name, params):
+    def create_storage_account(self, name: str, params: dict[str, Any]) -> Any:
         return self.storage_client.storage_accounts. \
             begin_create(self.resource_group, name.lower(),
                          StorageAccountCreateParameters(**params)).result()
@@ -342,7 +349,7 @@ class AzureClient(object):
     @tenacity.retry(stop=tenacity.stop.stop_after_attempt(2),
                     retry=tenacity.retry_if_exception_type(HttpResponseError),
                     reraise=True)
-    def _get_or_create_storage_account(self):
+    def _get_or_create_storage_account(self) -> Any:
         if self._storage_account:
             return self._storage_account
         else:
@@ -386,43 +393,44 @@ class AzureClient(object):
                                % exists_err
                     raise InvalidLabelException(mess)
 
-    def list_locations(self):
+    def list_locations(self) -> Any:
         return self.subscription_client.subscriptions. \
             list_locations(self.subscription_id)
 
-    def list_vm_firewall(self):
+    def list_vm_firewall(self) -> Any:
         return self.network_management_client.network_security_groups. \
             list(self.resource_group)
 
-    def create_vm_firewall(self, name, parameters):
+    def create_vm_firewall(self, name: str, parameters: dict[str, Any]) -> Any:
         return self.network_management_client.network_security_groups. \
             begin_create_or_update(
                 self.resource_group, name,
                 NetworkSecurityGroup(**parameters)).result()
 
-    def update_vm_firewall_tags(self, fw_id, tags):
+    def update_vm_firewall_tags(self, fw_id: str, tags: dict[str, str]) -> Any:
         url_params = azure_helpers.parse_url(VM_FIREWALL_RESOURCE_ID,
                                              fw_id)
         name = url_params.get(VM_FIREWALL_NAME, "")
         return self.network_management_client.network_security_groups. \
             update_tags(self.resource_group, name, TagsObject(tags=tags))
 
-    def get_vm_firewall(self, fw_id):
+    def get_vm_firewall(self, fw_id: str) -> Any:
         url_params = azure_helpers.parse_url(VM_FIREWALL_RESOURCE_ID,
                                              fw_id)
         fw_name = url_params.get(VM_FIREWALL_NAME, "")
         return self.network_management_client.network_security_groups. \
             get(self.resource_group, fw_name)
 
-    def delete_vm_firewall(self, fw_id):
+    def delete_vm_firewall(self, fw_id: str) -> None:
         url_params = azure_helpers.parse_url(VM_FIREWALL_RESOURCE_ID,
                                              fw_id)
         name = url_params.get(VM_FIREWALL_NAME, "")
         self.network_management_client \
             .network_security_groups.begin_delete(self.resource_group, name).wait()
 
-    def create_vm_firewall_rule(self, fw_id,
-                                rule_name, parameters):
+    def create_vm_firewall_rule(self, fw_id: str,
+                                rule_name: str,
+                                parameters: dict[str, Any] | SecurityRule) -> Any:
         url_params = azure_helpers.parse_url(VM_FIREWALL_RESOURCE_ID,
                                              fw_id)
         vm_firewall_name = url_params.get(VM_FIREWALL_NAME, "")
@@ -435,20 +443,22 @@ class AzureClient(object):
             begin_create_or_update(self.resource_group, vm_firewall_name,
                                    rule_name, rule).result()
 
-    def delete_vm_firewall_rule(self, fw_rule_id, vm_firewall):
+    def delete_vm_firewall_rule(self, fw_rule_id: str, vm_firewall: str) -> Any:
         url_params = azure_helpers.parse_url(VM_FIREWALL_RULE_RESOURCE_ID,
                                              fw_rule_id)
         name = url_params.get(VM_FIREWALL_RULE_NAME, "")
         return self.network_management_client.security_rules. \
             begin_delete(self.resource_group, vm_firewall, name).result()
 
-    def list_containers(self, prefix=None, limit=None, marker=None):
+    def list_containers(self, prefix: str | None = None,
+                        limit: int | None = None,
+                        marker: str | None = None) -> Any:
         results = self.blob_service.list_containers(name_starts_with=prefix,
                                                     results_per_page=limit,
                                                     marker=marker)
         return results
 
-    def create_container(self, container_name):
+    def create_container(self, container_name: str) -> Any:
         try:
             return self.blob_service.create_container(container_name)
         except ResourceExistsError:
@@ -459,40 +469,46 @@ class AzureClient(object):
                     "in Storage Accounts." % container_name
             raise DuplicateResourceException(msg)
 
-    def get_container(self, container_name):
+    def get_container(self, container_name: str) -> Any:
         return self.blob_service.get_container_client(container_name)
 
-    def delete_container(self, container_name):
+    def delete_container(self, container_name: str) -> None:
         self.blob_service.delete_container(container_name)
 
-    def list_blobs(self, container_name, prefix=None, include=None):
+    def list_blobs(self, container_name: str, prefix: str | None = None,
+                   include: Any = None) -> Any:
         container_client = self.get_container(container_name)
         return container_client.list_blobs(name_starts_with=prefix, include=include)
 
-    def upload_blob(self, container_name, blob_name, data, length=None,
-                    max_concurrency=1):
+    def upload_blob(self, container_name: str, blob_name: str, data: Any,
+                    length: int | None = None,
+                    max_concurrency: int = 1) -> None:
         blob_client = self.blob_client(container_name, blob_name)
         blob_client.upload_blob(data=data, length=length, overwrite=True,
                                 max_concurrency=max_concurrency)
 
-    def stage_block(self, container_name, blob_name, block_id, data):
+    def stage_block(self, container_name: str, blob_name: str,
+                    block_id: str, data: Any) -> None:
         blob_client = self.blob_client(container_name, blob_name)
         blob_client.stage_block(block_id, data)
 
-    def commit_block_list(self, container_name, blob_name, block_ids):
+    def commit_block_list(self, container_name: str, blob_name: str,
+                          block_ids: list[str]) -> None:
         blob_client = self.blob_client(container_name, blob_name)
         block_list = [BlobBlock(block_id=block_id) for block_id in block_ids]
         blob_client.commit_block_list(block_list)
 
-    def get_blob(self, container_name, blob_name):
+    def get_blob(self, container_name: str, blob_name: str) -> Any:
         blob_client = self.blob_client(container_name, blob_name)
         return blob_client.get_blob_properties(container_name, blob_name)
 
-    def delete_blob(self, container_name, blob_name, delete_snapshots="include"):
+    def delete_blob(self, container_name: str, blob_name: str,
+                    delete_snapshots: str = "include") -> None:
         blob_client = self.blob_client(container_name, blob_name)
         blob_client.delete_blob(delete_snapshots)
 
-    def get_blob_url(self, container_name, blob_name, expiry_time, writable):
+    def get_blob_url(self, container_name: Any, blob_name: str,
+                     expiry_time: int, writable: bool) -> str:
         now = datetime.datetime.utcnow()
         expiry = now + datetime.timedelta(
             seconds=expiry_time)
@@ -509,37 +525,37 @@ class AzureClient(object):
         url = f"https://{self.storage_account}.blob.core.windows.net/{container_name}/{blob_name}?{sas}"
         return url
 
-    def create_empty_disk(self, disk_name, params):
+    def create_empty_disk(self, disk_name: str, params: dict[str, Any]) -> Any:
         return self.compute_client.disks.begin_create_or_update(
             self.resource_group,
             disk_name,
             Disk(**params)
         ).result()
 
-    def create_snapshot_disk(self, disk_name, params):
+    def create_snapshot_disk(self, disk_name: str, params: dict[str, Any]) -> Any:
         return self.compute_client.disks.begin_create_or_update(
             self.resource_group,
             disk_name,
             Disk(**params)
         ).result()
 
-    def get_disk(self, disk_id):
+    def get_disk(self, disk_id: str) -> Any:
         url_params = azure_helpers.parse_url(VOLUME_RESOURCE_ID,
                                              disk_id)
         disk_name = url_params.get(VOLUME_NAME, "")
         return self.compute_client.disks.get(self.resource_group, disk_name)
 
-    def list_disks(self):
+    def list_disks(self) -> Any:
         return self.compute_client.disks. \
             list_by_resource_group(self.resource_group)
 
-    def delete_disk(self, disk_id):
+    def delete_disk(self, disk_id: str) -> None:
         url_params = azure_helpers.parse_url(VOLUME_RESOURCE_ID,
                                              disk_id)
         disk_name = url_params.get(VOLUME_NAME, "")
         self.compute_client.disks.begin_delete(self.resource_group, disk_name).wait()
 
-    def update_disk_tags(self, disk_id, tags):
+    def update_disk_tags(self, disk_id: str, tags: dict[str, str]) -> Any:
         url_params = azure_helpers.parse_url(VOLUME_RESOURCE_ID,
                                              disk_id)
         disk_name = url_params.get(VOLUME_NAME, "")
@@ -549,22 +565,25 @@ class AzureClient(object):
             DiskUpdate(tags=tags)
         ).wait()
 
-    def list_snapshots(self):
+    def list_snapshots(self) -> Any:
         return self.compute_client.snapshots. \
             list_by_resource_group(self.resource_group)
 
-    def get_snapshot(self, snapshot_id):
+    def get_snapshot(self, snapshot_id: str) -> Any:
         url_params = azure_helpers.parse_url(SNAPSHOT_RESOURCE_ID,
                                              snapshot_id)
         snapshot_name = url_params.get(SNAPSHOT_NAME, "")
         return self.compute_client.snapshots.get(self.resource_group,
                                                  snapshot_name)
 
-    def create_snapshot(self, snapshot_name, volume, tags):
+    def create_snapshot(self, snapshot_name: str, volume: Any,
+                        tags: dict[str, str] | None) -> Any:
+        # The typed azure.mgmt.compute stub's keyword overload omits the
+        # top-level creation_data kwarg that the runtime model accepts.
         snapshot = self.compute_client.snapshots.begin_create_or_update(
             self.resource_group,
             snapshot_name,
-            Snapshot(
+            Snapshot(  # type: ignore[call-overload]
                 location=volume.location,
                 creation_data=CreationData(
                     create_option='Copy',
@@ -577,14 +596,15 @@ class AzureClient(object):
         self.update_snapshot_tags(snapshot.id, tags)
         return snapshot
 
-    def delete_snapshot(self, snapshot_id):
+    def delete_snapshot(self, snapshot_id: str) -> None:
         url_params = azure_helpers.parse_url(SNAPSHOT_RESOURCE_ID,
                                              snapshot_id)
         snapshot_name = url_params.get(SNAPSHOT_NAME, "")
         self.compute_client.snapshots.begin_delete(self.resource_group,
                                                    snapshot_name).wait()
 
-    def update_snapshot_tags(self, snapshot_id, tags):
+    def update_snapshot_tags(self, snapshot_id: str,
+                             tags: dict[str, str] | None) -> Any:
         url_params = azure_helpers.parse_url(SNAPSHOT_RESOURCE_ID,
                                              snapshot_id)
         snapshot_name = url_params.get(SNAPSHOT_NAME, "")
@@ -594,33 +614,33 @@ class AzureClient(object):
             SnapshotUpdate(tags=tags)
         ).wait()
 
-    def is_gallery_image(self, image_id):
+    def is_gallery_image(self, image_id: str) -> bool:
         url_params = azure_helpers.parse_url(IMAGE_RESOURCE_ID,
                                              image_id)
         # If it is a gallery image, it will always have an offer
         return 'offer' in url_params
 
-    def create_image(self, name, params):
+    def create_image(self, name: str, params: dict[str, Any]) -> Any:
         return self.compute_client.images. \
             begin_create_or_update(
                 self.resource_group, name, Image(**params)).result()
 
-    def delete_image(self, image_id):
+    def delete_image(self, image_id: str) -> None:
         url_params = azure_helpers.parse_url(IMAGE_RESOURCE_ID,
                                              image_id)
         if not self.is_gallery_image(image_id):
             name = url_params.get(IMAGE_NAME, "")
             self.compute_client.images.begin_delete(self.resource_group, name).wait()
 
-    def list_images(self):
+    def list_images(self) -> list[Any]:
         azure_images = list(self.compute_client.images.
                             list_by_resource_group(self.resource_group))
         return azure_images
 
-    def list_gallery_refs(self):
+    def list_gallery_refs(self) -> list[Any]:
         return gallery_image_references
 
-    def get_image(self, image_id):
+    def get_image(self, image_id: str) -> Any:
         url_params = azure_helpers.parse_url(IMAGE_RESOURCE_ID,
                                              image_id)
         if self.is_gallery_image(image_id):
@@ -632,7 +652,7 @@ class AzureClient(object):
             name = url_params.get(IMAGE_NAME, "")
             return self.compute_client.images.get(self.resource_group, name)
 
-    def update_image_tags(self, image_id, tags):
+    def update_image_tags(self, image_id: str, tags: dict[str, str]) -> Any:
         url_params = azure_helpers.parse_url(IMAGE_RESOURCE_ID,
                                              image_id)
         if self.is_gallery_image(image_id):
@@ -643,54 +663,55 @@ class AzureClient(object):
                 self.resource_group, name,
                 ImageUpdate(tags=tags)).result()
 
-    def list_vm_types(self):
+    def list_vm_types(self) -> Any:
         return self.compute_client.virtual_machine_sizes. \
             list(self.region_name)
 
-    def list_networks(self):
+    def list_networks(self) -> Any:
         return self.network_management_client.virtual_networks.list(
             self.networking_resource_group)
 
-    def get_network(self, network_id):
+    def get_network(self, network_id: str) -> Any:
         url_params = azure_helpers.parse_url(NETWORK_RESOURCE_ID,
                                              network_id)
         network_name = url_params.get(NETWORK_NAME, "")
         return self.network_management_client.virtual_networks.get(
             self.networking_resource_group, network_name)
 
-    def create_network(self, name, params):
+    def create_network(self, name: str, params: dict[str, Any]) -> Any:
         return self.network_management_client.virtual_networks. \
             begin_create_or_update(
                 self.networking_resource_group, name,
                 parameters=VirtualNetwork(**params)).result()
 
-    def delete_network(self, network_id):
+    def delete_network(self, network_id: str) -> Any:
         url_params = azure_helpers.parse_url(NETWORK_RESOURCE_ID, network_id)
         network_name = url_params.get(NETWORK_NAME, "")
         return self.network_management_client.virtual_networks. \
             begin_delete(self.networking_resource_group, network_name).wait()
 
-    def update_network_tags(self, network_id, tags):
+    def update_network_tags(self, network_id: str,
+                            tags: dict[str, str]) -> Any:
         url_params = azure_helpers.parse_url(NETWORK_RESOURCE_ID, network_id)
         network_name = url_params.get(NETWORK_NAME, "")
         return self.network_management_client.virtual_networks. \
             update_tags(self.networking_resource_group, network_name,
                         TagsObject(tags=tags))
 
-    def get_network_id_for_subnet(self, subnet_id):
+    def get_network_id_for_subnet(self, subnet_id: str) -> str:
         url_params = azure_helpers.parse_url(SUBNET_RESOURCE_ID, subnet_id)
         network_id = NETWORK_RESOURCE_ID[0]
         for key, val in url_params.items():
             network_id = network_id.replace("{" + key + "}", val)
         return network_id
 
-    def list_subnets(self, network_id):
+    def list_subnets(self, network_id: str) -> Any:
         url_params = azure_helpers.parse_url(NETWORK_RESOURCE_ID, network_id)
         network_name = url_params.get(NETWORK_NAME, "")
         return self.network_management_client.subnets. \
             list(self.networking_resource_group, network_name)
 
-    def get_subnet(self, subnet_id):
+    def get_subnet(self, subnet_id: str) -> Any:
         url_params = azure_helpers.parse_url(SUBNET_RESOURCE_ID,
                                              subnet_id)
         network_name = url_params.get(NETWORK_NAME, "")
@@ -698,7 +719,8 @@ class AzureClient(object):
         return self.network_management_client.subnets. \
             get(self.networking_resource_group, network_name, subnet_name)
 
-    def create_subnet(self, network_id, subnet_name, params):
+    def create_subnet(self, network_id: str, subnet_name: str,
+                      params: dict[str, Any]) -> Any:
         url_params = azure_helpers.parse_url(NETWORK_RESOURCE_ID, network_id)
         network_name = url_params.get(NETWORK_NAME, "")
         result_create = self.network_management_client \
@@ -712,7 +734,8 @@ class AzureClient(object):
 
         return subnet_info
 
-    def __if_subnet_in_use(e):
+    @staticmethod
+    def __if_subnet_in_use(e: BaseException) -> bool:
         # return True if the CloudError exception is due to subnet being in use
         if isinstance(e, HttpResponseError):
             if "InUseSubnetCannotBeDeleted" in e.message:
@@ -723,7 +746,7 @@ class AzureClient(object):
                     retry=tenacity.retry_if_exception(__if_subnet_in_use),
                     wait=tenacity.wait.wait_fixed(5),
                     reraise=True)
-    def delete_subnet(self, subnet_id):
+    def delete_subnet(self, subnet_id: str) -> None:
         url_params = azure_helpers.parse_url(SUBNET_RESOURCE_ID,
                                              subnet_id)
         network_name = url_params.get(NETWORK_NAME, "")
@@ -741,21 +764,22 @@ class AzureClient(object):
             log.exception(cloud_error.message)
             raise cloud_error
 
-    def create_floating_ip(self, public_ip_name, public_ip_parameters):
+    def create_floating_ip(self, public_ip_name: str,
+                           public_ip_parameters: dict[str, Any]) -> Any:
         return self.network_management_client.public_ip_addresses. \
             begin_create_or_update(
                 self.networking_resource_group,
                 public_ip_name,
                 PublicIPAddress(**public_ip_parameters)).result()
 
-    def get_floating_ip(self, public_ip_id):
+    def get_floating_ip(self, public_ip_id: str) -> Any:
         url_params = azure_helpers.parse_url(PUBLIC_IP_RESOURCE_ID,
                                              public_ip_id)
         public_ip_name = url_params.get(PUBLIC_IP_NAME, "")
         return self.network_management_client. \
             public_ip_addresses.get(self.networking_resource_group, public_ip_name)
 
-    def delete_floating_ip(self, public_ip_id):
+    def delete_floating_ip(self, public_ip_id: str) -> None:
         url_params = azure_helpers.parse_url(PUBLIC_IP_RESOURCE_ID,
                                              public_ip_id)
         public_ip_name = url_params.get(PUBLIC_IP_NAME, "")
@@ -763,7 +787,7 @@ class AzureClient(object):
             public_ip_addresses.begin_delete(self.networking_resource_group,
                                              public_ip_name).wait()
 
-    def update_fip_tags(self, fip_id, tags):
+    def update_fip_tags(self, fip_id: str, tags: dict[str, str]) -> None:
         url_params = azure_helpers.parse_url(PUBLIC_IP_RESOURCE_ID,
                                              fip_id)
         fip_name = url_params.get(PUBLIC_IP_NAME, "")
@@ -771,37 +795,37 @@ class AzureClient(object):
             update_tags(self.networking_resource_group, fip_name,
                         TagsObject(tags=tags))
 
-    def list_floating_ips(self):
+    def list_floating_ips(self) -> Any:
         return self.network_management_client.public_ip_addresses.list(
             self.networking_resource_group)
 
-    def list_vm(self):
+    def list_vm(self) -> Any:
         return self.compute_client.virtual_machines.list(
             self.resource_group
         )
 
-    def restart_vm(self, vm_id):
+    def restart_vm(self, vm_id: str) -> Any:
         url_params = azure_helpers.parse_url(VM_RESOURCE_ID,
                                              vm_id)
         vm_name = url_params.get(VM_NAME, "")
         return self.compute_client.virtual_machines.begin_restart(
             self.resource_group, vm_name).wait()
 
-    def stop_vm(self, vm_id):
+    def stop_vm(self, vm_id: str) -> None:
         url_params = azure_helpers.parse_url(VM_RESOURCE_ID,
                                              vm_id)
         vm_name = url_params.get(VM_NAME, "")
         self.compute_client.virtual_machines. \
             begin_power_off(self.resource_group, vm_name).wait()
 
-    def delete_vm(self, vm_id):
+    def delete_vm(self, vm_id: str) -> Any:
         url_params = azure_helpers.parse_url(VM_RESOURCE_ID,
                                              vm_id)
         vm_name = url_params.get(VM_NAME, "")
         return self.compute_client.virtual_machines.begin_delete(
             self.resource_group, vm_name).wait()
 
-    def get_vm(self, vm_id):
+    def get_vm(self, vm_id: str) -> Any:
         url_params = azure_helpers.parse_url(VM_RESOURCE_ID,
                                              vm_id)
         vm_name = url_params.get(VM_NAME, "")
@@ -811,13 +835,13 @@ class AzureClient(object):
             expand='instanceView'
         )
 
-    def create_vm(self, vm_name, params):
+    def create_vm(self, vm_name: str, params: dict[str, Any]) -> Any:
         return self.compute_client.virtual_machines. \
             begin_create_or_update(
                 self.resource_group, vm_name,
                 VirtualMachine(**params)).result()
 
-    def update_vm(self, vm_id, params):
+    def update_vm(self, vm_id: str, params: dict[str, Any]) -> Any:
         url_params = azure_helpers.parse_url(VM_RESOURCE_ID,
                                              vm_id)
         vm_name = url_params.get(VM_NAME, "")
@@ -826,28 +850,28 @@ class AzureClient(object):
                 self.resource_group, vm_name,
                 VirtualMachine(**params)).wait()
 
-    def deallocate_vm(self, vm_id):
+    def deallocate_vm(self, vm_id: str) -> None:
         url_params = azure_helpers.parse_url(VM_RESOURCE_ID,
                                              vm_id)
         vm_name = url_params.get(VM_NAME, "")
         self.compute_client. \
             virtual_machines.begin_deallocate(self.resource_group, vm_name).wait()
 
-    def generalize_vm(self, vm_id):
+    def generalize_vm(self, vm_id: str) -> None:
         url_params = azure_helpers.parse_url(VM_RESOURCE_ID,
                                              vm_id)
         vm_name = url_params.get(VM_NAME, "")
         self.compute_client.virtual_machines. \
             generalize(self.resource_group, vm_name)
 
-    def start_vm(self, vm_id):
+    def start_vm(self, vm_id: str) -> None:
         url_params = azure_helpers.parse_url(VM_RESOURCE_ID,
                                              vm_id)
         vm_name = url_params.get(VM_NAME, "")
         self.compute_client.virtual_machines. \
             begin_start(self.resource_group, vm_name).wait()
 
-    def update_vm_tags(self, vm_id, tags):
+    def update_vm_tags(self, vm_id: str, tags: dict[str, str]) -> None:
         url_params = azure_helpers.parse_url(VM_RESOURCE_ID,
                                              vm_id)
         vm_name = url_params.get(VM_NAME, "")
@@ -855,21 +879,22 @@ class AzureClient(object):
             self.resource_group, vm_name,
             VirtualMachineUpdate(tags=tags)).result()
 
-    def delete_nic(self, nic_id):
+    def delete_nic(self, nic_id: str) -> None:
         nic_params = azure_helpers.\
             parse_url(NETWORK_INTERFACE_RESOURCE_ID, nic_id)
         nic_name = nic_params.get(NETWORK_INTERFACE_NAME, "")
         self.network_management_client. \
             network_interfaces.begin_delete(self.resource_group, nic_name).wait()
 
-    def get_nic(self, nic_id):
+    def get_nic(self, nic_id: str) -> Any:
         nic_params = azure_helpers.\
             parse_url(NETWORK_INTERFACE_RESOURCE_ID, nic_id)
         nic_name = nic_params.get(NETWORK_INTERFACE_NAME, "")
         return self.network_management_client. \
             network_interfaces.get(self.resource_group, nic_name)
 
-    def update_nic(self, nic_id, params):
+    def update_nic(self, nic_id: str,
+                   params: dict[str, Any] | NetworkInterface) -> Any:
         nic_params = azure_helpers.\
             parse_url(NETWORK_INTERFACE_RESOURCE_ID, nic_id)
         nic_name = nic_params.get(NETWORK_INTERFACE_NAME, "")
@@ -886,7 +911,7 @@ class AzureClient(object):
         nic_info = async_nic_creation.result()
         return nic_info
 
-    def create_nic(self, nic_name, params):
+    def create_nic(self, nic_name: str, params: dict[str, Any]) -> Any:
         return self.network_management_client. \
             network_interfaces.begin_create_or_update(
                 self.resource_group,
@@ -894,21 +919,23 @@ class AzureClient(object):
                 NetworkInterface(**params)
             ).result()
 
-    def create_public_key(self, entity):
+    def create_public_key(self, entity: dict[str, Any]) -> Any:
         return self.table_service.upsert_entity(entity)
 
-    def get_public_key(self, name):
+    def get_public_key(self, name: str) -> Any:
         entities = list(self.table_service.query_entities(
             query_filter="Name eq '{0}'".format(name),
             results_per_page=1))
         return entities[0] if entities else None
 
-    def delete_public_key(self, entity):
+    def delete_public_key(self, entity: dict[str, Any]) -> None:
         self.table_service.delete_entity(
             partition_key=entity['PartitionKey'],
             row_key=entity['RowKey'])
 
-    def list_public_keys(self, partition_key, limit=None, marker=None):
+    def list_public_keys(self, partition_key: str, limit: int | None = None,
+                         marker: str | None = None
+                         ) -> tuple[list[Any], str | None]:
         pager = self.table_service.query_entities(
             query_filter="PartitionKey eq '{0}'".format(partition_key),
             results_per_page=limit).by_page(continuation_token=marker)
@@ -919,12 +946,13 @@ class AzureClient(object):
         items = list(page)
         return (items, pager.continuation_token)
 
-    def delete_route_table(self, route_table_name):
+    def delete_route_table(self, route_table_name: str) -> None:
         self.network_management_client. \
             route_tables.begin_delete(self.resource_group,
                                       route_table_name).wait()
 
-    def attach_subnet_to_route_table(self, subnet_id, route_table_id):
+    def attach_subnet_to_route_table(self, subnet_id: str,
+                                     route_table_id: str) -> Any:
         url_params = azure_helpers.parse_url(SUBNET_RESOURCE_ID,
                                              subnet_id)
         network_name = url_params.get(NETWORK_NAME, "")
@@ -943,12 +971,13 @@ class AzureClient(object):
                  self.resource_group,
                  network_name,
                  subnet_name,
-                 subnet_info)  # type: ignore
+                 subnet_info)
             subnet_info = result_create.result()
 
         return subnet_info
 
-    def detach_subnet_to_route_table(self, subnet_id, route_table_id):
+    def detach_subnet_to_route_table(self, subnet_id: str,
+                                     route_table_id: str) -> Any:
         url_params = azure_helpers.parse_url(SUBNET_RESOURCE_ID,
                                              subnet_id)
         network_name = url_params.get(NETWORK_NAME, "")
@@ -968,64 +997,68 @@ class AzureClient(object):
                  self.resource_group,
                  network_name,
                  subnet_name,
-                 subnet_info)  # type: ignore
+                 subnet_info)
             subnet_info = result_create.result()
 
         return subnet_info
 
-    def list_route_tables(self):
+    def list_route_tables(self) -> Any:
         return self.network_management_client. \
             route_tables.list(self.resource_group)
 
-    def get_route_table(self, router_id):
+    def get_route_table(self, router_id: str) -> Any:
         url_params = azure_helpers.parse_url(ROUTER_RESOURCE_ID,
                                              router_id)
         router_name = url_params.get(ROUTER_NAME, "")
         return self.network_management_client. \
             route_tables.get(self.resource_group, router_name)
 
-    def create_route_table(self, route_table_name, params):
+    def create_route_table(self, route_table_name: str,
+                           params: dict[str, Any]) -> Any:
         return self.network_management_client. \
             route_tables.begin_create_or_update(
              self.resource_group,
              route_table_name, RouteTable(**params)).result()
 
-    def update_route_table_tags(self, route_table_name, tags):
+    def update_route_table_tags(self, route_table_name: str,
+                                tags: dict[str, str]) -> None:
         self.network_management_client.route_tables.update_tags(
             self.resource_group, route_table_name,
             TagsObject(tags=tags))
 
     # DNS operations
-    def get_dns_zone(self, zone_name):
+    def get_dns_zone(self, zone_name: str) -> Any:
         return self.dns_client.zones.get(self.resource_group, zone_name)
 
-    def list_dns_zones(self):
+    def list_dns_zones(self) -> list[Any]:
         return list(self.dns_client.zones.list_by_resource_group(
             self.resource_group))
 
-    def create_dns_zone(self, zone_name, params):
+    def create_dns_zone(self, zone_name: str, params: dict[str, Any]) -> Any:
         return self.dns_client.zones.create_or_update(
             self.resource_group, zone_name, Zone(**params))
 
-    def delete_dns_zone(self, zone_name):
+    def delete_dns_zone(self, zone_name: str) -> None:
         self.dns_client.zones.begin_delete(
             self.resource_group, zone_name).wait()
 
-    def get_dns_record(self, zone_name, relative_record_name, record_type):
+    def get_dns_record(self, zone_name: str, relative_record_name: str,
+                       record_type: str) -> Any:
         return self.dns_client.record_sets.get(
             self.resource_group, zone_name, relative_record_name, record_type)
 
-    def list_dns_records(self, zone_name):
+    def list_dns_records(self, zone_name: str) -> list[Any]:
         return list(self.dns_client.record_sets.list_all_by_dns_zone(
             self.resource_group, zone_name))
 
-    def create_dns_record(self, zone_name, relative_record_name,
-                          record_type, params):
+    def create_dns_record(self, zone_name: str, relative_record_name: str,
+                          record_type: str, params: dict[str, Any]) -> Any:
         from azure.mgmt.dns.models import RecordSet
         return self.dns_client.record_sets.create_or_update(
             self.resource_group, zone_name, relative_record_name,
             record_type, RecordSet(**params))
 
-    def delete_dns_record(self, zone_name, relative_record_name, record_type):
+    def delete_dns_record(self, zone_name: str, relative_record_name: str,
+                          record_type: str) -> None:
         self.dns_client.record_sets.delete(
             self.resource_group, zone_name, relative_record_name, record_type)

--- a/cloudbridge/providers/azure/helpers.py
+++ b/cloudbridge/providers/azure/helpers.py
@@ -1,4 +1,5 @@
 import re
+from typing import Any
 
 from cloudbridge.interfaces.exceptions import InvalidValueException
 
@@ -6,7 +7,7 @@ from cloudbridge.interfaces.exceptions import InvalidValueException
 _RG_NAME_RE = re.compile(r'(/resourceGroups/)([^/]+)', re.IGNORECASE)
 
 
-def normalize_rg_case(azure_id):
+def normalize_rg_case(azure_id: str | None) -> str | None:
     # Microsoft.Compute/images list_by_resource_group returns the RG segment
     # in a case that can differ from what create/get echo back (we've seen
     # uppercase from list, lowercase from create/get for the same RG).
@@ -38,7 +39,7 @@ def normalize_rg_case(azure_id):
 #         return list_items
 
 
-def parse_url(template_urls, original_url):
+def parse_url(template_urls: list[str], original_url: str) -> dict[str, str]:
     """
     In Azure all the resource IDs are returned as URIs.
     ex: '/subscriptions/{subscriptionId}/resourceGroups/' \
@@ -52,7 +53,7 @@ def parse_url(template_urls, original_url):
     https://docs.microsoft.com/en-us/azure/virtual-machines/linux/cli-ps-findimage
     """
     if not original_url:
-        raise InvalidValueException(template_urls, original_url)
+        raise InvalidValueException(str(template_urls), original_url)
     original_url_parts = original_url.split('/')
     if len(original_url_parts) == 1:
         original_url_parts = original_url.split(':')
@@ -63,15 +64,15 @@ def parse_url(template_urls, original_url):
         if len(template_url_parts) == len(original_url_parts):
             break
     if len(template_url_parts) != len(original_url_parts):
-        raise InvalidValueException(template_urls, original_url)
-    resource_param = {}
+        raise InvalidValueException(str(template_urls), original_url)
+    resource_param: dict[str, str] = {}
     for key, value in zip(template_url_parts, original_url_parts):
         if key.startswith('{') and key.endswith('}'):
             resource_param.update({key[1:-1]: value})
     return resource_param
 
 
-def generate_urn(gallery_image):
+def generate_urn(gallery_image: Any) -> str:
     """
     This function takes an azure gallery image and outputs a corresponding URN
     :param gallery_image: a GalleryImageReference object

--- a/cloudbridge/providers/azure/provider.py
+++ b/cloudbridge/providers/azure/provider.py
@@ -1,5 +1,6 @@
 import logging
 import uuid
+from typing import Any
 
 from azure.core.exceptions import HttpResponseError
 from azure.core.exceptions import ResourceNotFoundError
@@ -12,6 +13,11 @@ import cloudbridge
 from cloudbridge.base import BaseCloudProvider
 from cloudbridge.base.helpers import get_env
 from cloudbridge.interfaces.exceptions import ProviderConnectionException
+from cloudbridge.interfaces.services import ComputeService
+from cloudbridge.interfaces.services import DnsService
+from cloudbridge.interfaces.services import NetworkingService
+from cloudbridge.interfaces.services import SecurityService
+from cloudbridge.interfaces.services import StorageService
 from cloudbridge.providers.azure.azure_client import AzureClient
 
 from .services import AzureComputeService
@@ -24,9 +30,9 @@ log = logging.getLogger(__name__)
 
 
 class AzureCloudProvider(BaseCloudProvider):
-    PROVIDER_ID = 'azure'
+    PROVIDER_ID: str = 'azure'
 
-    def __init__(self, config):
+    def __init__(self, config: dict[str, Any]) -> None:
         super(AzureCloudProvider, self).__init__(config)
 
         # mandatory config values
@@ -74,7 +80,7 @@ class AzureCloudProvider(BaseCloudProvider):
             'azure_public_key_storage_table_name', get_env(
                 'AZURE_PUBLIC_KEY_STORAGE_TABLE_NAME', 'cbcerts'))
 
-        self._azure_client = None
+        self._azure_client: AzureClient | None = None
 
         self._security = AzureSecurityService(self)
         self._storage = AzureStorageService(self)
@@ -82,7 +88,7 @@ class AzureCloudProvider(BaseCloudProvider):
         self._networking = AzureNetworkingService(self)
         self._dns = AzureDnsService(self)
 
-    def __get_deprecated_username(self, default):
+    def __get_deprecated_username(self, default: str) -> str:
         username = self._get_config_value(
             'azure_vm_default_user_name', get_env(
                 'AZURE_VM_DEFAULT_USER_NAME', None))
@@ -96,31 +102,31 @@ class AzureCloudProvider(BaseCloudProvider):
                 current_version=cloudbridge.__version__,
                 details='AZURE_VM_DEFAULT_USER_NAME was deprecated in favor '
                         'of AZURE_VM_DEFAULT_USERNAME')
-    def __wrap_deprecated_username(self, username):
+    def __wrap_deprecated_username(self, username: str) -> str:
         return username
 
     @property
-    def compute(self):
+    def compute(self) -> ComputeService:
         return self._compute
 
     @property
-    def networking(self):
+    def networking(self) -> NetworkingService:
         return self._networking
 
     @property
-    def security(self):
+    def security(self) -> SecurityService:
         return self._security
 
     @property
-    def storage(self):
+    def storage(self) -> StorageService:
         return self._storage
 
     @property
-    def dns(self):
+    def dns(self) -> DnsService:
         return self._dns
 
     @property
-    def azure_client(self):
+    def azure_client(self) -> Any:
         if not self._azure_client:
 
             # create a dict with both optional and mandatory configuration
@@ -148,12 +154,16 @@ class AzureCloudProvider(BaseCloudProvider):
     @tenacity.retry(stop=tenacity.stop_after_attempt(2),
                     retry=tenacity.retry_if_exception_type(HttpResponseError),
                     reraise=True)
-    def _initialize(self):
+    def _initialize(self) -> None:
         """
         Verifying that resource group and storage account exists
         if not create one with the name provided in the
         configuration
         """
+        # ``_initialize`` is only ever invoked by the ``azure_client`` property
+        # immediately after assigning ``self._azure_client``, so the client is
+        # guaranteed to be set here.
+        assert self._azure_client is not None
         try:
             self._azure_client.get_resource_group(self.resource_group)
 
@@ -164,7 +174,7 @@ class AzureCloudProvider(BaseCloudProvider):
                     create_resource_group(self.resource_group,
                                           resource_group_params)
             except HttpResponseError as cloud_error2:  # pragma: no cover
-                if getattr(cloud_error2, 'error', None) and \
+                if cloud_error2.error and \
                         cloud_error2.error.code == "AuthorizationFailed":
                     mess = 'The following error was returned by Azure:\n' \
                            '%s\n\nThis is likely because the Role' \

--- a/cloudbridge/providers/azure/resources.py
+++ b/cloudbridge/providers/azure/resources.py
@@ -1,106 +1,150 @@
 """
 DataTypes used by this provider
 """
+from __future__ import annotations
+
 import collections
 import io
 import logging
+from datetime import datetime
+from typing import Any
+from typing import IO
+from typing import Iterable
+from typing import Iterator
+from typing import TYPE_CHECKING
+from typing import cast
 
-import paramiko
-from cloudbridge.base.resources import (BaseAttachmentInfo, BaseBucket,
-                                        BaseBucketObject, BaseDnsRecord,
-                                        BaseDnsZone, BaseFloatingIP,
-                                        BaseInstance, BaseInternetGateway,
-                                        BaseKeyPair, BaseLaunchConfig,
-                                        BaseMachineImage, BaseNetwork,
-                                        BasePlacementZone, BaseRegion,
-                                        BaseRouter, BaseSnapshot, BaseSubnet,
-                                        BaseVMFirewall, BaseVMFirewallRule,
-                                        BaseVMType, BaseVolume)
-from cloudbridge.interfaces import InstanceState, VolumeState
-from cloudbridge.interfaces.resources import (Instance, MachineImageState,
-                                              NetworkState, RouterState,
-                                              SnapshotState, SubnetState,
-                                              TrafficDirection)
-
-from azure.common import AzureException
 from azure.core.exceptions import ResourceNotFoundError
-from azure.mgmt.compute.models import (DataDisk, ManagedDiskParameters,
-                                       SubResource as ComputeSubResource)
+from azure.mgmt.compute.models import DataDisk
+from azure.mgmt.compute.models import ManagedDiskParameters
+from azure.mgmt.compute.models import SubResource as ComputeSubResource
 from azure.mgmt.devtestlabs.models import GalleryImageReference
 from azure.mgmt.network.models import NetworkSecurityGroup
 
+import paramiko
+
+from cloudbridge.base.resources import BaseAttachmentInfo
+from cloudbridge.base.resources import BaseBucket
+from cloudbridge.base.resources import BaseBucketObject
+from cloudbridge.base.resources import BaseDnsRecord
+from cloudbridge.base.resources import BaseDnsZone
+from cloudbridge.base.resources import BaseFloatingIP
+from cloudbridge.base.resources import BaseInstance
+from cloudbridge.base.resources import BaseInternetGateway
+from cloudbridge.base.resources import BaseKeyPair
+from cloudbridge.base.resources import BaseLaunchConfig
+from cloudbridge.base.resources import BaseMachineImage
+from cloudbridge.base.resources import BaseNetwork
+from cloudbridge.base.resources import BasePlacementZone
+from cloudbridge.base.resources import BaseRegion
+from cloudbridge.base.resources import BaseRouter
+from cloudbridge.base.resources import BaseSnapshot
+from cloudbridge.base.resources import BaseSubnet
+from cloudbridge.base.resources import BaseVMFirewall
+from cloudbridge.base.resources import BaseVMFirewallRule
+from cloudbridge.base.resources import BaseVMType
+from cloudbridge.base.resources import BaseVolume
+from cloudbridge.interfaces import InstanceState
+from cloudbridge.interfaces import VolumeState
+from cloudbridge.interfaces.exceptions import ProviderInternalException
+from cloudbridge.interfaces.resources import AttachmentInfo
+from cloudbridge.interfaces.resources import BucketObject
+from cloudbridge.interfaces.resources import FloatingIP
+from cloudbridge.interfaces.resources import Gateway
+from cloudbridge.interfaces.resources import Instance
+from cloudbridge.interfaces.resources import MachineImage
+from cloudbridge.interfaces.resources import MachineImageState
+from cloudbridge.interfaces.resources import NetworkState
+from cloudbridge.interfaces.resources import PlacementZone
+from cloudbridge.interfaces.resources import RouterState
+from cloudbridge.interfaces.resources import Snapshot
+from cloudbridge.interfaces.resources import SnapshotState
+from cloudbridge.interfaces.resources import Subnet
+from cloudbridge.interfaces.resources import SubnetState
+from cloudbridge.interfaces.resources import TrafficDirection
+from cloudbridge.interfaces.resources import UploadConfig
+from cloudbridge.interfaces.resources import VMFirewall
+from cloudbridge.interfaces.resources import VMType
+from cloudbridge.interfaces.resources import Volume
+
 from . import helpers as azure_helpers
-from .subservices import (AzureBucketObjectSubService,
-                          AzureDnsRecordSubService,
-                          AzureFloatingIPSubService, AzureGatewaySubService,
-                          AzureSubnetSubService, AzureVMFirewallRuleSubService)
+from .subservices import AzureBucketObjectSubService
+from .subservices import AzureDnsRecordSubService
+from .subservices import AzureFloatingIPSubService
+from .subservices import AzureGatewaySubService
+from .subservices import AzureSubnetSubService
+from .subservices import AzureVMFirewallRuleSubService
+
+if TYPE_CHECKING:
+    from cloudbridge.providers.azure.provider import AzureCloudProvider
 
 log = logging.getLogger(__name__)
 
 
 class AzureVMFirewall(BaseVMFirewall):
-    def __init__(self, provider, vm_firewall):
+    def __init__(self, provider: AzureCloudProvider, vm_firewall: Any) -> None:
         super(AzureVMFirewall, self).__init__(provider, vm_firewall)
         self._vm_firewall = vm_firewall
         self._vm_firewall.tags = self._vm_firewall.tags or {}
         self._rule_container = AzureVMFirewallRuleSubService(provider, self)
 
     @property
-    def network_id(self):
+    def network_id(self) -> str | None:
         return self._vm_firewall.tags.get('network_id', None)
 
     @property
-    def resource_id(self):
+    def resource_id(self) -> str:
         return self._vm_firewall.id
 
     @property
-    def id(self):
+    def id(self) -> str:
         return self._vm_firewall.id
 
     @property
-    def name(self):
+    def name(self) -> str:
         return self._vm_firewall.name
 
     @property
-    def label(self):
+    def label(self) -> str | None:
         return self._vm_firewall.tags.get('Label', None)
 
     @label.setter
-    def label(self, value):
+    def label(self, value: str) -> None:
         self.assert_valid_resource_label(value)
         self._vm_firewall.tags.update(Label=value or "")
-        self._provider.azure_client.update_vm_firewall_tags(
-            self.id, self._vm_firewall.tags)
+        cast("AzureCloudProvider", self._provider).azure_client \
+            .update_vm_firewall_tags(self.id, self._vm_firewall.tags)
 
     @property
-    def description(self):
+    def description(self) -> str | None:
         return self._vm_firewall.tags.get('Description')
 
     @description.setter
-    def description(self, value):
+    def description(self, value: str) -> None:
         self._vm_firewall.tags.update(Description=value or "")
-        self._provider.azure_client.\
+        cast("AzureCloudProvider", self._provider).azure_client. \
             update_vm_firewall_tags(self.id,
                                     self._vm_firewall.tags)
 
     @property
-    def rules(self):
+    def rules(self) -> AzureVMFirewallRuleSubService:
         return self._rule_container
 
-    def refresh(self):
+    def refresh(self) -> None:
         """
         Refreshes the security group with tags if required.
         """
         try:
-            self._vm_firewall = self._provider.azure_client. \
+            self._vm_firewall = cast(
+                "AzureCloudProvider", self._provider).azure_client. \
                 get_vm_firewall(self.id)
             if not self._vm_firewall.tags:
                 self._vm_firewall.tags = {}
         except (ResourceNotFoundError, ValueError) as cloud_error:
-            log.exception(cloud_error.message)
+            log.exception(cloud_error)
             # The security group no longer exists and cannot be refreshed.
 
-    def to_json(self):
+    def to_json(self) -> dict[str, Any]:
         js = super(AzureVMFirewall, self).to_json()
         json_rules = [r.to_json() for r in self.rules]
         js['rules'] = json_rules
@@ -114,36 +158,40 @@ PortRange = collections.namedtuple('PortRange', ['from_port', 'to_port'])
 
 
 class AzureVMFirewallRule(BaseVMFirewallRule):
-    def __init__(self, parent_fw, rule):
+    def __init__(self, parent_fw: VMFirewall, rule: Any) -> None:
         super(AzureVMFirewallRule, self).__init__(parent_fw, rule)
 
     @property
-    def id(self):
+    def id(self) -> str:
         return self._rule.id
 
     @property
-    def name(self):
+    def name(self) -> str:
         return self._rule.name
 
     @property
-    def direction(self):
-        return (TrafficDirection.INBOUND if self._rule.direction == "Inbound"
-                else TrafficDirection.OUTBOUND)
+    def direction(self) -> TrafficDirection:
+        if self._rule.direction == "Inbound":
+            return TrafficDirection.INBOUND
+        elif self._rule.direction == "Outbound":
+            return TrafficDirection.OUTBOUND
+        raise ProviderInternalException(
+            "Unknown traffic direction: {0}".format(self._rule.direction))
 
     @property
-    def protocol(self):
+    def protocol(self) -> str | None:
         return self._rule.protocol
 
     @property
-    def from_port(self):
+    def from_port(self) -> int:
         return self._port_range_tuple.from_port
 
     @property
-    def to_port(self):
+    def to_port(self) -> int:
         return self._port_range_tuple.to_port
 
     @property
-    def _port_range_tuple(self):
+    def _port_range_tuple(self) -> PortRange:
         if self._rule.destination_port_range == '*':
             return PortRange(1, 65535)
         destination_port_range = self._rule.destination_port_range
@@ -151,66 +199,67 @@ class AzureVMFirewallRule(BaseVMFirewallRule):
         return PortRange(int(port_range_split[0]), int(port_range_split[1]))
 
     @property
-    def cidr(self):
+    def cidr(self) -> str | None:
         return self._rule.source_address_prefix
 
     @property
-    def src_dest_fw_id(self):
+    def src_dest_fw_id(self) -> str | None:
         return self.firewall.id
 
     @property
-    def src_dest_fw(self):
+    def src_dest_fw(self) -> VMFirewall | None:
         return self.firewall
 
 
 class AzureBucketObject(BaseBucketObject):
-    def __init__(self, provider, container, blob_properties):
+    def __init__(self, provider: AzureCloudProvider, container: AzureBucket,
+                 blob_properties: Any) -> None:
         super(AzureBucketObject, self).__init__(provider)
         self._container = container
         self._blob_properties = blob_properties
 
     @property
-    def _blob_client(self):
+    def _blob_client(self) -> Any:
         return self._container._bucket.get_blob_client(self.name)
 
     @property
-    def id(self):
+    def id(self) -> str:
         return self._blob_properties.name
 
     @property
-    def name(self):
+    def name(self) -> str:
         return self._blob_properties.name
 
     @property
-    def size(self):
+    def size(self) -> int:
         """
         Get this object's size.
         """
         return self._blob_properties.size
 
     @property
-    def last_modified(self):
+    def last_modified(self) -> str:
 
         """
         Get the date and time this object was last modified.
         """
         return self._blob_properties.last_modified.strftime("%Y-%m-%dT%H:%M:%S.%f")
 
-    def iter_content(self):
+    def iter_content(self) -> Iterable[bytes]:
         """
         Returns this object's content as an
         iterable stream.
         """
 
-        def iterable_to_stream(iterable):
+        def iterable_to_stream(iterable: Iterator[bytes]) -> io.RawIOBase:
             class IterStream(io.RawIOBase):
-                def __init__(self):
-                    self.leftover = None
+                def __init__(self) -> None:
+                    self.leftover: bytes | None = None
 
-                def readable(self):
+                def readable(self) -> bool:
                     return True
 
-                def readinto(self, b):
+                def readinto(self, b: Any) -> int:
                     try:
                         buffer_length = len(b)  # We're supposed to return at most this much
                         chunk = self.leftover or next(iterable)
@@ -222,45 +271,38 @@ class AzureBucketObject(BaseBucketObject):
 
             return IterStream()
 
-        def blob_iterator():
+        def blob_iterator() -> Iterator[bytes]:
             for chunk in self._blob_client.download_blob().chunks():
                 yield chunk
 
         return iterable_to_stream(blob_iterator())
 
     @property
-    def bucket(self):
+    def bucket(self) -> AzureBucket:
         return self._container
 
-    def _upload_single_shot(self, data):
+    def _upload_single_shot(self, data: str | bytes | IO[bytes]) -> BucketObject:
         """
         Upload the object in a single request. ``data`` may be text, bytes or
         a file-like object; the Azure SDK streams file-like data rather than
         buffering it all in memory. Larger uploads are handled transparently
         by the base class via the multipart path.
         """
-        try:
-            self._provider.azure_client.upload_blob(
-                self._container.id, self.id, data)
-            return True
-        except AzureException as azureEx:
-            log.exception(azureEx)
-            return False
+        cast("AzureCloudProvider", self._provider).azure_client.upload_blob(
+            self._container.id, self.id, data)
+        return self
 
-    def _upload_multipart(self, stream, config=None):
+    def _upload_multipart(self, stream: IO[bytes],
+                          config: UploadConfig | None = None) -> BucketObject:
         # The Azure SDK's upload_blob stages blocks concurrently (max_concurrency
         # workers) over a thread-safe client, so the transparent multipart path
         # delegates to it rather than CloudBridge's generic clone-pool driver.
-        try:
-            self._provider.azure_client.upload_blob(
-                self._container.id, self.id, stream,
-                max_concurrency=self._multipart_max_concurrency(config))
-            return True
-        except AzureException as azureEx:
-            log.exception(azureEx)
-            return False
+        cast("AzureCloudProvider", self._provider).azure_client.upload_blob(
+            self._container.id, self.id, stream,
+            max_concurrency=self._multipart_max_concurrency(config))
+        return self
 
-    def delete(self):
+    def delete(self) -> None:
         """
         Delete this object.
 
@@ -269,25 +311,26 @@ class AzureBucketObject(BaseBucketObject):
         """
         self._blob_client.delete_blob()
 
-    def generate_url(self, expires_in, writable=False):
+    def generate_url(self, expires_in: int, writable: bool = False) -> str:
         """
         Generate a URL to this object.
         """
-        return self._provider.azure_client.get_blob_url(
+        return cast(
+            "AzureCloudProvider", self._provider).azure_client.get_blob_url(
             self._container, self.name, expires_in, writable)
 
-    def refresh(self):
+    def refresh(self) -> None:
         pass
 
 
 class AzureBucket(BaseBucket):
-    def __init__(self, provider, bucket):
+    def __init__(self, provider: AzureCloudProvider, bucket: Any) -> None:
         super(AzureBucket, self).__init__(provider)
         self._bucket = bucket
         self._object_container = AzureBucketObjectSubService(provider, self)
 
     @property
-    def id(self):
+    def id(self) -> str:
         try:
             name = self._bucket.name
         except AttributeError:
@@ -295,7 +338,7 @@ class AzureBucket(BaseBucket):
         return name
 
     @property
-    def name(self):
+    def name(self) -> str:
         """
         Get this bucket's name.
 
@@ -309,19 +352,19 @@ class AzureBucket(BaseBucket):
             name = self._bucket.container_name
         return name
 
-    def exists(self, name):
+    def exists(self, name: str) -> bool:
         """
         Determine if an object with given name exists in this bucket.
         """
-        return True if self.get(name) else False
+        return True if self.objects.get(name) else False
 
     @property
-    def objects(self):
+    def objects(self) -> AzureBucketObjectSubService:
         return self._object_container
 
 
 class AzureVolume(BaseVolume):
-    VOLUME_STATE_MAP = {
+    VOLUME_STATE_MAP: dict[str, str] = {
         'InProgress': VolumeState.CREATING,
         'Creating': VolumeState.CREATING,
         'Unattached': VolumeState.AVAILABLE,
@@ -333,16 +376,16 @@ class AzureVolume(BaseVolume):
         'Canceled': VolumeState.ERROR
     }
 
-    def __init__(self, provider, volume):
+    def __init__(self, provider: AzureCloudProvider, volume: Any) -> None:
         super(AzureVolume, self).__init__(provider)
         self._volume = volume
-        self._description = None
+        self._description: str | None = None
         self._state = 'unknown'
         self._update_state()
         if not self._volume.tags:
             self._volume.tags = {}
 
-    def _update_state(self):
+    def _update_state(self) -> None:
         if not self._volume.provisioning_state == 'Succeeded':
             self._state = self._volume.provisioning_state
         elif self._volume.managed_by:
@@ -351,23 +394,23 @@ class AzureVolume(BaseVolume):
             self._state = 'Unattached'
 
     @property
-    def id(self):
+    def id(self) -> str:
         return self._volume.id
 
     @property
-    def resource_id(self):
+    def resource_id(self) -> str:
         return self._volume.id
 
     @property
-    def name(self):
+    def name(self) -> str:
         return self._volume.name
 
     @property
-    def tags(self):
+    def tags(self) -> dict[str, str]:
         return self._volume.tags
 
     @property
-    def label(self):
+    def label(self) -> str | None:
         """
         Get the volume label.
 
@@ -377,45 +420,45 @@ class AzureVolume(BaseVolume):
 
     @label.setter
     # pylint:disable=arguments-differ
-    def label(self, value):
+    def label(self, value: str) -> None:
         """
         Set the volume label.
         """
         self.assert_valid_resource_label(value)
         self._volume.tags.update(Label=value or "")
-        self._provider.azure_client. \
+        cast("AzureCloudProvider", self._provider).azure_client. \
             update_disk_tags(self.id,
                              self._volume.tags)
 
     @property
-    def description(self):
+    def description(self) -> str:
         return self._volume.tags.get('Description', None)
 
     @description.setter
-    def description(self, value):
+    def description(self, value: str) -> None:
         self._volume.tags.update(Description=value or "")
-        self._provider.azure_client. \
+        cast("AzureCloudProvider", self._provider).azure_client. \
             update_disk_tags(self.id,
                              self._volume.tags)
 
     @property
-    def size(self):
+    def size(self) -> int:
         return self._volume.disk_size_gb
 
     @property
-    def create_time(self):
+    def create_time(self) -> str:
         return self._volume.time_created.strftime("%Y-%m-%dT%H:%M:%S.%f")
 
     @property
-    def zone_id(self):
+    def zone_id(self) -> str:
         return self._volume.location
 
     @property
-    def source(self):
+    def source(self) -> Snapshot | MachineImage | None:
         return self._volume.creation_data.source_uri
 
     @property
-    def attachments(self):
+    def attachments(self) -> AttachmentInfo | None:
         """
         Azure does not have option to specify the device name
         while attaching disk to VM. It is automatically populated
@@ -429,14 +472,15 @@ class AzureVolume(BaseVolume):
         else:
             return None
 
-    def attach(self, instance, device=None):
+    def attach(self, instance: str | Instance, device: str) -> None:
         """
         Attach this volume to an instance.
         """
         instance_id = instance.id if isinstance(
             instance,
             Instance) else instance
-        vm = self._provider.azure_client.get_vm(instance_id)
+        vm = cast("AzureCloudProvider", self._provider).azure_client.get_vm(
+            instance_id)
 
         vm.storage_profile.data_disks.append(DataDisk(
             lun=len(vm.storage_profile.data_disks),
@@ -444,20 +488,23 @@ class AzureVolume(BaseVolume):
             create_option='attach',
             managed_disk=ManagedDiskParameters(id=self.resource_id)
         ))
-        self._provider.azure_client.update_vm(instance_id, vm)
+        cast("AzureCloudProvider", self._provider).azure_client.update_vm(
+            instance_id, vm)
 
-    def detach(self, force=False):
+    def detach(self, force: bool = False) -> None:
         """
         Detach this volume from an instance.
         """
-        for vm in self._provider.azure_client.list_vm():
+        azure_client = cast("AzureCloudProvider", self._provider).azure_client
+        for vm in azure_client.list_vm():
             for item in vm.storage_profile.data_disks:
                 if item.managed_disk and \
                         item.managed_disk.id == self.resource_id:
                     vm.storage_profile.data_disks.remove(item)
-                    self._provider.azure_client.update_vm(vm.id, vm)
+                    azure_client.update_vm(vm.id, vm)
 
-    def create_snapshot(self, label, description=None):
+    def create_snapshot(self, label: str,
+                        description: str | None = None) -> Snapshot:
         """
         Create a snapshot of this Volume.
         """
@@ -465,28 +512,29 @@ class AzureVolume(BaseVolume):
                                                        description)
 
     @property
-    def state(self):
+    def state(self) -> str:
         return AzureVolume.VOLUME_STATE_MAP.get(
             self._state, VolumeState.UNKNOWN)
 
-    def refresh(self):
+    def refresh(self) -> None:
         """
         Refreshes the state of this volume by re-querying the cloud provider
         for its latest state.
         """
         try:
-            self._volume = self._provider.azure_client. \
+            self._volume = cast(
+                "AzureCloudProvider", self._provider).azure_client. \
                 get_disk(self.id)
             self._update_state()
         except (ResourceNotFoundError, ValueError) as cloud_error:
-            log.exception(cloud_error.message)
+            log.exception(cloud_error)
             # The volume no longer exists and cannot be refreshed.
             # set the state to unknown
             self._state = 'unknown'
 
 
 class AzureSnapshot(BaseSnapshot):
-    SNAPSHOT_STATE_MAP = {
+    SNAPSHOT_STATE_MAP: dict[str, str] = {
         'InProgress': SnapshotState.PENDING,
         'Succeeded': SnapshotState.AVAILABLE,
         'Failed': SnapshotState.ERROR,
@@ -496,28 +544,28 @@ class AzureSnapshot(BaseSnapshot):
         'Deleted': SnapshotState.UNKNOWN
     }
 
-    def __init__(self, provider, snapshot):
+    def __init__(self, provider: AzureCloudProvider, snapshot: Any) -> None:
         super(AzureSnapshot, self).__init__(provider)
         self._snapshot = snapshot
-        self._description = None
+        self._description: str | None = None
         self._state = self._snapshot.provisioning_state
         if not self._snapshot.tags:
             self._snapshot.tags = {}
 
     @property
-    def id(self):
+    def id(self) -> str:
         return self._snapshot.id
 
     @property
-    def name(self):
+    def name(self) -> str:
         return self._snapshot.name
 
     @property
-    def resource_id(self):
+    def resource_id(self) -> str:
         return self._snapshot.id
 
     @property
-    def label(self):
+    def label(self) -> str | None:
         """
         Get the snapshot label.
 
@@ -527,60 +575,63 @@ class AzureSnapshot(BaseSnapshot):
 
     @label.setter
     # pylint:disable=arguments-differ
-    def label(self, value):
+    def label(self, value: str) -> None:
         """
         Set the snapshot label.
         """
         self.assert_valid_resource_label(value)
         self._snapshot.tags.update(Label=value or "")
-        self._provider.azure_client. \
+        cast("AzureCloudProvider", self._provider).azure_client. \
             update_snapshot_tags(self.id,
                                  self._snapshot.tags)
 
     @property
-    def description(self):
+    def description(self) -> str:
         return self._snapshot.tags.get('Description', None)
 
     @description.setter
-    def description(self, value):
+    def description(self, value: str) -> None:
         self._snapshot.tags.update(Description=value or "")
-        self._provider.azure_client. \
+        cast("AzureCloudProvider", self._provider).azure_client. \
             update_snapshot_tags(self.id,
                                  self._snapshot.tags)
 
     @property
-    def size(self):
+    def size(self) -> int:
         return self._snapshot.disk_size_gb
 
     @property
-    def volume_id(self):
+    def volume_id(self) -> str | None:
         return self._snapshot.creation_data.source_resource_id
 
     @property
-    def create_time(self):
+    def create_time(self) -> str:
         return self._snapshot.time_created.strftime("%Y-%m-%dT%H:%M:%S.%f")
 
     @property
-    def state(self):
+    def state(self) -> str:
         return AzureSnapshot.SNAPSHOT_STATE_MAP.get(
             self._state, SnapshotState.UNKNOWN)
 
-    def refresh(self):
+    def refresh(self) -> None:
         """
         Refreshes the state of this snapshot by re-querying the cloud provider
         for its latest state.
         """
         try:
-            self._snapshot = self._provider.azure_client. \
+            self._snapshot = cast(
+                "AzureCloudProvider", self._provider).azure_client. \
                 get_snapshot(self.id)
             self._state = self._snapshot.provisioning_state
         except (ResourceNotFoundError, ValueError) as cloud_error:
-            log.exception(cloud_error.message)
+            log.exception(cloud_error)
             # The snapshot no longer exists and cannot be refreshed.
             # set the state to unknown
             self._state = 'unknown'
 
-    def create_volume(self, size=None, volume_type=None, iops=None):
+    def create_volume(self, size: int | None = None,
+                      volume_type: str | None = None,
+                      iops: int | None = None) -> Volume:
         """
         Create a new Volume from this Snapshot.
         """
@@ -589,13 +640,13 @@ class AzureSnapshot(BaseSnapshot):
 
 
 class AzureMachineImage(BaseMachineImage):
-    IMAGE_STATE_MAP = {
+    IMAGE_STATE_MAP: dict[str, str] = {
         'InProgress': MachineImageState.PENDING,
         'Succeeded': MachineImageState.AVAILABLE,
         'Failed': MachineImageState.ERROR
     }
 
-    def __init__(self, provider, image):
+    def __init__(self, provider: AzureCloudProvider, image: Any) -> None:
         super(AzureMachineImage, self).__init__(provider)
         # Image can be either a dict for public image reference
         # or the Azure iamge object
@@ -608,7 +659,7 @@ class AzureMachineImage(BaseMachineImage):
                 self._image.tags = {}
 
     @property
-    def id(self):
+    def id(self) -> str:
         """
         Get the image identifier.
 
@@ -618,42 +669,45 @@ class AzureMachineImage(BaseMachineImage):
         if self.is_gallery_image:
             return azure_helpers.generate_urn(self._image)
         else:
-            return azure_helpers.normalize_rg_case(self._image.id)
+            image_id = azure_helpers.normalize_rg_case(self._image.id)
+            if not image_id:
+                raise ProviderInternalException("Image is missing an id")
+            return image_id
 
     @property
-    def name(self):
+    def name(self) -> str:
         if self.is_gallery_image:
             return azure_helpers.generate_urn(self._image)
         else:
             return self._image.name
 
     @property
-    def resource_id(self):
+    def resource_id(self) -> str:
         if self.is_gallery_image:
             return azure_helpers.generate_urn(self._image)
         else:
             return self._image.id
 
     @property
-    def label(self):
+    def label(self) -> str | None:
         if self.is_gallery_image:
             return azure_helpers.generate_urn(self._image)
         else:
             return self._image.tags.get('Label', None)
 
     @label.setter
-    def label(self, value):
+    def label(self, value: str) -> None:
         """
         Set the image label when it is a private image.
         """
         if not self.is_gallery_image:
             self.assert_valid_resource_label(value)
             self._image.tags.update(Label=value or "")
-            self._provider.azure_client. \
+            cast("AzureCloudProvider", self._provider).azure_client. \
                 update_image_tags(self.id, self._image.tags)
 
     @property
-    def description(self):
+    def description(self) -> str | None:
         """
         Get the image description.
 
@@ -667,17 +721,17 @@ class AzureMachineImage(BaseMachineImage):
             return self._image.tags.get('Description', None)
 
     @description.setter
-    def description(self, value):
+    def description(self, value: str) -> None:
         """
         Set the image description.
         """
         if not self.is_gallery_image:
             self._image.tags.update(Description=value or "")
-            self._provider.azure_client. \
+            cast("AzureCloudProvider", self._provider).azure_client. \
                 update_image_tags(self.id, self._image.tags)
 
     @property
-    def min_disk(self):
+    def min_disk(self) -> int | None:
         """
         Returns the minimum size of the disk that's required to
         boot this image (in GB).
@@ -692,15 +746,16 @@ class AzureMachineImage(BaseMachineImage):
         else:
             return self._image.storage_profile.os_disk.disk_size_gb or 0
 
-    def delete(self):
+    def delete(self) -> None:
         """
         Delete this image
         """
         if not self.is_gallery_image:
-            self._provider.azure_client.delete_image(self.id)
+            cast("AzureCloudProvider", self._provider).azure_client. \
+                delete_image(self.id)
 
     @property
-    def state(self):
+    def state(self) -> str:
         if self.is_gallery_image:
             return MachineImageState.AVAILABLE
         else:
@@ -708,35 +763,37 @@ class AzureMachineImage(BaseMachineImage):
                 self._state, MachineImageState.UNKNOWN)
 
     @property
-    def is_gallery_image(self):
+    def is_gallery_image(self) -> bool:
         """
         Returns true if the image is a public reference and false if it
         is a private image in the resource group.
         """
         return isinstance(self._image, GalleryImageReference)
 
-    def refresh(self):
+    def refresh(self) -> None:
         """
         Refreshes the state of this instance by re-querying the cloud provider
         for its latest state.
         """
         if not self.is_gallery_image:
             try:
-                self._image = self._provider.azure_client.get_image(self.id)
+                self._image = cast(
+                    "AzureCloudProvider", self._provider).azure_client. \
+                    get_image(self.id)
                 self._state = self._image.provisioning_state
             except ResourceNotFoundError as cloud_error:
-                log.exception(cloud_error.message)
+                log.exception(cloud_error)
                 # image no longer exists
                 self._state = "unknown"
 
 
 class AzureNetwork(BaseNetwork):
-    NETWORK_STATE_MAP = {
+    NETWORK_STATE_MAP: dict[str, str] = {
         'InProgress': NetworkState.PENDING,
         'Succeeded': NetworkState.AVAILABLE,
     }
 
-    def __init__(self, provider, network):
+    def __init__(self, provider: AzureCloudProvider, network: Any) -> None:
         super(AzureNetwork, self).__init__(provider)
         self._network = network
         self._state = self._network.provisioning_state
@@ -746,19 +803,19 @@ class AzureNetwork(BaseNetwork):
         self._subnet_svc = AzureSubnetSubService(provider, self)
 
     @property
-    def id(self):
+    def id(self) -> str:
         return self._network.id
 
     @property
-    def name(self):
+    def name(self) -> str:
         return self._network.name
 
     @property
-    def resource_id(self):
+    def resource_id(self) -> str:
         return self._network.id
 
     @property
-    def label(self):
+    def label(self) -> str | None:
         """
         Get the network label.
 
@@ -768,17 +825,17 @@ class AzureNetwork(BaseNetwork):
 
     @label.setter
     # pylint:disable=arguments-differ
-    def label(self, value):
+    def label(self, value: str) -> None:
         """
         Set the network label.
         """
         self.assert_valid_resource_label(value)
         self._network.tags.update(Label=value or "")
-        self._provider.azure_client. \
+        cast("AzureCloudProvider", self._provider).azure_client. \
             update_network_tags(self.id, self._network.tags)
 
     @property
-    def external(self):
+    def external(self) -> bool:
         """
         For Azure, all VPC networks can be connected to the Internet so always
         return ``True``.
@@ -786,111 +843,117 @@ class AzureNetwork(BaseNetwork):
         return True
 
     @property
-    def state(self):
+    def state(self) -> str:
         return AzureNetwork.NETWORK_STATE_MAP.get(
             self._state, NetworkState.UNKNOWN)
 
-    def refresh(self):
+    def refresh(self) -> None:
         """
         Refreshes the state of this network by re-querying the cloud provider
         for its latest state.
         """
         try:
-            self._network = self._provider.azure_client.\
+            self._network = cast(
+                "AzureCloudProvider", self._provider).azure_client.\
                 get_network(self.id)
             self._state = self._network.provisioning_state
         except (ResourceNotFoundError, ValueError) as cloud_error:
-            log.exception(cloud_error.message)
+            log.exception(cloud_error)
             # The network no longer exists and cannot be refreshed.
             # set the state to unknown
             self._state = 'unknown'
 
     @property
-    def cidr_block(self):
+    def cidr_block(self) -> str:
         """
         Address space associated with this network
         :return:
         """
         return self._network.address_space.address_prefixes[0]
 
-    def delete(self):
+    def delete(self) -> None:
         """
         Delete an existing network.
         """
-        self._provider.azure_client.delete_network(self.id)
+        cast("AzureCloudProvider", self._provider).azure_client. \
+            delete_network(self.id)
 
     @property
-    def subnets(self):
+    def subnets(self) -> AzureSubnetSubService:
         return self._subnet_svc
 
     @property
-    def gateways(self):
+    def gateways(self) -> AzureGatewaySubService:
         return self._gateway_service
 
 
 class AzureFloatingIP(BaseFloatingIP):
 
-    def __init__(self, provider, floating_ip):
+    def __init__(self, provider: AzureCloudProvider,
+                 floating_ip: Any) -> None:
         super(AzureFloatingIP, self).__init__(provider)
         self._ip = floating_ip
 
     @property
-    def id(self):
+    def id(self) -> str:
         return self._ip.id
 
     @property
-    def name(self):
+    def name(self) -> str:
         return self._ip.ip_address
 
     @property
-    def resource_id(self):
+    def resource_id(self) -> str:
         return self._ip.id
 
     @property
-    def public_ip(self):
+    def public_ip(self) -> str:
         return self._ip.ip_address
 
     @property
-    def private_ip(self):
+    def private_ip(self) -> str | None:
         return self._ip.ip_configuration.private_ip_address \
             if self._ip.ip_configuration else None
 
     @property
-    def in_use(self):
+    def in_use(self) -> bool:
         return True if self._ip.ip_configuration else False
 
-    def refresh(self):
+    def refresh(self) -> None:
         # Gateway is not needed as it doesn't exist in Azure, so just
         # getting the Floating IP again from the client
         # pylint:disable=protected-access
-        fip = self._provider.networking._floating_ips.get(None, self.id)
+        fip = cast(AzureFloatingIP, self._provider.networking._floating_ips.get(
+            cast(Any, None), self.id))
         # pylint:disable=protected-access
         self._ip = fip._ip
 
 
 class AzureRegion(BaseRegion):
-    def __init__(self, provider, azure_region):
+    def __init__(self, provider: AzureCloudProvider,
+                 azure_region: Any) -> None:
         super(AzureRegion, self).__init__(provider)
         self._azure_region = azure_region
 
     @property
-    def id(self):
+    def id(self) -> str:
         return self._azure_region.name
 
     @property
-    def name(self):
+    def name(self) -> str:
         return self._azure_region.name
 
     @property
-    def zones(self):
+    def zones(self) -> list[AzurePlacementZone]:
         """
             Access information about placement zones within this region.
             As Azure does not have this feature, mapping the region
             name as zone id and name.
         """
-        return [AzurePlacementZone(self._provider,
-                                   self._azure_region.name,
-                                   self._azure_region.name)]
+        return [AzurePlacementZone(
+            cast("AzureCloudProvider", self._provider),
+            self._azure_region.name,
+            self._azure_region.name)]
 
 
 class AzurePlacementZone(BasePlacementZone):
@@ -898,13 +961,14 @@ class AzurePlacementZone(BasePlacementZone):
     As Azure does not provide zones (limited support), we are mapping the
     region information in the zones.
     """
-    def __init__(self, provider, zone, region):
+    def __init__(self, provider: AzureCloudProvider, zone: str,
+                 region: str) -> None:
         super(AzurePlacementZone, self).__init__(provider)
         self._azure_zone = zone
         self._azure_region = region
 
     @property
-    def id(self):
+    def id(self) -> str:
         """
             Get the zone id
             :rtype: ``str``
@@ -913,7 +977,7 @@ class AzurePlacementZone(BasePlacementZone):
         return self._azure_zone
 
     @property
-    def name(self):
+    def name(self) -> str:
         """
             Get the zone name.
             :rtype: ``str``
@@ -922,7 +986,7 @@ class AzurePlacementZone(BasePlacementZone):
         return self._azure_region
 
     @property
-    def region_name(self):
+    def region_name(self) -> str:
         """
             Get the region that this zone belongs to.
             :rtype: ``str``
@@ -933,88 +997,92 @@ class AzurePlacementZone(BasePlacementZone):
 
 
 class AzureSubnet(BaseSubnet):
-    _SUBNET_STATE_MAP = {
+    _SUBNET_STATE_MAP: dict[str, str] = {
         'InProgress': SubnetState.PENDING,
         'Succeeded': SubnetState.AVAILABLE,
     }
 
-    def __init__(self, provider, subnet):
+    def __init__(self, provider: AzureCloudProvider, subnet: Any) -> None:
         super(AzureSubnet, self).__init__(provider)
         self._subnet = subnet
         self._state = self._subnet.provisioning_state
-        self._tag_name = None
+        self._tag_name: str | None = None
 
     @property
-    def id(self):
+    def id(self) -> str:
         return self._subnet.id
 
     @property
-    def name(self):
+    def name(self) -> str:
         net_name = self.network_id.split('/')[-1]
         sn_name = self._subnet.name
         return '{0}/{1}'.format(net_name, sn_name)
 
     @property
-    def label(self):
+    def label(self) -> str | None:
         # Although Subnet doesn't support labels, we use the parent Network's
         # tags to track the subnet's labels
         network = self.network
         # pylint:disable=protected-access
-        az_network = network._network
+        az_network = cast(AzureNetwork, network)._network
         return az_network.tags.get(self.tag_name, None)
 
     @label.setter
     # pylint:disable=arguments-differ
-    def label(self, value):
+    def label(self, value: str) -> None:
         self.assert_valid_resource_label(value)
         network = self.network
         # pylint:disable=protected-access
-        az_network = network._network
+        az_network = cast(AzureNetwork, network)._network
         kwargs = {self.tag_name: value or ""}
         az_network.tags.update(**kwargs)
-        self._provider.azure_client.update_network_tags(
-            az_network.id, az_network.tags)
+        cast("AzureCloudProvider", self._provider).azure_client \
+            .update_network_tags(az_network.id, az_network.tags)
 
     @property
-    def tag_name(self):
+    def tag_name(self) -> str:
         if not self._tag_name:
             self._tag_name = 'SubnetLabel_{0}'.format(self._subnet.name)
         return self._tag_name
 
     @property
-    def resource_id(self):
+    def resource_id(self) -> str:
         return self._subnet.id
 
     @property
-    def zone(self):
+    def zone(self) -> PlacementZone | None:
         # pylint:disable=protected-access
         region = self._provider.compute.regions.get(
-            self.network._network.location)
-        return region.zones[0]
+            cast(AzureNetwork, self.network)._network.location)
+        if not region:
+            return None
+        return list(region.zones)[0]
 
     @property
-    def cidr_block(self):
+    def cidr_block(self) -> str:
         return self._subnet.address_prefix
 
     @property
-    def network_id(self):
-        return self._provider.azure_client.get_network_id_for_subnet(self.id)
+    def network_id(self) -> str:
+        return cast("AzureCloudProvider", self._provider).azure_client \
+            .get_network_id_for_subnet(self.id)
 
     @property
-    def state(self):
+    def state(self) -> str:
         return self._SUBNET_STATE_MAP.get(self._state, NetworkState.UNKNOWN)
 
-    def refresh(self):
+    def refresh(self) -> None:
         """
         Refreshes the state of this network by re-querying the cloud provider
         for its latest state.
         """
         try:
-            self._subnet = self._provider.azure_client. \
+            self._subnet = cast(
+                "AzureCloudProvider", self._provider).azure_client. \
                 get_subnet(self.id)
             self._state = self._subnet.provisioning_state
         except (ResourceNotFoundError, ValueError) as cloud_error:
-            log.exception(cloud_error.message)
+            log.exception(cloud_error)
             # The subnet no longer exists and cannot be refreshed.
             # set the state to unknown
             self._state = 'unknown'
@@ -1022,7 +1090,7 @@ class AzureSubnet(BaseSubnet):
 
 class AzureInstance(BaseInstance):
 
-    INSTANCE_STATE_MAP = {
+    INSTANCE_STATE_MAP: dict[str, str] = {
         'InProgress': InstanceState.PENDING,
         'Creating': InstanceState.PENDING,
         'VM running': InstanceState.RUNNING,
@@ -1040,7 +1108,8 @@ class AzureInstance(BaseInstance):
         'VM starting': InstanceState.CONFIGURING
     }
 
-    def __init__(self, provider, vm_instance):
+    def __init__(self, provider: AzureCloudProvider,
+                 vm_instance: Any) -> None:
         super(AzureInstance, self).__init__(provider)
         self._vm = vm_instance
         self._update_state()
@@ -1048,41 +1117,42 @@ class AzureInstance(BaseInstance):
             self._vm.tags = {}
 
     @property
-    def _nic_ids(self):
+    def _nic_ids(self) -> Iterator[str]:
         return (nic.id for nic in self._vm.network_profile.network_interfaces)
 
     @property
-    def _nics(self):
-        return (self._provider.azure_client.get_nic(nic_id)
+    def _nics(self) -> Iterator[Any]:
+        azure_client = cast("AzureCloudProvider", self._provider).azure_client
+        return (azure_client.get_nic(nic_id)
                 for nic_id in self._nic_ids)
 
     @property
-    def _public_ip_ids(self):
+    def _public_ip_ids(self) -> Iterator[str]:
         return (ip_config.public_ip_address.id
                 for nic in self._nics
                 for ip_config in nic.ip_configurations
                 if nic.ip_configurations and ip_config.public_ip_address)
 
     @property
-    def id(self):
+    def id(self) -> str:
         """
         Get the instance identifier.
         """
         return self._vm.id
 
     @property
-    def name(self):
+    def name(self) -> str:
         """
         Get the instance name.
         """
         return self._vm.name
 
     @property
-    def resource_id(self):
+    def resource_id(self) -> str:
         return self._vm.id
 
     @property
-    def label(self):
+    def label(self) -> str | None:
         """
         Get the instance label.
 
@@ -1092,25 +1162,26 @@ class AzureInstance(BaseInstance):
 
     @label.setter
     # pylint:disable=arguments-differ
-    def label(self, value):
+    def label(self, value: str) -> None:
         """
         Set the instance label.
         """
         self.assert_valid_resource_label(value)
         self._vm.tags.update(Label=value or "")
-        self._provider.azure_client. \
+        cast("AzureCloudProvider", self._provider).azure_client. \
             update_vm_tags(self.id, self._vm.tags)
 
     @property
-    def public_ips(self):
+    def public_ips(self) -> list[str]:
         """
         Get all the public IP addresses for this instance.
         """
-        return [self._provider.azure_client.get_floating_ip(pip).ip_address
+        azure_client = cast("AzureCloudProvider", self._provider).azure_client
+        return [azure_client.get_floating_ip(pip).ip_address
                 for pip in self._public_ip_ids]
 
     @property
-    def private_ips(self):
+    def private_ips(self) -> list[str]:
         """
         Get all the private IP addresses for this instance.
         """
@@ -1120,14 +1191,14 @@ class AzureInstance(BaseInstance):
                 if nic.ip_configurations and ip_config.private_ip_address]
 
     @property
-    def vm_type_id(self):
+    def vm_type_id(self) -> str:
         """
         Get the instance type name.
         """
         return self._vm.hardware_profile.vm_size
 
     @property
-    def vm_type(self):
+    def vm_type(self) -> VMType:
         """
         Get the instance type.
         """
@@ -1135,26 +1206,35 @@ class AzureInstance(BaseInstance):
             name=self.vm_type_id)[0]
 
     @property
-    def create_time(self):
+    def create_time(self) -> str | datetime:
         """
         Get the instance creation time
         """
         return self._vm.time_created
 
-    def reboot(self):
+    def reboot(self) -> None:
         """
         Reboot this instance (using the cloud middleware API).
         """
-        self._provider.azure_client.restart_vm(self.id)
+        cast("AzureCloudProvider", self._provider).azure_client. \
+            restart_vm(self.id)
 
-    def stop(self):
+    def start(self) -> None:
+        """
+        Start this instance (using the cloud middleware API).
+        """
+        cast("AzureCloudProvider", self._provider).azure_client. \
+            start_vm(self.id)
+
+    def stop(self) -> None:
         """
         Stop this instance (using the cloud middleware API).
         """
-        self._provider.azure_client.stop_vm(self.id)
+        cast("AzureCloudProvider", self._provider).azure_client. \
+            stop_vm(self.id)
 
     @property
-    def image_id(self):
+    def image_id(self) -> str:
         """
         Get the image ID for this instance.
         """
@@ -1169,14 +1249,14 @@ class AzureInstance(BaseInstance):
             return reference_dict['id']
 
     @property
-    def zone_id(self):
+    def zone_id(self) -> str:
         """
         Get the placement zone id where this instance is running.
         """
         return self._vm.location
 
     @property
-    def subnet_id(self):
+    def subnet_id(self) -> str:
         """
         Return the first subnet id associated with the first network iface.
 
@@ -1184,30 +1264,35 @@ class AzureInstance(BaseInstance):
         each interface having at most one subnet. This method will return only
         the subnet of the first attached network interface.
         """
+        azure_client = cast("AzureCloudProvider", self._provider).azure_client
         for nic_id in self._nic_ids:
-            nic = self._provider.azure_client.get_nic(nic_id)
+            nic = azure_client.get_nic(nic_id)
             for ipc in nic.ip_configurations:
                 return ipc.subnet.id
+        raise ProviderInternalException(
+            "Instance {0} has no subnet".format(self.id))
 
     @property
-    def vm_firewalls(self):
-        return [self._provider.security.vm_firewalls.get(group_id)
-                for group_id in self.vm_firewall_ids]
+    def vm_firewalls(self) -> list[VMFirewall]:
+        return cast("list[VMFirewall]", [
+            self._provider.security.vm_firewalls.get(group_id)
+            for group_id in self.vm_firewall_ids])
 
     @property
-    def vm_firewall_ids(self):
+    def vm_firewall_ids(self) -> list[str]:
         return [nic.network_security_group.id
                 for nic in self._nics
                 if nic.network_security_group]
 
     @property
-    def key_pair_id(self):
+    def key_pair_id(self) -> str | None:
         """
         Get the name of the key pair associated with this instance.
         """
         return self._vm.tags.get('Key_Pair')
 
-    def create_image(self, label, private_key_path=None):
+    def create_image(self, label: str,
+                     private_key_path: str | None = None) -> MachineImage:
         """
         Create a new image based on this instance. Documentation for create
         image available at https://docs.microsoft.com/en-us/azure/virtual-ma
@@ -1222,15 +1307,16 @@ class AzureInstance(BaseInstance):
 
         self.assert_valid_resource_label(label)
         name = self._generate_name_from_label(label, 'cb-img')
+        azure_client = cast("AzureCloudProvider", self._provider).azure_client
 
         if not self._state == 'VM generalized':
             if not self._state == 'VM running':
-                self._provider.azure_client.start_vm(self.id)
+                azure_client.start_vm(self.id)
 
             # if private_key_path:
             self._deprovision(private_key_path)
-            self._provider.azure_client.deallocate_vm(self.id)
-            self._provider.azure_client.generalize_vm(self.id)
+            azure_client.deallocate_vm(self.id)
+            azure_client.generalize_vm(self.id)
 
         create_params = {
             'location': self._provider.region_name,
@@ -1238,11 +1324,11 @@ class AzureInstance(BaseInstance):
             'tags': {'Label': label}
         }
 
-        image = self._provider.azure_client.create_image(name,
-                                                         create_params)
-        return AzureMachineImage(self._provider, image)
+        image = azure_client.create_image(name, create_params)
+        return AzureMachineImage(
+            cast("AzureCloudProvider", self._provider), image)
 
-    def _deprovision(self, private_key_path):
+    def _deprovision(self, private_key_path: str | None) -> None:
         if not private_key_path:
             return
         client = paramiko.SSHClient()
@@ -1250,13 +1336,15 @@ class AzureInstance(BaseInstance):
         try:
             client.connect(
                 hostname=self.public_ips[0],
-                username=self._provider.vm_default_user_name,
+                username=cast(
+                    "AzureCloudProvider",
+                    self._provider).vm_default_user_name,
                 key_filename=private_key_path)
             client.exec_command('sudo waagent -deprovision -force')
         finally:
             client.close()
 
-    def add_floating_ip(self, floating_ip):
+    def add_floating_ip(self, floating_ip: FloatingIP | str) -> None:
         """
         Attaches public ip to the instance.
         """
@@ -1266,9 +1354,10 @@ class AzureInstance(BaseInstance):
         nic.ip_configurations[0].public_ip_address = {
             'id': floating_ip_id
         }
-        self._provider.azure_client.update_nic(nic.id, nic)
+        cast("AzureCloudProvider", self._provider).azure_client. \
+            update_nic(nic.id, nic)
 
-    def remove_floating_ip(self, floating_ip):
+    def remove_floating_ip(self, floating_ip: FloatingIP | str) -> None:
         """
         Remove a public IP address from this instance.
         """
@@ -1278,9 +1367,10 @@ class AzureInstance(BaseInstance):
         for ip_config in nic.ip_configurations:
             if ip_config.public_ip_address.id == floating_ip_id:
                 nic.ip_configurations[0].public_ip_address = None
-                self._provider.azure_client.update_nic(nic.id, nic)
+                cast("AzureCloudProvider", self._provider).azure_client. \
+                    update_nic(nic.id, nic)
 
-    def add_vm_firewall(self, fw):
+    def add_vm_firewall(self, firewall: VMFirewall) -> None:
         '''
         :param fw:
         :return: None
@@ -1292,16 +1382,16 @@ class AzureInstance(BaseInstance):
         if not associated any security group to NIC
         else replacing the existing security group.
         '''
-        fw = (self._provider.security.vm_firewalls.get(fw)
-              if isinstance(fw, str) else fw)
+        fw: Any = (self._provider.security.vm_firewalls.get(firewall)
+                   if isinstance(firewall, str) else firewall)
         nic = next(self._nics)
         if not nic.network_security_group:
             nic.network_security_group = NetworkSecurityGroup()
             nic.network_security_group.id = fw.resource_id
         else:
-            existing_fw = self._provider.security.\
+            existing_fw: Any = self._provider.security.\
                 vm_firewalls.get(nic.network_security_group.id)
-            new_fw = self._provider.security.vm_firewalls.\
+            new_fw: Any = self._provider.security.vm_firewalls.\
                 create('{0}-{1}'.format(fw.name, existing_fw.name),
                        'Merged security groups {0} and {1}'.
                        format(fw.name, existing_fw.name))
@@ -1309,9 +1399,10 @@ class AzureInstance(BaseInstance):
             new_fw.add_rule(src_dest_fw=existing_fw)
             nic.network_security_group.id = new_fw.resource_id
 
-        self._provider.azure_client.update_nic(nic.id, nic)
+        cast("AzureCloudProvider", self._provider).azure_client. \
+            update_nic(nic.id, nic)
 
-    def remove_vm_firewall(self, fw):
+    def remove_vm_firewall(self, firewall: VMFirewall) -> None:
 
         '''
         :param fw:
@@ -1326,14 +1417,15 @@ class AzureInstance(BaseInstance):
         '''
 
         nic = next(self._nics)
-        fw = (self._provider.security.vm_firewalls.get(fw)
-              if isinstance(fw, str) else fw)
+        fw: Any = (self._provider.security.vm_firewalls.get(firewall)
+                   if isinstance(firewall, str) else firewall)
         if nic.network_security_group and \
                 nic.network_security_group.id == fw.resource_id:
             nic.network_security_group = None
-            self._provider.azure_client.update_nic(nic.id, nic)
+            cast("AzureCloudProvider", self._provider).azure_client. \
+                update_nic(nic.id, nic)
 
-    def _update_state(self):
+    def _update_state(self) -> None:
         """
         Azure python sdk list operation does not return the current
         staus of the instance. We have to explicity call the get method
@@ -1352,22 +1444,24 @@ class AzureInstance(BaseInstance):
                 self._vm.provisioning_state
 
     @property
-    def state(self):
+    def state(self) -> str:
         return AzureInstance.INSTANCE_STATE_MAP.get(
             self._state, InstanceState.UNKNOWN)
 
-    def refresh(self):
+    def refresh(self) -> None:
         """
         Refreshes the state of this instance by re-querying the cloud provider
         for its latest state.
         """
         try:
-            self._vm = self._provider.azure_client.get_vm(self.id)
+            self._vm = cast(
+                "AzureCloudProvider", self._provider).azure_client.get_vm(
+                self.id)
             if not self._vm.tags:
                 self._vm.tags = {}
             self._update_state()
         except (ResourceNotFoundError, ValueError) as cloud_error:
-            log.exception(cloud_error.message)
+            log.exception(cloud_error)
             # The volume no longer exists and cannot be refreshed.
             # set the state to unknown
             self._state = 'unknown'
@@ -1375,26 +1469,26 @@ class AzureInstance(BaseInstance):
 
 class AzureLaunchConfig(BaseLaunchConfig):
 
-    def __init__(self, provider):
+    def __init__(self, provider: AzureCloudProvider) -> None:
         super(AzureLaunchConfig, self).__init__(provider)
 
 
 class AzureVMType(BaseVMType):
 
-    def __init__(self, provider, vm_type):
+    def __init__(self, provider: AzureCloudProvider, vm_type: Any) -> None:
         super(AzureVMType, self).__init__(provider)
         self._vm_type = vm_type
 
     @property
-    def id(self):
+    def id(self) -> str:
         return self._vm_type.name
 
     @property
-    def name(self):
+    def name(self) -> str:
         return self._vm_type.name
 
     @property
-    def family(self):
+    def family(self) -> str | None:
         """
         Python sdk does not return family details.
         So, as of now populating it with 'Unknown'
@@ -1402,23 +1496,23 @@ class AzureVMType(BaseVMType):
         return "Unknown"
 
     @property
-    def vcpus(self):
+    def vcpus(self) -> int:
         return self._vm_type.number_of_cores
 
     @property
-    def ram(self):
+    def ram(self) -> float:
         return int(self._vm_type.memory_in_mb) / 1024
 
     @property
-    def size_root_disk(self):
+    def size_root_disk(self) -> int:
         return self._vm_type.os_disk_size_in_mb / 1024
 
     @property
-    def size_ephemeral_disks(self):
+    def size_ephemeral_disks(self) -> int:
         return self._vm_type.resource_disk_size_in_mb / 1024
 
     @property
-    def num_ephemeral_disks(self):
+    def num_ephemeral_disks(self) -> int:
         """
         Azure by default adds one ephemeral disk. We can not add
         more ephemeral disks to VM explicitly
@@ -1427,7 +1521,7 @@ class AzureVMType(BaseVMType):
         return 0
 
     @property
-    def extra_data(self):
+    def extra_data(self) -> dict[str, Any]:
         return {
                     'max_data_disk_count':
                     self._vm_type.max_data_disk_count
@@ -1436,39 +1530,44 @@ class AzureVMType(BaseVMType):
 
 class AzureKeyPair(BaseKeyPair):
 
-    def __init__(self, provider, key_pair):
+    def __init__(self, provider: AzureCloudProvider, key_pair: Any) -> None:
         super(AzureKeyPair, self).__init__(provider, key_pair)
 
     @property
-    def id(self):
+    def id(self) -> str:
         return self._key_pair['Name']
 
     @property
-    def name(self):
+    def name(self) -> str:
         return self._key_pair['Name']
 
 
 class AzureRouter(BaseRouter):
-    def __init__(self, provider, route_table):
+    def __init__(self, provider: AzureCloudProvider,
+                 route_table: Any) -> None:
         super(AzureRouter, self).__init__(provider)
         self._route_table = route_table
         if not self._route_table.tags:
             self._route_table.tags = {}
 
     @property
-    def id(self):
-        return self._route_table.id
+    def id(self) -> str:
+        route_table_id = self._route_table.id
+        if not route_table_id:
+            raise ProviderInternalException(
+                "Route table is missing an id")
+        return route_table_id
 
     @property
-    def name(self):
+    def name(self) -> str:
         return self._route_table.name
 
     @property
-    def resource_id(self):
+    def resource_id(self) -> str:
         return self._route_table.id
 
     @property
-    def label(self):
+    def label(self) -> str | None:
         """
         Get the router label.
 
@@ -1478,59 +1577,64 @@ class AzureRouter(BaseRouter):
 
     @label.setter
     # pylint:disable=arguments-differ
-    def label(self, value):
+    def label(self, value: str) -> None:
         """
         Set the router label.
         """
         self.assert_valid_resource_label(value)
         self._route_table.tags.update(Label=value or "")
-        self._provider.azure_client. \
+        cast("AzureCloudProvider", self._provider).azure_client. \
             update_route_table_tags(self._route_table.name,
                                     self._route_table.tags)
 
-    def refresh(self):
-        self._route_table = self._provider.azure_client. \
+    def refresh(self) -> None:
+        self._route_table = cast(
+            "AzureCloudProvider", self._provider).azure_client. \
             get_route_table(self._route_table.name)
 
     @property
-    def state(self):
+    def state(self) -> str:
         self.refresh()  # Explicitly refresh the local object
         if self._route_table.subnets:
             return RouterState.ATTACHED
         return RouterState.DETACHED
 
     @property
-    def network_id(self):
+    def network_id(self) -> str | None:
         return None
 
-    def attach_subnet(self, subnet):
-        self._provider.azure_client. \
-            attach_subnet_to_route_table(subnet.id,
+    def attach_subnet(self, subnet: Subnet | str) -> None:
+        subnet_id = subnet.id if isinstance(subnet, AzureSubnet) else subnet
+        cast("AzureCloudProvider", self._provider).azure_client. \
+            attach_subnet_to_route_table(subnet_id,
                                          self.resource_id)
         self.refresh()
 
     @property
-    def subnets(self):
+    def subnets(self) -> Iterable[Subnet]:
         if self._route_table.subnets:
-            return [AzureSubnet(self._provider, sn)
-                    for sn in self._route_table.subnets]
+            return [AzureSubnet(
+                cast("AzureCloudProvider", self._provider), sn)
+                for sn in self._route_table.subnets]
         return []
 
-    def detach_subnet(self, subnet):
-        self._provider.azure_client. \
-            detach_subnet_to_route_table(subnet.id,
+    def detach_subnet(self, subnet: Subnet | str) -> None:
+        subnet_id = subnet.id if isinstance(subnet, AzureSubnet) else subnet
+        cast("AzureCloudProvider", self._provider).azure_client. \
+            detach_subnet_to_route_table(subnet_id,
                                          self.resource_id)
         self.refresh()
 
-    def attach_gateway(self, gateway):
+    def attach_gateway(self, gateway: Gateway) -> None:
         pass
 
-    def detach_gateway(self, gateway):
+    def detach_gateway(self, gateway: Gateway) -> None:
         pass
 
 
 class AzureInternetGateway(BaseInternetGateway):
-    def __init__(self, provider, gateway, gateway_net):
+    def __init__(self, provider: AzureCloudProvider, gateway: Any,
+                 gateway_net: AzureNetwork | str) -> None:
         super(AzureInternetGateway, self).__init__(provider)
         self._gateway = gateway
         self._network_id = gateway_net.id if isinstance(
@@ -1539,35 +1643,35 @@ class AzureInternetGateway(BaseInternetGateway):
         self._fips_container = AzureFloatingIPSubService(provider, self)
 
     @property
-    def id(self):
+    def id(self) -> str:
         return "cb-gateway-wrapper"
 
     @property
-    def name(self):
+    def name(self) -> str:
         return "cb-gateway-wrapper"
 
-    def refresh(self):
+    def refresh(self) -> None:
         pass
 
     @property
-    def state(self):
+    def state(self) -> str:
         return self._state
 
     @property
-    def network_id(self):
+    def network_id(self) -> str | None:
         return self._network_id
 
-    def delete(self):
+    def delete(self) -> None:
         pass
 
     @property
-    def floating_ips(self):
+    def floating_ips(self) -> AzureFloatingIPSubService:
         return self._fips_container
 
 
 # Map Azure record-set type suffix (e.g. 'Microsoft.Network/dnszones/A')
 # to cloudbridge DnsRecordType. Used to expose record data in a normalized form.
-_AZURE_RECORD_TYPE_ATTR = {
+_AZURE_RECORD_TYPE_ATTR: dict[str, str] = {
     'A': 'a_records',
     'AAAA': 'aaaa_records',
     'CNAME': 'cname_record',
@@ -1579,14 +1683,14 @@ _AZURE_RECORD_TYPE_ATTR = {
 }
 
 
-def _azure_record_type(raw_record):
+def _azure_record_type(raw_record: Any) -> str:
     """Return the bare type (e.g. 'A') from an Azure RecordSet."""
     rec_type = raw_record.type or ''
     # Azure formats: 'Microsoft.Network/dnszones/A' or bare 'A'
     return rec_type.split('/')[-1] if '/' in rec_type else rec_type
 
 
-def _azure_record_data(raw_record):
+def _azure_record_data(raw_record: Any) -> list[str]:
     """Extract the data values from an Azure RecordSet as a list of strings."""
     rt = _azure_record_type(raw_record)
     attr = _AZURE_RECORD_TYPE_ATTR.get(rt)
@@ -1619,60 +1723,70 @@ def _azure_record_data(raw_record):
 
 class AzureDnsZone(BaseDnsZone):
 
-    def __init__(self, provider, dns_zone):
+    def __init__(self, provider: AzureCloudProvider, dns_zone: Any) -> None:
         super(AzureDnsZone, self).__init__(provider)
         self._dns_zone = dns_zone
         self._dns_record_container = AzureDnsRecordSubService(provider, self)
 
     @property
-    def id(self):
+    def id(self) -> str:
+        zone_id = self._dns_zone.name
+        if not zone_id:
+            raise ProviderInternalException(
+                "DNS zone is missing a name")
+        return zone_id
+
+    @property
+    def name(self) -> str:
         return self._dns_zone.name
 
     @property
-    def name(self):
-        return self._dns_zone.name
-
-    @property
-    def admin_email(self):
+    def admin_email(self) -> str | None:
         tags = self._dns_zone.tags or {}
         return tags.get('admin_email')
 
     @property
-    def records(self):
+    def records(self) -> AzureDnsRecordSubService:
         return self._dns_record_container
 
 
 class AzureDnsRecord(BaseDnsRecord):
 
-    def __init__(self, provider, dns_zone, dns_record):
+    def __init__(self, provider: AzureCloudProvider, dns_zone: AzureDnsZone,
+                 dns_record: Any) -> None:
         super(AzureDnsRecord, self).__init__(provider)
         self._dns_zone = dns_zone
         self._dns_rec = dns_record
 
     @property
-    def id(self):
+    def id(self) -> str:
         return self.name + ":" + self.type
 
     @property
-    def name(self):
+    def name(self) -> str:
         return self._dns_rec.name
 
     @property
-    def zone_id(self):
-        return self._dns_zone.id
+    def zone_id(self) -> str:
+        zone_id = self._dns_zone.id
+        if not zone_id:
+            raise ProviderInternalException(
+                "DNS record is missing a zone id")
+        return zone_id
 
     @property
-    def type(self):
+    def type(self) -> str:
         return _azure_record_type(self._dns_rec)
 
     @property
-    def data(self):
+    def data(self) -> list[str]:
         return _azure_record_data(self._dns_rec)
 
     @property
-    def ttl(self):
+    def ttl(self) -> int:
         return self._dns_rec.ttl
 
-    def delete(self):
+    def delete(self) -> None:
         # pylint:disable=protected-access
-        return self._provider.dns._records.delete(self._dns_zone, self)
+        records: Any = self._provider.dns._records
+        records.delete(self._dns_zone, self)

--- a/cloudbridge/providers/azure/services.py
+++ b/cloudbridge/providers/azure/services.py
@@ -1,61 +1,121 @@
+from __future__ import annotations
+
 import base64
+import builtins
 import logging
 import uuid
+from typing import Any
+from typing import TYPE_CHECKING
+from typing import cast
+
+from azure.core.exceptions import ResourceNotFoundError
+from azure.mgmt.compute.models import CreationData
+from azure.mgmt.compute.models import DataDisk
+from azure.mgmt.compute.models import DiskCreateOption
+from azure.mgmt.compute.models import HardwareProfile
+from azure.mgmt.compute.models import ImageReference
+from azure.mgmt.compute.models import LinuxConfiguration
+from azure.mgmt.compute.models import ManagedDiskParameters
+from azure.mgmt.compute.models import NetworkInterfaceReference
+from azure.mgmt.compute.models import NetworkProfile
+from azure.mgmt.compute.models import OSDisk
+from azure.mgmt.compute.models import OSProfile
+from azure.mgmt.compute.models import SshConfiguration
+from azure.mgmt.compute.models import SshPublicKey
+from azure.mgmt.compute.models import StorageProfile
+from azure.mgmt.network.models import AddressSpace
+from azure.mgmt.network.models import NetworkInterfaceIPConfiguration
+from azure.mgmt.network.models import PublicIPAddressSku
+from azure.mgmt.network.models import PublicIPAddressSkuName
+from azure.mgmt.network.models import SubResource
 
 import cloudbridge.base.helpers as cb_helpers
 from cloudbridge.base.middleware import dispatch
-from cloudbridge.base.resources import (BaseMultipartUpload, BaseUploadPart,
-                                        ClientPagedResultList,
-                                        ServerPagedResultList)
-from cloudbridge.base.services import (BaseBucketObjectService,
-                                       BaseBucketService, BaseComputeService,
-                                       BaseDnsRecordService, BaseDnsService,
-                                       BaseDnsZoneService,
-                                       BaseFloatingIPService,
-                                       BaseGatewayService, BaseImageService,
-                                       BaseInstanceService, BaseKeyPairService,
-                                       BaseNetworkingService,
-                                       BaseNetworkService, BaseRegionService,
-                                       BaseRouterService, BaseSecurityService,
-                                       BaseSnapshotService, BaseStorageService,
-                                       BaseSubnetService,
-                                       BaseVMFirewallRuleService,
-                                       BaseVMFirewallService,
-                                       BaseVMTypeService, BaseVolumeService)
-from cloudbridge.interfaces.exceptions import (DuplicateResourceException,
-                                               InvalidParamException,
-                                               InvalidValueException)
-from cloudbridge.interfaces.resources import (MachineImage, Network, Snapshot,
-                                              TrafficDirection, VMFirewall,
-                                              VMType, Volume)
-from azure.core.exceptions import ResourceNotFoundError
+from cloudbridge.base.resources import BaseMultipartUpload
+from cloudbridge.base.resources import BaseUploadPart
+from cloudbridge.base.resources import ClientPagedResultList
+from cloudbridge.base.resources import ServerPagedResultList
+from cloudbridge.base.services import BaseBucketObjectService
+from cloudbridge.base.services import BaseBucketService
+from cloudbridge.base.services import BaseComputeService
+from cloudbridge.base.services import BaseDnsRecordService
+from cloudbridge.base.services import BaseDnsService
+from cloudbridge.base.services import BaseDnsZoneService
+from cloudbridge.base.services import BaseFloatingIPService
+from cloudbridge.base.services import BaseGatewayService
+from cloudbridge.base.services import BaseImageService
+from cloudbridge.base.services import BaseInstanceService
+from cloudbridge.base.services import BaseKeyPairService
+from cloudbridge.base.services import BaseNetworkService
+from cloudbridge.base.services import BaseNetworkingService
+from cloudbridge.base.services import BaseRegionService
+from cloudbridge.base.services import BaseRouterService
+from cloudbridge.base.services import BaseSecurityService
+from cloudbridge.base.services import BaseSnapshotService
+from cloudbridge.base.services import BaseStorageService
+from cloudbridge.base.services import BaseSubnetService
+from cloudbridge.base.services import BaseVMFirewallRuleService
+from cloudbridge.base.services import BaseVMFirewallService
+from cloudbridge.base.services import BaseVMTypeService
+from cloudbridge.base.services import BaseVolumeService
+from cloudbridge.interfaces.exceptions import DuplicateResourceException
+from cloudbridge.interfaces.exceptions import InvalidParamException
+from cloudbridge.interfaces.exceptions import InvalidValueException
+from cloudbridge.interfaces.exceptions import ProviderInternalException
+from cloudbridge.interfaces.resources import Bucket
+from cloudbridge.interfaces.resources import BucketObject
+from cloudbridge.interfaces.resources import DnsRecord
+from cloudbridge.interfaces.resources import DnsZone
+from cloudbridge.interfaces.resources import FloatingIP
+from cloudbridge.interfaces.resources import Gateway
+from cloudbridge.interfaces.resources import Instance
+from cloudbridge.interfaces.resources import InternetGateway
+from cloudbridge.interfaces.resources import KeyPair
+from cloudbridge.interfaces.resources import LaunchConfig
+from cloudbridge.interfaces.resources import MachineImage
+from cloudbridge.interfaces.resources import MultipartUpload
+from cloudbridge.interfaces.resources import Network
+from cloudbridge.interfaces.resources import Region
+from cloudbridge.interfaces.resources import ResultList
+from cloudbridge.interfaces.resources import Router
+from cloudbridge.interfaces.resources import Snapshot
+from cloudbridge.interfaces.resources import Subnet
+from cloudbridge.interfaces.resources import TrafficDirection
+from cloudbridge.interfaces.resources import UploadPart
+from cloudbridge.interfaces.resources import VMFirewall
+from cloudbridge.interfaces.resources import VMFirewallRule
+from cloudbridge.interfaces.resources import VMType
+from cloudbridge.interfaces.resources import Volume
 
-from azure.mgmt.compute.models import (CreationData, DataDisk,
-                                       DiskCreateOption, HardwareProfile,
-                                       ImageReference, LinuxConfiguration,
-                                       ManagedDiskParameters,
-                                       NetworkInterfaceReference,
-                                       NetworkProfile, OSDisk, OSProfile,
-                                       SshConfiguration, SshPublicKey,
-                                       StorageProfile)
-from azure.mgmt.network.models import (AddressSpace,
-                                       NetworkInterfaceIPConfiguration,
-                                       PublicIPAddressSku,
-                                       PublicIPAddressSkuName, SubResource)
+from .resources import AzureBucket
+from .resources import AzureBucketObject
+from .resources import AzureDnsRecord
+from .resources import AzureDnsZone
+from .resources import AzureFloatingIP
+from .resources import AzureInstance
+from .resources import AzureInternetGateway
+from .resources import AzureKeyPair
+from .resources import AzureLaunchConfig
+from .resources import AzureMachineImage
+from .resources import AzureNetwork
+from .resources import AzureRegion
+from .resources import AzureRouter
+from .resources import AzureSnapshot
+from .resources import AzureSubnet
+from .resources import AzureVMFirewall
+from .resources import AzureVMFirewallRule
+from .resources import AzureVMType
+from .resources import AzureVolume
 
-from .resources import (AzureBucket, AzureBucketObject, AzureDnsRecord,
-                        AzureDnsZone, AzureFloatingIP, AzureInstance,
-                        AzureInternetGateway, AzureKeyPair, AzureLaunchConfig,
-                        AzureMachineImage, AzureNetwork, AzureRegion,
-                        AzureRouter, AzureSnapshot, AzureSubnet,
-                        AzureVMFirewall, AzureVMFirewallRule, AzureVMType,
-                        AzureVolume)
+if TYPE_CHECKING:
+    from cloudbridge.interfaces.provider import CloudProvider
+    from cloudbridge.providers.azure.provider import AzureCloudProvider
 
 log = logging.getLogger(__name__)
 
 
 class AzureSecurityService(BaseSecurityService):
-    def __init__(self, provider):
+    def __init__(self, provider: CloudProvider) -> None:
         super(AzureSecurityService, self).__init__(provider)
 
         # Initialize provider services
@@ -64,28 +124,29 @@ class AzureSecurityService(BaseSecurityService):
         self._vm_firewall_rule_svc = AzureVMFirewallRuleService(provider)
 
     @property
-    def key_pairs(self):
+    def key_pairs(self) -> AzureKeyPairService:
         return self._key_pairs
 
     @property
-    def vm_firewalls(self):
+    def vm_firewalls(self) -> AzureVMFirewallService:
         return self._vm_firewalls
 
     @property
-    def _vm_firewall_rules(self):
+    def _vm_firewall_rules(self) -> AzureVMFirewallRuleService:
         return self._vm_firewall_rule_svc
 
 
 class AzureVMFirewallService(BaseVMFirewallService):
-    def __init__(self, provider):
+    def __init__(self, provider: CloudProvider) -> None:
         super(AzureVMFirewallService, self).__init__(provider)
 
     @dispatch(event="provider.security.vm_firewalls.get",
               priority=BaseVMFirewallService.STANDARD_EVENT_PRIORITY)
-    def get(self, vm_firewall_id):
+    def get(self, vm_firewall_id: str) -> VMFirewall | None:
+        provider = cast("AzureCloudProvider", self.provider)
         try:
-            fws = self.provider.azure_client.get_vm_firewall(vm_firewall_id)
-            return AzureVMFirewall(self.provider, fws)
+            fws = provider.azure_client.get_vm_firewall(vm_firewall_id)
+            return AzureVMFirewall(provider, fws)
         except (ResourceNotFoundError, InvalidValueException) as cloud_error:
             # Azure raises the cloud error if the resource not available
             log.exception(cloud_error)
@@ -93,27 +154,31 @@ class AzureVMFirewallService(BaseVMFirewallService):
 
     @dispatch(event="provider.security.vm_firewalls.list",
               priority=BaseVMFirewallService.STANDARD_EVENT_PRIORITY)
-    def list(self, limit=None, marker=None):
-        fws = [AzureVMFirewall(self.provider, fw)
-               for fw in self.provider.azure_client.list_vm_firewall()]
+    def list(self, limit: int | None = None,
+             marker: str | None = None) -> ResultList[VMFirewall]:
+        provider = cast("AzureCloudProvider", self.provider)
+        fws = [AzureVMFirewall(provider, fw)
+               for fw in provider.azure_client.list_vm_firewall()]
         return ClientPagedResultList(self.provider, fws, limit, marker)
 
     @cb_helpers.deprecated_alias(network_id='network')
     @dispatch(event="provider.security.vm_firewalls.create",
               priority=BaseVMFirewallService.STANDARD_EVENT_PRIORITY)
-    def create(self, label, network, description=None):
+    def create(self, label: str, network: Network | str,
+               description: str | None = None) -> VMFirewall:
         AzureVMFirewall.assert_valid_resource_label(label)
         name = AzureVMFirewall._generate_name_from_label(label, "cb-fw")
         net = network.id if isinstance(network, Network) else network
-        parameters = {"location": self.provider.region_name,
-                      "tags": {'Label': label,
-                               'network_id': net}}
+        provider = cast("AzureCloudProvider", self.provider)
+        parameters: dict[str, Any] = {"location": self.provider.region_name,
+                                      "tags": {'Label': label,
+                                               'network_id': net}}
 
         if description:
             parameters['tags'].update(Description=description)
 
-        fw = self.provider.azure_client.create_vm_firewall(name,
-                                                           parameters)
+        azure_client = provider.azure_client
+        fw = azure_client.create_vm_firewall(name, parameters)
 
         # Add default rules to negate azure default rules.
         # See: https://github.com/CloudVE/cloudbridge/issues/106
@@ -124,7 +189,7 @@ class AzureVMFirewallService(BaseVMFirewallService):
             # only 0-4096 are allowed for custom rules
             rule.priority = rule.priority - 61440
             rule.access = "Deny"
-            self.provider.azure_client.create_vm_firewall_rule(
+            azure_client.create_vm_firewall_rule(
                 fw.id, rule_name, rule)
 
         # Add a new custom rule allowing all outbound traffic to the internet
@@ -136,43 +201,47 @@ class AzureVMFirewallService(BaseVMFirewallService):
                       "destination_address_prefix": "Internet",
                       "access": "Allow",
                       "direction": "Outbound"}
-        result = self.provider.azure_client.create_vm_firewall_rule(
+        result = azure_client.create_vm_firewall_rule(
             fw.id, "cb-default-internet-outbound", parameters)
         fw.security_rules.append(result)
 
-        cb_fw = AzureVMFirewall(self.provider, fw)
+        cb_fw = AzureVMFirewall(provider, fw)
         return cb_fw
 
     @dispatch(event="provider.security.vm_firewalls.delete",
               priority=BaseVMFirewallService.STANDARD_EVENT_PRIORITY)
-    def delete(self, vm_firewall):
+    def delete(self, vm_firewall: VMFirewall | str) -> None:
         fw_id = (vm_firewall.id if isinstance(vm_firewall, AzureVMFirewall)
                  else vm_firewall)
-        self.provider.azure_client.delete_vm_firewall(fw_id)
+        cast("AzureCloudProvider", self.provider).azure_client.\
+            delete_vm_firewall(fw_id)
 
 
 class AzureVMFirewallRuleService(BaseVMFirewallRuleService):
 
-    def __init__(self, provider):
+    def __init__(self, provider: CloudProvider) -> None:
         super(AzureVMFirewallRuleService, self).__init__(provider)
 
     @dispatch(event="provider.security.vm_firewall_rules.list",
               priority=BaseVMFirewallRuleService.STANDARD_EVENT_PRIORITY)
-    def list(self, firewall, limit=None, marker=None):
+    def list(self, firewall: VMFirewall, limit: int | None = None,
+             marker: str | None = None) -> ResultList[VMFirewallRule]:
         # Filter out firewall rules with priority < 3500 because values
         # between 3500 and 4096 are assumed to be owned by cloudbridge
         # default rules.
         # pylint:disable=protected-access
         rules = [AzureVMFirewallRule(firewall, rule) for rule
-                 in firewall._vm_firewall.security_rules
+                 in cast(Any, firewall)._vm_firewall.security_rules
                  if rule.priority < 3500]
         return ClientPagedResultList(self.provider, rules,
                                      limit=limit, marker=marker)
 
     @dispatch(event="provider.security.vm_firewall_rules.create",
               priority=BaseVMFirewallRuleService.STANDARD_EVENT_PRIORITY)
-    def create(self, firewall, direction, protocol=None, from_port=None,
-               to_port=None, cidr=None, src_dest_fw=None):
+    def create(self, firewall: VMFirewall, direction: TrafficDirection,
+               protocol: str | None = None, from_port: int | None = None,
+               to_port: int | None = None, cidr: str | None = None,
+               src_dest_fw: VMFirewall | None = None) -> VMFirewallRule:
         if protocol and from_port and to_port:
             return self._create_rule(firewall, direction, protocol, from_port,
                                      to_port, cidr)
@@ -180,30 +249,39 @@ class AzureVMFirewallRuleService(BaseVMFirewallRuleService):
             result = None
             fw = (self.provider.security.vm_firewalls.get(src_dest_fw)
                   if isinstance(src_dest_fw, str) else src_dest_fw)
+            if fw is None:
+                raise ProviderInternalException(
+                    "Source firewall %s not found" % src_dest_fw)
             for rule in fw.rules:
                 result = self._create_rule(
-                    rule.direction, rule.protocol, rule.from_port,
-                    rule.to_port, rule.cidr)
+                    firewall, rule.direction, cast(str, rule.protocol),
+                    rule.from_port, rule.to_port, rule.cidr)
+            if result is None:
+                raise ProviderInternalException(
+                    "Source firewall %s has no rules to copy" % src_dest_fw)
             return result
         else:
-            return None
+            raise InvalidParamException(
+                "Either (protocol, from_port, to_port) or src_dest_fw "
+                "must be provided to create a firewall rule")
 
-    def _create_rule(self, firewall, direction, protocol,
-                     from_port, to_port, cidr):
+    def _create_rule(self, firewall: VMFirewall, direction: TrafficDirection,
+                     protocol: str, from_port: int, to_port: int,
+                     cidr: str | None) -> AzureVMFirewallRule:
 
         # If cidr is None, default values is set as 0.0.0.0/0
         if not cidr:
             cidr = '0.0.0.0/0'
 
-        count = len(firewall._vm_firewall.security_rules) + 1
+        count = len(cast(Any, firewall)._vm_firewall.security_rules) + 1
         rule_name = "cb-rule-" + str(count)
         priority = 1000 + count
         destination_port_range = str(from_port) + "-" + str(to_port)
         source_port_range = '*'
         destination_address_prefix = "*"
         access = "Allow"
-        direction = ("Inbound" if direction == TrafficDirection.INBOUND
-                     else "Outbound")
+        az_direction = ("Inbound" if direction == TrafficDirection.INBOUND
+                        else "Outbound")
         parameters = {"priority": priority,
                       "protocol": protocol,
                       "source_port_range": source_port_range,
@@ -211,43 +289,43 @@ class AzureVMFirewallRuleService(BaseVMFirewallRuleService):
                       "destination_port_range": destination_port_range,
                       "destination_address_prefix": destination_address_prefix,
                       "access": access,
-                      "direction": direction}
-        result = self.provider.azure_client. \
+                      "direction": az_direction}
+        result = cast("AzureCloudProvider", self.provider).azure_client. \
             create_vm_firewall_rule(firewall.id,
                                     rule_name, parameters)
         # pylint:disable=protected-access
-        firewall._vm_firewall.security_rules.append(result)
+        cast(Any, firewall)._vm_firewall.security_rules.append(result)
         return AzureVMFirewallRule(firewall, result)
 
     @dispatch(event="provider.security.vm_firewall_rules.delete",
               priority=BaseVMFirewallRuleService.STANDARD_EVENT_PRIORITY)
-    def delete(self, firewall, rule):
+    def delete(self, firewall: VMFirewall, rule: VMFirewallRule) -> None:
         rule_id = rule.id if isinstance(rule, AzureVMFirewallRule) else rule
         fw_name = firewall.name
-        self.provider.azure_client. \
+        cast("AzureCloudProvider", self.provider).azure_client. \
             delete_vm_firewall_rule(rule_id, fw_name)
-        for i, o in enumerate(firewall._vm_firewall.security_rules):
+        for i, o in enumerate(cast(Any, firewall)._vm_firewall.security_rules):
             if o.id == rule_id:
                 # pylint:disable=protected-access
-                del firewall._vm_firewall.security_rules[i]
+                del cast(Any, firewall)._vm_firewall.security_rules[i]
                 break
 
 
 class AzureKeyPairService(BaseKeyPairService):
     PARTITION_KEY = '00000000-0000-0000-0000-000000000000'
 
-    def __init__(self, provider):
+    def __init__(self, provider: CloudProvider) -> None:
         super(AzureKeyPairService, self).__init__(provider)
 
     @dispatch(event="provider.security.key_pairs.get",
               priority=BaseKeyPairService.STANDARD_EVENT_PRIORITY)
-    def get(self, key_pair_id):
+    def get(self, key_pair_id: str) -> KeyPair | None:
+        provider = cast("AzureCloudProvider", self.provider)
         try:
-            key_pair = self.provider.azure_client.\
-                get_public_key(key_pair_id)
+            key_pair = provider.azure_client.get_public_key(key_pair_id)
 
             if key_pair:
-                return AzureKeyPair(self.provider, key_pair)
+                return AzureKeyPair(provider, key_pair)
             return None
         except ResourceNotFoundError as error:
             log.debug("KeyPair %s was not found.", key_pair_id)
@@ -256,11 +334,13 @@ class AzureKeyPairService(BaseKeyPairService):
 
     @dispatch(event="provider.security.key_pairs.list",
               priority=BaseKeyPairService.STANDARD_EVENT_PRIORITY)
-    def list(self, limit=None, marker=None):
-        key_pairs, resume_marker = self.provider.azure_client.list_public_keys(
+    def list(self, limit: int | None = None,
+             marker: str | None = None) -> ResultList[KeyPair]:
+        provider = cast("AzureCloudProvider", self.provider)
+        key_pairs, resume_marker = provider.azure_client.list_public_keys(
             AzureKeyPairService.PARTITION_KEY, marker=marker,
             limit=limit or self.provider.config.default_result_limit)
-        results = [AzureKeyPair(self.provider, key_pair)
+        results = [AzureKeyPair(provider, key_pair)
                    for key_pair in key_pairs]
         return ServerPagedResultList(is_truncated=resume_marker,
                                      marker=resume_marker,
@@ -269,8 +349,8 @@ class AzureKeyPairService(BaseKeyPairService):
 
     @dispatch(event="provider.security.key_pairs.find",
               priority=BaseKeyPairService.STANDARD_EVENT_PRIORITY)
-    def find(self, **kwargs):
-        obj_list = self
+    def find(self, **kwargs: Any) -> ResultList[KeyPair]:
+        obj_list: list[KeyPair] = list(self)
         filters = ['name']
         matches = cb_helpers.generic_find(filters, kwargs, obj_list)
 
@@ -285,7 +365,8 @@ class AzureKeyPairService(BaseKeyPairService):
 
     @dispatch(event="provider.security.key_pairs.create",
               priority=BaseKeyPairService.STANDARD_EVENT_PRIORITY)
-    def create(self, name, public_key_material=None):
+    def create(self, name: str,
+               public_key_material: str | None = None) -> KeyPair:
         AzureKeyPair.assert_valid_resource_name(name)
         key_pair = self.get(name)
 
@@ -304,23 +385,28 @@ class AzureKeyPairService(BaseKeyPairService):
             'Key': public_key_material
         }
 
-        self.provider.azure_client.create_public_key(entity)
+        cast("AzureCloudProvider", self.provider).azure_client.\
+            create_public_key(entity)
         key_pair = self.get(name)
+        if key_pair is None:
+            raise ProviderInternalException(
+                "KeyPair %s could not be retrieved after creation" % name)
         key_pair.material = private_key
         return key_pair
 
     @dispatch(event="provider.security.key_pairs.delete",
               priority=BaseKeyPairService.STANDARD_EVENT_PRIORITY)
-    def delete(self, key_pair):
-        key_pair = (key_pair if isinstance(key_pair, AzureKeyPair) else
-                    self.get(key_pair))
-        if key_pair:
+    def delete(self, key_pair: KeyPair | str) -> None:
+        kp = (key_pair if isinstance(key_pair, AzureKeyPair) else
+              self.get(key_pair))
+        if kp:
             # pylint:disable=protected-access
-            self.provider.azure_client.delete_public_key(key_pair._key_pair)
+            cast("AzureCloudProvider", self.provider).azure_client.\
+                delete_public_key(cast(Any, kp)._key_pair)
 
 
 class AzureStorageService(BaseStorageService):
-    def __init__(self, provider):
+    def __init__(self, provider: CloudProvider) -> None:
         super(AzureStorageService, self).__init__(provider)
 
         # Initialize provider services
@@ -330,32 +416,33 @@ class AzureStorageService(BaseStorageService):
         self._bucket_obj_svc = AzureBucketObjectService(self.provider)
 
     @property
-    def volumes(self):
+    def volumes(self) -> AzureVolumeService:
         return self._volume_svc
 
     @property
-    def snapshots(self):
+    def snapshots(self) -> AzureSnapshotService:
         return self._snapshot_svc
 
     @property
-    def buckets(self):
+    def buckets(self) -> AzureBucketService:
         return self._bucket_svc
 
     @property
-    def _bucket_objects(self):
+    def _bucket_objects(self) -> AzureBucketObjectService:
         return self._bucket_obj_svc
 
 
 class AzureVolumeService(BaseVolumeService):
-    def __init__(self, provider):
+    def __init__(self, provider: CloudProvider) -> None:
         super(AzureVolumeService, self).__init__(provider)
 
     @dispatch(event="provider.storage.volumes.get",
               priority=BaseVolumeService.STANDARD_EVENT_PRIORITY)
-    def get(self, volume_id):
+    def get(self, volume_id: str) -> Volume | None:
+        provider = cast("AzureCloudProvider", self.provider)
         try:
-            volume = self.provider.azure_client.get_disk(volume_id)
-            return AzureVolume(self.provider, volume)
+            volume = provider.azure_client.get_disk(volume_id)
+            return AzureVolume(provider, volume)
         except (ResourceNotFoundError, InvalidValueException) as cloud_error:
             # Azure raises the cloud error if the resource not available
             log.exception(cloud_error)
@@ -363,8 +450,8 @@ class AzureVolumeService(BaseVolumeService):
 
     @dispatch(event="provider.storage.volumes.find",
               priority=BaseVolumeService.STANDARD_EVENT_PRIORITY)
-    def find(self, **kwargs):
-        obj_list = self
+    def find(self, **kwargs: Any) -> ResultList[Volume]:
+        obj_list: list[Volume] = list(self)
         filters = ['label']
         matches = cb_helpers.generic_find(filters, kwargs, obj_list)
 
@@ -379,15 +466,19 @@ class AzureVolumeService(BaseVolumeService):
 
     @dispatch(event="provider.storage.volumes.list",
               priority=BaseVolumeService.STANDARD_EVENT_PRIORITY)
-    def list(self, limit=None, marker=None):
-        azure_vols = self.provider.azure_client.list_disks()
-        cb_vols = [AzureVolume(self.provider, vol) for vol in azure_vols]
+    def list(self, limit: int | None = None,
+             marker: str | None = None) -> ResultList[Volume]:
+        provider = cast("AzureCloudProvider", self.provider)
+        azure_vols = provider.azure_client.list_disks()
+        cb_vols = [AzureVolume(provider, vol) for vol in azure_vols]
         return ClientPagedResultList(self.provider, cb_vols,
                                      limit=limit, marker=marker)
 
     @dispatch(event="provider.storage.volumes.create",
               priority=BaseVolumeService.STANDARD_EVENT_PRIORITY)
-    def create(self, label, size, snapshot=None, description=None):
+    def create(self, label: str, size: int,
+               snapshot: Snapshot | str | None = None,
+               description: str | None = None) -> Volume:
         AzureVolume.assert_valid_resource_label(label)
         disk_name = AzureVolume._generate_name_from_label(label, "cb-vol")
         tags = {'Label': label}
@@ -398,55 +489,58 @@ class AzureVolumeService(BaseVolumeService):
         if description:
             tags.update(Description=description)
 
+        provider = cast("AzureCloudProvider", self.provider)
+        azure_client = provider.azure_client
+        params: dict[str, Any]
         if snapshot:
             params = {
                 'location': self.provider.region_name,
                 'creation_data': CreationData(
-                    create_option=DiskCreateOption.copy,
-                    source_uri=snapshot.resource_id,
+                    create_option=cast(Any, DiskCreateOption.copy),
+                    source_uri=cast(Any, snapshot).resource_id,
                 ),
                 'tags': tags
             }
 
-            disk = self.provider.azure_client.create_snapshot_disk(disk_name,
-                                                                   params)
+            disk = azure_client.create_snapshot_disk(disk_name, params)
 
         else:
             params = {
                 'location': self.provider.region_name,
                 'disk_size_gb': size,
                 'creation_data': CreationData(
-                    create_option=DiskCreateOption.empty,
+                    create_option=cast(Any, DiskCreateOption.empty),
                 ),
                 'tags': tags
             }
 
-            disk = self.provider.azure_client.create_empty_disk(disk_name,
-                                                                params)
+            disk = azure_client.create_empty_disk(disk_name, params)
 
-        azure_vol = self.provider.azure_client.get_disk(disk.id)
-        cb_vol = AzureVolume(self.provider, azure_vol)
+        azure_vol = azure_client.get_disk(disk.id)
+        cb_vol = AzureVolume(provider, azure_vol)
 
         return cb_vol
 
     @dispatch(event="provider.storage.volumes.delete",
               priority=BaseVolumeService.STANDARD_EVENT_PRIORITY)
-    def delete(self, volume_id):
-        vol_id = (volume_id.id if isinstance(volume_id, AzureVolume)
-                  else volume_id)
-        self.provider.azure_client.delete_disk(vol_id)
+    def delete(self, volume: Volume | str) -> None:
+        vol_id = (volume.id if isinstance(volume, AzureVolume)
+                  else volume)
+        cast("AzureCloudProvider", self.provider).azure_client.\
+            delete_disk(vol_id)
 
 
 class AzureSnapshotService(BaseSnapshotService):
-    def __init__(self, provider):
+    def __init__(self, provider: CloudProvider) -> None:
         super(AzureSnapshotService, self).__init__(provider)
 
     @dispatch(event="provider.storage.snapshots.get",
               priority=BaseSnapshotService.STANDARD_EVENT_PRIORITY)
-    def get(self, snapshot_id):
+    def get(self, snapshot_id: str) -> Snapshot | None:
+        provider = cast("AzureCloudProvider", self.provider)
         try:
-            snapshot = self.provider.azure_client.get_snapshot(snapshot_id)
-            return AzureSnapshot(self.provider, snapshot)
+            snapshot = provider.azure_client.get_snapshot(snapshot_id)
+            return AzureSnapshot(provider, snapshot)
         except (ResourceNotFoundError, InvalidValueException) as cloud_error:
             # Azure raises the cloud error if the resource not available
             log.exception(cloud_error)
@@ -454,8 +548,8 @@ class AzureSnapshotService(BaseSnapshotService):
 
     @dispatch(event="provider.storage.snapshots.find",
               priority=BaseSnapshotService.STANDARD_EVENT_PRIORITY)
-    def find(self, **kwargs):
-        obj_list = self
+    def find(self, **kwargs: Any) -> ResultList[Snapshot]:
+        obj_list: list[Snapshot] = list(self)
         filters = ['label']
         matches = cb_helpers.generic_find(filters, kwargs, obj_list)
 
@@ -470,15 +564,17 @@ class AzureSnapshotService(BaseSnapshotService):
 
     @dispatch(event="provider.storage.snapshots.list",
               priority=BaseSnapshotService.STANDARD_EVENT_PRIORITY)
-    def list(self, limit=None, marker=None):
-        snaps = [AzureSnapshot(self.provider, obj)
-                 for obj in
-                 self.provider.azure_client.list_snapshots()]
+    def list(self, limit: int | None = None,
+             marker: str | None = None) -> ResultList[Snapshot]:
+        provider = cast("AzureCloudProvider", self.provider)
+        snaps = [AzureSnapshot(provider, obj)
+                 for obj in provider.azure_client.list_snapshots()]
         return ClientPagedResultList(self.provider, snaps, limit, marker)
 
     @dispatch(event="provider.storage.snapshots.create",
               priority=BaseSnapshotService.STANDARD_EVENT_PRIORITY)
-    def create(self, label, volume, description=None):
+    def create(self, label: str, volume: Volume | str,
+               description: str | None = None) -> Snapshot:
         AzureSnapshot.assert_valid_resource_label(label)
         snapshot_name = AzureSnapshot._generate_name_from_label(label,
                                                                 "cb-snap")
@@ -486,116 +582,138 @@ class AzureSnapshotService(BaseSnapshotService):
         if description:
             tags.update(Description=description)
 
-        volume = (self.provider.storage.volumes.get(volume)
-                  if isinstance(volume, str) else volume)
+        vol = (self.provider.storage.volumes.get(volume)
+               if isinstance(volume, str) else volume)
 
         # We need to pass the Disk Object to create the snapshot
-        volume = volume._volume
+        azure_volume = cast(Any, vol)._volume
 
-        azure_snap = self.provider.azure_client.create_snapshot(
-            snapshot_name, volume, tags
-        )
+        provider = cast("AzureCloudProvider", self.provider)
+        azure_snap = provider.azure_client.create_snapshot(
+            snapshot_name, azure_volume, tags)
 
-        return AzureSnapshot(self.provider, azure_snap)
+        return AzureSnapshot(provider, azure_snap)
 
     @dispatch(event="provider.storage.snapshots.delete",
               priority=BaseSnapshotService.STANDARD_EVENT_PRIORITY)
-    def delete(self, snapshot_id):
-        snap_id = (snapshot_id.id if isinstance(snapshot_id, AzureSnapshot)
-                   else snapshot_id)
-        self.provider.azure_client.delete_snapshot(snap_id)
+    def delete(self, snapshot: Snapshot | str) -> None:
+        snap_id = (snapshot.id if isinstance(snapshot, AzureSnapshot)
+                   else snapshot)
+        cast("AzureCloudProvider", self.provider).azure_client.\
+            delete_snapshot(snap_id)
 
 
 class AzureBucketService(BaseBucketService):
-    def __init__(self, provider):
+    def __init__(self, provider: CloudProvider) -> None:
         super(AzureBucketService, self).__init__(provider)
 
     @dispatch(event="provider.storage.buckets.get",
               priority=BaseBucketService.STANDARD_EVENT_PRIORITY)
-    def get(self, bucket_id):
+    def get(self, bucket_id: str) -> Bucket | None:
         """
         Returns a bucket given its ID. Returns ``None`` if the bucket
         does not exist.
         """
-        bucket = self.provider.azure_client.get_container(bucket_id)
+        provider = cast("AzureCloudProvider", self.provider)
+        bucket = provider.azure_client.get_container(bucket_id)
         if bucket.exists():
-            return AzureBucket(self.provider, bucket)
+            return AzureBucket(provider, bucket)
         else:
             return None
 
     @dispatch(event="provider.storage.buckets.list",
               priority=BaseBucketService.STANDARD_EVENT_PRIORITY)
-    def list(self, limit=None, marker=None):
-        buckets = [AzureBucket(self.provider, bucket)
+    def list(self, limit: int | None = None,
+             marker: str | None = None) -> ResultList[Bucket]:
+        provider = cast("AzureCloudProvider", self.provider)
+        buckets = [AzureBucket(provider, bucket)
                    for bucket
-                   in self.provider.azure_client.list_containers()]
+                   in provider.azure_client.list_containers()]
         return ClientPagedResultList(self.provider, buckets,
                                      limit=limit, marker=marker)
 
     @dispatch(event="provider.storage.buckets.create",
               priority=BaseBucketService.STANDARD_EVENT_PRIORITY)
-    def create(self, name, location=None):
+    def create(self, name: str,
+               location: Region | str | None = None) -> Bucket:
         """
         Create a new bucket.
         """
         AzureBucket.assert_valid_resource_name(name)
-        bucket = self.provider.azure_client.create_container(name)
-        return AzureBucket(self.provider, bucket)
+        provider = cast("AzureCloudProvider", self.provider)
+        bucket = provider.azure_client.create_container(name)
+        return AzureBucket(provider, bucket)
 
     @dispatch(event="provider.storage.buckets.delete",
               priority=BaseBucketService.STANDARD_EVENT_PRIORITY)
-    def delete(self, bucket):
+    def delete(self, bucket: Bucket | str) -> None:
         """
         Delete this bucket.
         """
         b_id = bucket.id if isinstance(bucket, AzureBucket) else bucket
-        self.provider.azure_client.delete_container(b_id)
+        cast("AzureCloudProvider", self.provider).azure_client.\
+            delete_container(b_id)
 
 
 class AzureBucketObjectService(BaseBucketObjectService):
-    def __init__(self, provider):
+    def __init__(self, provider: CloudProvider) -> None:
         super(AzureBucketObjectService, self).__init__(provider)
 
-    def get(self, bucket, object_id):
+    def get(self, bucket: Bucket | str,
+            object_id: str) -> BucketObject | None:
         """
         Retrieve a given object from this bucket.
         """
+        provider = cast("AzureCloudProvider", self.provider)
+        azure_bucket = cast("AzureBucket", bucket)
         try:
             # pylint:disable=protected-access
-            obj = bucket._bucket.get_blob_client(object_id).get_blob_properties()
-            return AzureBucketObject(self.provider, bucket, obj)
+            obj = cast(Any, bucket)._bucket.get_blob_client(
+                object_id).get_blob_properties()
+            return AzureBucketObject(provider, azure_bucket, obj)
         except ResourceNotFoundError as azureEx:
             log.exception(azureEx)
             return None
 
-    def list(self, bucket, limit=None, marker=None, prefix=None):
+    def list(self, bucket: Bucket | str, prefix: str | None = None,
+             limit: int | None = None,
+             marker: str | None = None) -> ResultList[BucketObject]:
         """
         List all objects within this bucket.
 
         :rtype: BucketObject
         :return: List of all available BucketObjects within this bucket.
         """
-        objects = [AzureBucketObject(self.provider, bucket, obj)
+        provider = cast("AzureCloudProvider", self.provider)
+        azure_bucket = cast("AzureBucket", bucket)
+        objects = [AzureBucketObject(provider, azure_bucket, obj)
                    for obj in
-                   bucket._bucket.list_blobs(name_starts_with=prefix)]
+                   cast(Any, bucket)._bucket.list_blobs(
+                       name_starts_with=prefix)]
         return ClientPagedResultList(self.provider, objects,
                                      limit=limit, marker=marker)
 
-    def find(self, bucket, **kwargs):
-        obj_list = [AzureBucketObject(self.provider, bucket, obj)
+    def find(self, bucket: Bucket | str,
+             **kwargs: Any) -> ResultList[BucketObject]:
+        provider = cast("AzureCloudProvider", self.provider)
+        azure_bucket = cast("AzureBucket", bucket)
+        obj_list = [AzureBucketObject(provider, azure_bucket, obj)
                     for obj in
-                    bucket._bucket.list_blobs()]
+                    cast(Any, bucket)._bucket.list_blobs()]
         filters = ['name']
         matches = cb_helpers.generic_find(filters, kwargs, obj_list)
         return ClientPagedResultList(self.provider, list(matches))
 
-    def create(self, bucket, name):
-        blob_client = bucket._bucket.get_blob_client(name)
+    def create(self, bucket: Bucket | str, name: str) -> BucketObject:
+        provider = cast("AzureCloudProvider", self.provider)
+        azure_bucket = cast("AzureBucket", bucket)
+        blob_client = cast(Any, bucket)._bucket.get_blob_client(name)
         blob_client.upload_blob('')
-        return AzureBucketObject(self.provider, bucket, blob_client.get_blob_properties())
+        return AzureBucketObject(provider, azure_bucket,
+                                 blob_client.get_blob_properties())
 
     @staticmethod
-    def _block_id(upload_id, part_number):
+    def _block_id(upload_id: str, part_number: int) -> str:
         # Azure requires every block id for a blob to be the same length and
         # base64-encoded. The upload id is a fixed-length uuid hex, so the
         # encoded ids are always equal length.
@@ -604,41 +722,54 @@ class AzureBucketObjectService(BaseBucketObjectService):
 
     @dispatch(event="provider.storage._bucket_objects.create_multipart_upload",
               priority=BaseBucketObjectService.STANDARD_EVENT_PRIORITY)
-    def create_multipart_upload(self, bucket, object_name):
+    def create_multipart_upload(self, bucket: Bucket | str,
+                                object_name: str) -> MultipartUpload:
         # Azure block blobs have no server-side "initiate" step; the upload id
         # only namespaces this upload's block ids.
-        return BaseMultipartUpload(self.provider, bucket, object_name,
-                                   uuid.uuid4().hex)
+        return BaseMultipartUpload(self.provider, cast("Bucket", bucket),
+                                   object_name, uuid.uuid4().hex)
 
     @dispatch(event="provider.storage._bucket_objects.upload_part",
               priority=BaseBucketObjectService.STANDARD_EVENT_PRIORITY)
-    def upload_part(self, bucket, upload, part_number, data):
+    def upload_part(self, bucket: Bucket | str, upload: MultipartUpload,
+                    part_number: int, data: Any) -> UploadPart:
         block_id = self._block_id(upload.id, part_number)
-        self.provider.azure_client.stage_block(
-            bucket.name, upload.object_name, block_id, data)
+        cast("AzureCloudProvider", self.provider).azure_client.stage_block(
+            cast("Bucket", bucket).name, upload.object_name, block_id, data)
         return BaseUploadPart(part_number, block_id)
 
     @dispatch(event="provider.storage._bucket_objects."
                     "complete_multipart_upload",
               priority=BaseBucketObjectService.STANDARD_EVENT_PRIORITY)
-    def complete_multipart_upload(self, bucket, upload, parts):
+    def complete_multipart_upload(self, bucket: Bucket | str,
+                                  upload: MultipartUpload,
+                                  parts: builtins.list[UploadPart]
+                                  ) -> BucketObject:
         ordered = sorted(parts, key=lambda p: p.part_number)
-        self.provider.azure_client.commit_block_list(
-            bucket.name, upload.object_name, [p.etag for p in ordered])
-        return self.get(bucket, upload.object_name)
+        cast("AzureCloudProvider", self.provider).azure_client.\
+            commit_block_list(
+                cast("Bucket", bucket).name, upload.object_name,
+                [p.etag for p in ordered])
+        obj = self.get(bucket, upload.object_name)
+        if obj is None:
+            raise ProviderInternalException(
+                "Object %s not found after completing multipart upload"
+                % upload.object_name)
+        return obj
 
     @dispatch(event="provider.storage._bucket_objects.abort_multipart_upload",
               priority=BaseBucketObjectService.STANDARD_EVENT_PRIORITY)
-    def abort_multipart_upload(self, bucket, upload):
+    def abort_multipart_upload(self, bucket: Bucket | str,
+                               upload: MultipartUpload) -> None:
         # Azure has no server-side abort: uncommitted blocks are garbage
         # collected automatically (after ~7 days), so there is nothing to do.
         log.debug("Azure has no multipart abort; uncommitted blocks for "
                   "%s/%s will expire automatically.",
-                  bucket.name, upload.object_name)
+                  cast("Bucket", bucket).name, upload.object_name)
 
 
 class AzureComputeService(BaseComputeService):
-    def __init__(self, provider):
+    def __init__(self, provider: CloudProvider) -> None:
         super(AzureComputeService, self).__init__(provider)
         self._vm_type_svc = AzureVMTypeService(self.provider)
         self._instance_svc = AzureInstanceService(self.provider)
@@ -646,40 +777,41 @@ class AzureComputeService(BaseComputeService):
         self._images_svc = AzureImageService(self.provider)
 
     @property
-    def images(self):
+    def images(self) -> AzureImageService:
         return self._images_svc
 
     @property
-    def vm_types(self):
+    def vm_types(self) -> AzureVMTypeService:
         return self._vm_type_svc
 
     @property
-    def instances(self):
+    def instances(self) -> AzureInstanceService:
         return self._instance_svc
 
     @property
-    def regions(self):
+    def regions(self) -> AzureRegionService:
         return self._region_svc
 
 
 class AzureImageService(BaseImageService):
-    def __init__(self, provider):
+    def __init__(self, provider: CloudProvider) -> None:
         super(AzureImageService, self).__init__(provider)
 
-    def get(self, image_id):
+    def get(self, image_id: str) -> MachineImage | None:
         """
         Returns an Image given its id
         """
+        provider = cast("AzureCloudProvider", self.provider)
         try:
-            image = self.provider.azure_client.get_image(image_id)
-            return AzureMachineImage(self.provider, image)
+            image = provider.azure_client.get_image(image_id)
+            return AzureMachineImage(provider, image)
         except (ResourceNotFoundError, InvalidValueException) as cloud_error:
             # Azure raises the cloud error if the resource not available
             log.exception(cloud_error)
             return None
 
-    def find(self, **kwargs):
-        obj_list = self
+    def find(self, **kwargs: Any) -> ResultList[MachineImage]:
+        obj_list: builtins.list[MachineImage] = list(self)
         filters = ['label']
         matches = cb_helpers.generic_find(filters, kwargs, obj_list)
 
@@ -692,59 +824,73 @@ class AzureImageService(BaseImageService):
         return ClientPagedResultList(self.provider,
                                      matches if matches else [])
 
-    def list(self, filter_by_owner=True, limit=None, marker=None):
+    def list(self,  # type: ignore[override]
+             filter_by_owner: bool = True, limit: int | None = None,
+             marker: str | None = None) -> ResultList[MachineImage]:
+        # Intentional arguments-differ: image listing accepts a leading
+        # filter_by_owner flag ahead of the base list(limit, marker).
         """
         List all images.
         """
-        azure_images = self.provider.azure_client.list_images()
-        azure_gallery_refs = self.provider.azure_client.list_gallery_refs() \
+        provider = cast("AzureCloudProvider", self.provider)
+        azure_client = provider.azure_client
+        azure_images = azure_client.list_images()
+        azure_gallery_refs = azure_client.list_gallery_refs() \
             if not filter_by_owner else []
-        cb_images = [AzureMachineImage(self.provider, img)
+        cb_images = [AzureMachineImage(provider, img)
                      for img in azure_images + azure_gallery_refs]
         return ClientPagedResultList(self.provider, cb_images,
                                      limit=limit, marker=marker)
 
 
 class AzureInstanceService(BaseInstanceService):
-    def __init__(self, provider):
+    def __init__(self, provider: CloudProvider) -> None:
         super(AzureInstanceService, self).__init__(provider)
 
-    def _resolve_launch_options(self, inst_name, subnet=None, zone_id=None,
-                                vm_firewalls=None):
+    def _resolve_launch_options(
+            self, inst_name: str, subnet: Subnet | None = None,
+            zone_id: str | None = None,
+            vm_firewalls: builtins.list[VMFirewall | str] | None = None
+    ) -> tuple[Any, str | None, Any]:
         if subnet:
             # subnet's zone takes precedence
-            zone_id = subnet.zone.id
+            zone_id = cast(Any, subnet.zone).id
         vm_firewall_id = None
 
         if isinstance(vm_firewalls, list) and len(vm_firewalls) > 0:
 
             if isinstance(vm_firewalls[0], VMFirewall):
-                vm_firewalls_ids = [fw.id for fw in vm_firewalls]
-                vm_firewall_id = vm_firewalls[0].resource_id
+                vm_firewalls_ids = [cast(Any, fw).id for fw in vm_firewalls]
+                vm_firewall_id = cast(Any, vm_firewalls[0]).resource_id
             else:
                 vm_firewalls_ids = vm_firewalls
                 vm_firewall = self.provider.security.\
                     vm_firewalls.get(vm_firewalls[0])
-                vm_firewall_id = vm_firewall.resource_id
+                vm_firewall_id = cast(Any, vm_firewall).resource_id
 
             if len(vm_firewalls) > 1:
-                new_fw = self.provider.security.vm_firewalls.\
+                # FLAGGED FOR REVIEW: this create() omits the required
+                # ``network`` argument (pre-existing bug); cast to Any so the
+                # missing-arg is not masked by a fabricated value here.
+                new_fw = cast(Any, self.provider.security.vm_firewalls).\
                     create(label='{0}-fw'.format(inst_name),
                            description='Merge vm firewall {0}'.
-                           format(','.join(vm_firewalls_ids)))
+                           format(','.join(cast(Any, vm_firewalls_ids))))
 
                 for fw in vm_firewalls:
-                    new_fw.add_rule(src_dest_fw=fw)
+                    cast(Any, new_fw).add_rule(src_dest_fw=fw)
 
-                vm_firewall_id = new_fw.resource_id
+                vm_firewall_id = cast(Any, new_fw).resource_id
 
-        return subnet.resource_id, zone_id, vm_firewall_id
+        return cast(Any, subnet).resource_id, zone_id, vm_firewall_id
 
-    def _create_storage_profile(self, image, launch_config, instance_name):
+    def _create_storage_profile(self, image: MachineImage,
+                                launch_config: LaunchConfig | None,
+                                instance_name: str) -> StorageProfile:
 
-        if image.is_gallery_image:
+        if cast(Any, image).is_gallery_image:
             # pylint:disable=protected-access
-            reference = image._image.as_dict()
+            reference = cast(Any, image)._image.as_dict()
             image_ref = ImageReference(
                 publisher=reference['publisher'],
                 offer=reference['offer'],
@@ -752,11 +898,11 @@ class AzureInstanceService(BaseInstanceService):
                 version=reference['version'],
             )
         else:
-            image_ref = ImageReference(id=image.resource_id)
+            image_ref = ImageReference(id=cast(Any, image).resource_id)
 
         os_disk = OSDisk(
             name=instance_name + '_os_disk',
-            create_option=DiskCreateOption.from_image,
+            create_option=cast(Any, DiskCreateOption.from_image),
         )
 
         data_disks = None
@@ -772,27 +918,32 @@ class AzureInstanceService(BaseInstanceService):
             data_disks=data_disks or None,
         )
 
-    def _process_block_device_mappings(self, launch_config):
+    def _process_block_device_mappings(
+            self, launch_config: LaunchConfig
+    ) -> tuple[builtins.list[Any], int | None]:
         """
         Processes block device mapping information
         and returns a DataDisk model list. If new volumes
         are requested (source is None and destination is VOLUME), they will be
         created and the relevant volume ids included in the mapping.
         """
-        data_disks = []
+        data_disks: builtins.list[Any] = []
         root_disk_size = None
 
-        def append_disk(disk_kwargs, device_no, delete_on_terminate,
-                        managed_disk_id=None):
+        def append_disk(disk_kwargs: dict[str, Any], device_no: int,
+                        delete_on_terminate: bool,
+                        managed_disk_id: str | None = None) -> None:
             # Azure has no direct equivalent of AWS' delete_on_terminate, so
             # the cleanup tag is recorded on the parent VM later; we just
             # carry the flag (and the disk id) alongside the DataDisk model.
             disk = DataDisk(lun=device_no, **disk_kwargs)
-            disk._cb_delete_on_terminate = delete_on_terminate
-            disk._cb_managed_disk_id = managed_disk_id
+            # Stash cloudbridge-only bookkeeping on the SDK model instance.
+            cast(Any, disk)._cb_delete_on_terminate = delete_on_terminate
+            cast(Any, disk)._cb_managed_disk_id = managed_disk_id
             data_disks.append(disk)
 
-        for device_no, device in enumerate(launch_config.block_devices):
+        for device_no, device in enumerate(cast(Any,
+                                                launch_config).block_devices):
             if device.is_volume:
                 if device.is_root:
                     root_disk_size = device.size
@@ -803,7 +954,7 @@ class AzureInstanceService(BaseInstanceService):
                         snapshot_vol = device.source.create_volume()
                         disk_kwargs = {
                             # pylint:disable=protected-access
-                            'name': snapshot_vol._volume.name,
+                            'name': cast(Any, snapshot_vol)._volume.name,
                             'create_option': DiskCreateOption.attach,
                             'managed_disk': ManagedDiskParameters(
                                 id=snapshot_vol.id),
@@ -815,7 +966,7 @@ class AzureInstanceService(BaseInstanceService):
                     elif isinstance(device.source, Volume):
                         disk_kwargs = {
                             # pylint:disable=protected-access
-                            'name': device.source._volume.name,
+                            'name': cast(Any, device.source)._volume.name,
                             'create_option': DiskCreateOption.attach,
                             'managed_disk': ManagedDiskParameters(
                                 id=device.source.id),
@@ -827,7 +978,7 @@ class AzureInstanceService(BaseInstanceService):
                     elif isinstance(device.source, MachineImage):
                         disk_kwargs = {
                             # pylint:disable=protected-access
-                            'name': device.source._volume.name,
+                            'name': cast(Any, device.source)._volume.name,
                             'create_option': DiskCreateOption.from_image,
                             'source_resource_id': device.source.id,
                         }
@@ -844,55 +995,64 @@ class AzureInstanceService(BaseInstanceService):
 
         return data_disks, root_disk_size
 
-    def create_launch_config(self):
-        return AzureLaunchConfig(self.provider)
+    def create_launch_config(self) -> LaunchConfig:
+        return AzureLaunchConfig(cast("AzureCloudProvider", self.provider))
 
     @dispatch(event="provider.compute.instances.create",
               priority=BaseInstanceService.STANDARD_EVENT_PRIORITY)
-    def create(self, label, image, vm_type, subnet,
-               key_pair=None, vm_firewalls=None, user_data=None,
-               launch_config=None, **kwargs):
+    def create(self, label: str, image: MachineImage | str,
+               vm_type: VMType | str, subnet: Subnet | str,
+               key_pair: KeyPair | str | None = None,
+               vm_firewalls: list[VMFirewall | str] | None = None,
+               user_data: str | None = None,
+               launch_config: LaunchConfig | None = None,
+               **kwargs: Any) -> Instance:
         AzureInstance.assert_valid_resource_label(label)
         instance_name = AzureInstance._generate_name_from_label(label,
                                                                 "cb-ins")
 
-        image = (image if isinstance(image, AzureMachineImage) else
-                 self.provider.compute.images.get(image))
-        if not isinstance(image, AzureMachineImage):
+        cb_image = (image if isinstance(image, AzureMachineImage) else
+                    self.provider.compute.images.get(cast(str, image)))
+        if not isinstance(cb_image, AzureMachineImage):
             raise Exception("Provided image %s is not a valid azure image"
                             % image)
 
         instance_size = vm_type.id if \
             isinstance(vm_type, VMType) else vm_type
 
+        cb_subnet: Subnet | None
         if subnet:
-            subnet = (subnet if isinstance(subnet, AzureSubnet) else
-                      self.provider.networking.subnets.get(subnet))
+            cb_subnet = (subnet if isinstance(subnet, AzureSubnet) else
+                         self.provider.networking.subnets.get(
+                             cast(str, subnet)))
         else:
-            subnet = self.provider.networking.subnets.get_or_create_default()
+            cb_subnet = cast(
+                Any,
+                self.provider.networking.subnets).get_or_create_default()
 
         zone_name = self.provider.zone_name
 
         subnet_id, zone_id, vm_firewall_id = \
             self._resolve_launch_options(instance_name,
-                                         subnet, zone_name, vm_firewalls)
+                                         cb_subnet, zone_name, vm_firewalls)
 
-        storage_profile = self._create_storage_profile(image, launch_config,
+        storage_profile = self._create_storage_profile(cb_image, launch_config,
                                                        instance_name)
 
-        nic_params = {
+        azure_client = cast("AzureCloudProvider", self.provider).azure_client
+        nic_params: dict[str, Any] = {
             'location': self.provider.region_name,
             'ip_configurations': [NetworkInterfaceIPConfiguration(
                 name=instance_name + '_ip_config',
                 private_ip_allocation_method='Dynamic',
-                subnet=SubResource(id=subnet_id),
+                subnet=cast(Any, SubResource(id=subnet_id)),
             )],
         }
 
         if vm_firewall_id:
             nic_params['network_security_group'] = SubResource(
                 id=vm_firewall_id)
-        nic_info = self.provider.azure_client.create_nic(
+        nic_info = azure_client.create_nic(
             instance_name + '_nic',
             nic_params
         )
@@ -903,9 +1063,11 @@ class AzureInstanceService(BaseInstanceService):
 
         # Key_pair is mandatory in azure and it should not be None.
         temp_key_pair = None
+        cb_key_pair: KeyPair | None
         if key_pair:
-            key_pair = (key_pair if isinstance(key_pair, AzureKeyPair)
-                        else self.provider.security.key_pairs.get(key_pair))
+            cb_key_pair = (key_pair if isinstance(key_pair, AzureKeyPair)
+                           else self.provider.security.key_pairs.get(
+                               cast(str, key_pair)))
         else:
             # Create a temporary keypair if none is provided to keep Azure
             # happy, but the private key will be discarded, so it'll be all
@@ -915,31 +1077,33 @@ class AzureInstanceService(BaseInstanceService):
             temp_kp_name = "".join(["cb-default-kp-",
                                    str(uuid.uuid5(uuid.NAMESPACE_OID,
                                                   instance_name))[-6:]])
-            key_pair = self.provider.security.key_pairs.create(
+            cb_key_pair = self.provider.security.key_pairs.create(
                 name=temp_kp_name)
-            temp_key_pair = key_pair
+            temp_key_pair = cb_key_pair
 
         os_profile = OSProfile(
-            admin_username=self.provider.vm_default_user_name,
+            admin_username=cast(
+                "AzureCloudProvider", self.provider).vm_default_user_name,
             computer_name=instance_name,
             linux_configuration=LinuxConfiguration(
                 disable_password_authentication=True,
                 ssh=SshConfiguration(public_keys=[SshPublicKey(
                     path="/home/{}/.ssh/authorized_keys".format(
-                        self.provider.vm_default_user_name),
-                    key_data=key_pair._key_pair['Key'],
+                        cast("AzureCloudProvider",
+                             self.provider).vm_default_user_name),
+                    key_data=cast(Any, cb_key_pair)._key_pair['Key'],
                 )]),
             ),
         )
 
-        tags = {'Label': label}
+        tags: dict[str, Any] = {'Label': label}
         # Surface each data disk's delete-on-terminate flag onto the parent
         # VM tags so the VM-delete path can later clean them up.
         for disk in (storage_profile.data_disks or []):
             tags['delete_on_terminate'] = getattr(
                 disk, '_cb_delete_on_terminate', False)
 
-        params = {
+        params: dict[str, Any] = {
             'location': zone_id,
             'os_profile': os_profile,
             'hardware_profile': HardwareProfile(vm_size=instance_size),
@@ -952,50 +1116,54 @@ class AzureInstanceService(BaseInstanceService):
         }
 
         if user_data:
-            custom_data = base64.b64encode(bytes(ud, 'utf-8'))
+            custom_data = base64.b64encode(bytes(cast(str, ud), 'utf-8'))
             params['os_profile'].custom_data = str(custom_data, 'utf-8')
 
         if not temp_key_pair:
-            params['tags'].update(Key_Pair=key_pair.id)
+            params['tags'].update(Key_Pair=cast(Any, cb_key_pair).id)
 
         try:
-            vm = self.provider.azure_client.create_vm(instance_name, params)
+            vm = azure_client.create_vm(instance_name, params)
         except Exception as e:
             # If VM creation fails, attempt to clean up intermediary resources
-            self.provider.azure_client.delete_nic(nic_info.id)
+            azure_client.delete_nic(nic_info.id)
             for disk in (storage_profile.data_disks or []):
                 if getattr(disk, '_cb_delete_on_terminate', False):
                     disk_id = getattr(disk, '_cb_managed_disk_id', None)
                     if disk_id:
                         vol = self.provider.storage.volumes.get(disk_id)
-                        vol.delete()
+                        if vol:
+                            vol.delete()
             raise e
         finally:
             if temp_key_pair:
                 temp_key_pair.delete()
-        return AzureInstance(self.provider, vm)
+        return AzureInstance(cast("AzureCloudProvider", self.provider), vm)
 
     @dispatch(event="provider.compute.instances.list",
               priority=BaseInstanceService.STANDARD_EVENT_PRIORITY)
-    def list(self, limit=None, marker=None):
+    def list(self, limit: int | None = None,
+             marker: str | None = None) -> ResultList[Instance]:
         """
         List all instances.
         """
-        instances = [AzureInstance(self.provider, inst)
-                     for inst in self.provider.azure_client.list_vm()]
+        provider = cast("AzureCloudProvider", self.provider)
+        instances = [AzureInstance(provider, inst)
+                     for inst in provider.azure_client.list_vm()]
         return ClientPagedResultList(self.provider, instances,
                                      limit=limit, marker=marker)
 
     @dispatch(event="provider.compute.instances.get",
               priority=BaseInstanceService.STANDARD_EVENT_PRIORITY)
-    def get(self, instance_id):
+    def get(self, instance_id: str) -> Instance | None:
         """
         Returns an instance given its id. Returns None
         if the object does not exist.
         """
+        provider = cast("AzureCloudProvider", self.provider)
         try:
-            vm = self.provider.azure_client.get_vm(instance_id)
-            return AzureInstance(self.provider, vm)
+            vm = provider.azure_client.get_vm(instance_id)
+            return AzureInstance(provider, vm)
         except (ResourceNotFoundError, InvalidValueException) as cloud_error:
             # Azure raises the cloud error if the resource not available
             log.exception(cloud_error)
@@ -1003,8 +1171,8 @@ class AzureInstanceService(BaseInstanceService):
 
     @dispatch(event="provider.compute.instances.find",
               priority=BaseInstanceService.STANDARD_EVENT_PRIORITY)
-    def find(self, **kwargs):
-        obj_list = self
+    def find(self, **kwargs: Any) -> ResultList[Instance]:
+        obj_list: builtins.list[Instance] = list(self)
         filters = ['label']
         matches = cb_helpers.generic_find(filters, kwargs, obj_list)
 
@@ -1019,7 +1187,7 @@ class AzureInstanceService(BaseInstanceService):
 
     @dispatch(event="provider.compute.instances.delete",
               priority=BaseInstanceService.STANDARD_EVENT_PRIORITY)
-    def delete(self, instance):
+    def delete(self, instance: Instance | str) -> None:
         """
         Permanently terminate this instance.
         After deleting the VM. we are deleting the network interface
@@ -1027,84 +1195,90 @@ class AzureInstanceService(BaseInstanceService):
         where tag with name 'delete_on_terminate' has value True.
         """
         ins = (instance if isinstance(instance, AzureInstance) else
-               self.get(instance))
-        if not instance:
+               self.get(cast(str, instance)))
+        if not ins:
             return
 
+        azure_client = cast("AzureCloudProvider", self.provider).azure_client
         # Remove IPs first to avoid a network interface conflict
         # pylint:disable=protected-access
-        for public_ip_id in ins._public_ip_ids:
+        for public_ip_id in cast(Any, ins)._public_ip_ids:
             ins.remove_floating_ip(public_ip_id)
-        self.provider.azure_client.deallocate_vm(ins.id)
-        self.provider.azure_client.delete_vm(ins.id)
+        azure_client.deallocate_vm(ins.id)
+        azure_client.delete_vm(ins.id)
         # pylint:disable=protected-access
-        for nic_id in ins._nic_ids:
-            self.provider.azure_client.delete_nic(nic_id)
+        for nic_id in cast(Any, ins)._nic_ids:
+            azure_client.delete_nic(nic_id)
         # pylint:disable=protected-access
-        for data_disk in ins._vm.storage_profile.data_disks:
+        for data_disk in cast(Any, ins)._vm.storage_profile.data_disks:
             if data_disk.managed_disk:
                 # pylint:disable=protected-access
-                if ins._vm.tags.get('delete_on_terminate',
-                                    'False') == 'True':
-                    self.provider.azure_client. \
-                        delete_disk(data_disk.managed_disk.id)
+                if cast(Any, ins)._vm.tags.get('delete_on_terminate',
+                                               'False') == 'True':
+                    azure_client.delete_disk(data_disk.managed_disk.id)
         # pylint:disable=protected-access
-        if ins._vm.storage_profile.os_disk.managed_disk:
-            self.provider.azure_client. \
-                delete_disk(ins._vm.storage_profile.os_disk.managed_disk.id)
+        if cast(Any, ins)._vm.storage_profile.os_disk.managed_disk:
+            azure_client.delete_disk(
+                cast(Any, ins)._vm.storage_profile.os_disk.managed_disk.id)
 
 
 class AzureVMTypeService(BaseVMTypeService):
 
-    def __init__(self, provider):
+    def __init__(self, provider: CloudProvider) -> None:
         super(AzureVMTypeService, self).__init__(provider)
 
     @property
-    def instance_data(self):
+    def instance_data(self) -> Any:
         """
         Fetch info about the available instances.
         """
-        r = self.provider.azure_client.list_vm_types()
+        r = cast("AzureCloudProvider", self.provider).azure_client.\
+            list_vm_types()
         return r
 
     @dispatch(event="provider.compute.vm_types.list",
               priority=BaseVMTypeService.STANDARD_EVENT_PRIORITY)
-    def list(self, limit=None, marker=None):
-        vm_types = [AzureVMType(self.provider, vm_type)
+    def list(self, limit: int | None = None,
+             marker: str | None = None) -> ResultList[VMType]:
+        provider = cast("AzureCloudProvider", self.provider)
+        vm_types = [AzureVMType(provider, vm_type)
                     for vm_type in self.instance_data]
         return ClientPagedResultList(self.provider, vm_types,
                                      limit=limit, marker=marker)
 
 
 class AzureRegionService(BaseRegionService):
-    def __init__(self, provider):
+    def __init__(self, provider: CloudProvider) -> None:
         super(AzureRegionService, self).__init__(provider)
 
     @dispatch(event="provider.compute.regions.get",
               priority=BaseRegionService.STANDARD_EVENT_PRIORITY)
-    def get(self, region_id):
+    def get(self, region_id: str) -> Region | None:
+        provider = cast("AzureCloudProvider", self.provider)
         region = None
-        for azureRegion in self.provider.azure_client.list_locations():
+        for azureRegion in provider.azure_client.list_locations():
             if azureRegion.name == region_id:
-                region = AzureRegion(self.provider, azureRegion)
+                region = AzureRegion(provider, azureRegion)
                 break
         return region
 
     @dispatch(event="provider.compute.regions.list",
               priority=BaseRegionService.STANDARD_EVENT_PRIORITY)
-    def list(self, limit=None, marker=None):
-        regions = [AzureRegion(self.provider, region)
-                   for region in self.provider.azure_client.list_locations()]
+    def list(self, limit: int | None = None,
+             marker: str | None = None) -> ResultList[Region]:
+        provider = cast("AzureCloudProvider", self.provider)
+        regions = [AzureRegion(provider, region)
+                   for region in provider.azure_client.list_locations()]
         return ClientPagedResultList(self.provider, regions,
                                      limit=limit, marker=marker)
 
     @property
-    def current(self):
+    def current(self) -> Region | None:
         return self.get(self.provider.region_name)
 
 
 class AzureNetworkingService(BaseNetworkingService):
-    def __init__(self, provider):
+    def __init__(self, provider: CloudProvider) -> None:
         super(AzureNetworkingService, self).__init__(provider)
         self._network_service = AzureNetworkService(self.provider)
         self._subnet_service = AzureSubnetService(self.provider)
@@ -1113,36 +1287,37 @@ class AzureNetworkingService(BaseNetworkingService):
         self._floating_ip_service = AzureFloatingIPService(self.provider)
 
     @property
-    def networks(self):
+    def networks(self) -> AzureNetworkService:
         return self._network_service
 
     @property
-    def subnets(self):
+    def subnets(self) -> AzureSubnetService:
         return self._subnet_service
 
     @property
-    def routers(self):
+    def routers(self) -> AzureRouterService:
         return self._router_service
 
     @property
-    def _gateways(self):
+    def _gateways(self) -> AzureGatewayService:
         return self._gateway_service
 
     @property
-    def _floating_ips(self):
+    def _floating_ips(self) -> AzureFloatingIPService:
         return self._floating_ip_service
 
 
 class AzureNetworkService(BaseNetworkService):
-    def __init__(self, provider):
+    def __init__(self, provider: CloudProvider) -> None:
         super(AzureNetworkService, self).__init__(provider)
 
     @dispatch(event="provider.networking.networks.get",
               priority=BaseNetworkService.STANDARD_EVENT_PRIORITY)
-    def get(self, network_id):
+    def get(self, network_id: str) -> Network | None:
+        provider = cast("AzureCloudProvider", self.provider)
         try:
-            network = self.provider.azure_client.get_network(network_id)
-            return AzureNetwork(self.provider, network)
+            network = provider.azure_client.get_network(network_id)
+            return AzureNetwork(provider, network)
         except (ResourceNotFoundError, InvalidValueException) as cloud_error:
             # Azure raises the cloud error if the resource not available
             log.exception(cloud_error)
@@ -1150,18 +1325,22 @@ class AzureNetworkService(BaseNetworkService):
 
     @dispatch(event="provider.networking.networks.list",
               priority=BaseNetworkService.STANDARD_EVENT_PRIORITY)
-    def list(self, limit=None, marker=None):
-        networks = [AzureNetwork(self.provider, network)
-                    for network in self.provider.azure_client.list_networks()]
+    def list(self, limit: int | None = None,
+             marker: str | None = None) -> ResultList[Network]:
+        provider = cast("AzureCloudProvider", self.provider)
+        networks = [AzureNetwork(provider, network)
+                    for network in provider.azure_client.list_networks()]
         return ClientPagedResultList(self.provider, networks,
                                      limit=limit, marker=marker)
 
     @dispatch(event="provider.networking.networks.create",
               priority=BaseNetworkService.STANDARD_EVENT_PRIORITY)
-    def create(self, label, cidr_block):
+    def create(self, label: str, cidr_block: str) -> Network:
         AzureNetwork.assert_valid_resource_label(label)
+        provider = cast("AzureCloudProvider", self.provider)
+        azure_client = provider.azure_client
         params = {
-            'location': self.provider.azure_client.region_name,
+            'location': azure_client.region_name,
             'address_space': AddressSpace(
                 address_prefixes=[cidr_block]),
             'tags': {'Label': label}
@@ -1169,55 +1348,60 @@ class AzureNetworkService(BaseNetworkService):
 
         network_name = AzureNetwork._generate_name_from_label(label, 'cb-net')
 
-        az_network = self.provider.azure_client.create_network(network_name,
-                                                               params)
-        cb_network = AzureNetwork(self.provider, az_network)
+        az_network = azure_client.create_network(network_name, params)
+        cb_network = AzureNetwork(provider, az_network)
         return cb_network
 
     @dispatch(event="provider.networking.networks.delete",
               priority=BaseNetworkService.STANDARD_EVENT_PRIORITY)
-    def delete(self, network):
+    def delete(self, network: Network | str) -> None:
         net_id = network.id if isinstance(network, AzureNetwork) else network
         if net_id:
-            self.provider.azure_client.delete_network(net_id)
+            cast("AzureCloudProvider", self.provider).azure_client.\
+                delete_network(net_id)
 
 
 class AzureSubnetService(BaseSubnetService):
 
-    def __init__(self, provider):
+    def __init__(self, provider: CloudProvider) -> None:
         super(AzureSubnetService, self).__init__(provider)
 
-    def _list_subnets(self, network=None):
+    def _list_subnets(
+            self, network: Network | str | None = None
+    ) -> builtins.list[AzureSubnet]:
         result_list = []
+        provider = cast("AzureCloudProvider", self.provider)
+        azure_client = provider.azure_client
         if network:
             network_id = network.id \
                 if isinstance(network, Network) else network
-            result_list = self.provider.azure_client.list_subnets(network_id)
+            result_list = azure_client.list_subnets(network_id)
         else:
             for net in self.provider.networking.networks:
                 try:
-                    result_list.extend(self.provider.azure_client.list_subnets(
+                    result_list.extend(azure_client.list_subnets(
                         net.id
                     ))
                 except ResourceNotFoundError as not_found_error:
                     log.exception(not_found_error)
-        subnets = [AzureSubnet(self.provider, subnet)
+        subnets = [AzureSubnet(provider, subnet)
                    for subnet in result_list]
 
         return subnets
 
     @dispatch(event="provider.networking.subnets.get",
               priority=BaseSubnetService.STANDARD_EVENT_PRIORITY)
-    def get(self, subnet_id):
+    def get(self, subnet_id: str) -> Subnet | None:
         """
          Azure does not provide an api to get the subnet directly by id.
          It also requires the network id.
          To make it consistent across the providers the following code
          gets the specific code from the subnet list.
         """
+        provider = cast("AzureCloudProvider", self.provider)
         try:
-            azure_subnet = self.provider.azure_client.get_subnet(subnet_id)
-            return AzureSubnet(self.provider,
+            azure_subnet = provider.azure_client.get_subnet(subnet_id)
+            return AzureSubnet(provider,
                                azure_subnet) if azure_subnet else None
         except (ResourceNotFoundError, InvalidValueException) as cloud_error:
             # Azure raises the cloud error if the resource not available
@@ -1226,14 +1410,19 @@ class AzureSubnetService(BaseSubnetService):
 
     @dispatch(event="provider.networking.subnets.list",
               priority=BaseSubnetService.STANDARD_EVENT_PRIORITY)
-    def list(self, network=None, limit=None, marker=None):
+    def list(self, network: Network | str | None = None,
+             limit: int | None = None,
+             marker: str | None = None) -> ResultList[Subnet]:
+        # The base SubnetService.list already accepts a leading network
+        # filter ahead of list(limit, marker).
         return ClientPagedResultList(self.provider,
                                      self._list_subnets(network),
                                      limit=limit, marker=marker)
 
     @dispatch(event="provider.networking.subnets.find",
               priority=BaseSubnetService.STANDARD_EVENT_PRIORITY)
-    def find(self, network=None, **kwargs):
+    def find(self, network: Network | None = None,
+             **kwargs: Any) -> ResultList[Subnet]:
         obj_list = self._list_subnets(network)
         filters = ['label']
         matches = cb_helpers.generic_find(filters, kwargs, obj_list)
@@ -1243,7 +1432,8 @@ class AzureSubnetService(BaseSubnetService):
 
     @dispatch(event="provider.networking.subnets.create",
               priority=BaseSubnetService.STANDARD_EVENT_PRIORITY)
-    def create(self, label, network, cidr_block):
+    def create(self, label: str, network: Network | str,
+               cidr_block: str) -> Subnet:
         AzureSubnet.assert_valid_resource_label(label)
         # Although Subnet doesn't support tags in Azure, we use the parent
         # Network's tags to track its subnets' labels
@@ -1252,45 +1442,48 @@ class AzureSubnetService(BaseSubnetService):
         network_id = network.id \
             if isinstance(network, Network) else network
 
-        subnet_info = self.provider.azure_client\
-            .create_subnet(
-                network_id,
-                subnet_name,
-                {
-                    'address_prefix': cidr_block
-                }
-            )
+        provider = cast("AzureCloudProvider", self.provider)
+        subnet_info = provider.azure_client.create_subnet(
+            network_id,
+            subnet_name,
+            {
+                'address_prefix': cidr_block
+            }
+        )
 
-        subnet = AzureSubnet(self.provider, subnet_info)
+        subnet = AzureSubnet(provider, subnet_info)
         subnet.label = label
         return subnet
 
     @dispatch(event="provider.networking.subnets.delete",
               priority=BaseSubnetService.STANDARD_EVENT_PRIORITY)
-    def delete(self, subnet):
+    def delete(self, subnet: Subnet | str) -> None:
         sn = subnet if isinstance(subnet, AzureSubnet) else self.get(subnet)
         if sn:
-            self.provider.azure_client.delete_subnet(sn.id)
+            azure_client = cast(
+                "AzureCloudProvider", self.provider).azure_client
+            azure_client.delete_subnet(sn.id)
             # Although Subnet doesn't support labels, we use the parent
             # Network's tags to track the subnet's labels, thus that
             # network-level tag must be deleted with the subnet
             net_id = sn.network_id
-            az_network = self.provider.azure_client.get_network(net_id)
+            az_network = azure_client.get_network(net_id)
             az_network.tags.pop(sn.tag_name)
-            self.provider.azure_client.update_network_tags(
+            azure_client.update_network_tags(
                 az_network.id, az_network.tags)
 
 
 class AzureRouterService(BaseRouterService):
-    def __init__(self, provider):
+    def __init__(self, provider: CloudProvider) -> None:
         super(AzureRouterService, self).__init__(provider)
 
     @dispatch(event="provider.networking.routers.get",
               priority=BaseRouterService.STANDARD_EVENT_PRIORITY)
-    def get(self, router_id):
+    def get(self, router_id: str) -> Router | None:
+        provider = cast("AzureCloudProvider", self.provider)
         try:
-            route = self.provider.azure_client.get_route_table(router_id)
-            return AzureRouter(self.provider, route)
+            route = provider.azure_client.get_route_table(router_id)
+            return AzureRouter(provider, route)
         except (ResourceNotFoundError, InvalidValueException) as cloud_error:
             # Azure raises the cloud error if the resource not available
             log.exception(cloud_error)
@@ -1298,8 +1491,8 @@ class AzureRouterService(BaseRouterService):
 
     @dispatch(event="provider.networking.routers.find",
               priority=BaseRouterService.STANDARD_EVENT_PRIORITY)
-    def find(self, **kwargs):
-        obj_list = self
+    def find(self, **kwargs: Any) -> ResultList[Router]:
+        obj_list: builtins.list[Router] = list(self)
         filters = ['label']
         matches = cb_helpers.generic_find(filters, kwargs, obj_list)
 
@@ -1314,36 +1507,39 @@ class AzureRouterService(BaseRouterService):
 
     @dispatch(event="provider.networking.routers.list",
               priority=BaseRouterService.STANDARD_EVENT_PRIORITY)
-    def list(self, limit=None, marker=None):
-        routes = [AzureRouter(self.provider, route)
-                  for route in
-                  self.provider.azure_client.list_route_tables()]
+    def list(self, limit: int | None = None,
+             marker: str | None = None) -> ResultList[Router]:
+        provider = cast("AzureCloudProvider", self.provider)
+        routes = [AzureRouter(provider, route)
+                  for route in provider.azure_client.list_route_tables()]
         return ClientPagedResultList(self.provider,
                                      routes,
                                      limit=limit, marker=marker)
 
     @dispatch(event="provider.networking.routers.create",
               priority=BaseRouterService.STANDARD_EVENT_PRIORITY)
-    def create(self, label, network):
+    def create(self, label: str, network: Network | str) -> Router:
         router_name = AzureRouter._generate_name_from_label(label, "cb-router")
 
         parameters = {"location": self.provider.region_name,
                       "tags": {'Label': label}}
 
-        route = self.provider.azure_client. \
-            create_route_table(router_name, parameters)
-        return AzureRouter(self.provider, route)
+        provider = cast("AzureCloudProvider", self.provider)
+        route = provider.azure_client.create_route_table(
+            router_name, parameters)
+        return AzureRouter(provider, route)
 
     @dispatch(event="provider.networking.routers.delete",
               priority=BaseRouterService.STANDARD_EVENT_PRIORITY)
-    def delete(self, router):
+    def delete(self, router: Router | str) -> None:
         r = router if isinstance(router, AzureRouter) else self.get(router)
         if r:
-            self.provider.azure_client.delete_route_table(r.name)
+            cast("AzureCloudProvider", self.provider).azure_client.\
+                delete_route_table(r.name)
 
 
 class AzureGatewayService(BaseGatewayService):
-    def __init__(self, provider):
+    def __init__(self, provider: CloudProvider) -> None:
         super(AzureGatewayService, self).__init__(provider)
 
     # Azure doesn't have a notion of a route table or an internet
@@ -1351,17 +1547,23 @@ class AzureGatewayService(BaseGatewayService):
     # AzureInternetGateway here.
     # http://bit.ly/2BqGdVh
     # Singleton returned by the list and get methods
-    def _gateway_singleton(self, network):
-        return AzureInternetGateway(self.provider, None, network)
+    def _gateway_singleton(self,
+                           network: Network | str) -> AzureInternetGateway:
+        return AzureInternetGateway(
+            cast("AzureCloudProvider", self.provider), None,
+            cast("AzureNetwork | str", network))
 
     @dispatch(event="provider.networking.gateways.get_or_create",
               priority=BaseGatewayService.STANDARD_EVENT_PRIORITY)
-    def get_or_create(self, network):
+    def get_or_create(self, network: Network | str) -> InternetGateway:
         return self._gateway_singleton(network)
 
     @dispatch(event="provider.networking.gateways.list",
               priority=BaseGatewayService.STANDARD_EVENT_PRIORITY)
-    def list(self, network, limit=None, marker=None):
+    def list(self, network: Network | str, limit: int | None = None,
+             marker: str | None = None) -> ResultList[Gateway]:
+        # The base GatewayService.list already requires a leading network
+        # argument ahead of list(limit, marker).
         gws = [self._gateway_singleton(network)]
         return ClientPagedResultList(self.provider,
                                      gws,
@@ -1369,42 +1571,46 @@ class AzureGatewayService(BaseGatewayService):
 
     @dispatch(event="provider.networking.gateways.delete",
               priority=BaseGatewayService.STANDARD_EVENT_PRIORITY)
-    def delete(self, network, gateway):
+    def delete(self, network: Network | str, gateway: Gateway) -> None:
         pass
 
 
 class AzureFloatingIPService(BaseFloatingIPService):
 
-    def __init__(self, provider):
+    def __init__(self, provider: CloudProvider) -> None:
         super(AzureFloatingIPService, self).__init__(provider)
 
     @dispatch(event="provider.networking.floating_ips.get",
               priority=BaseFloatingIPService.STANDARD_EVENT_PRIORITY)
-    def get(self, gateway, fip_id):
+    def get(self, gateway: Gateway, fip_id: str) -> FloatingIP | None:
+        provider = cast("AzureCloudProvider", self.provider)
         try:
-            az_ip = self.provider.azure_client.get_floating_ip(fip_id)
+            az_ip = provider.azure_client.get_floating_ip(fip_id)
         except (ResourceNotFoundError, InvalidValueException) as cloud_error:
             # Azure raises the cloud error if the resource not available
             log.exception(cloud_error)
             return None
-        return AzureFloatingIP(self.provider, az_ip)
+        return AzureFloatingIP(provider, az_ip)
 
     @dispatch(event="provider.networking.floating_ips.list",
               priority=BaseFloatingIPService.STANDARD_EVENT_PRIORITY)
-    def list(self, gateway, limit=None, marker=None):
-        floating_ips = [AzureFloatingIP(self.provider, floating_ip)
-                        for floating_ip in self.provider.azure_client.
-                        list_floating_ips()]
+    def list(self, gateway: Gateway, limit: int | None = None,
+             marker: str | None = None) -> ResultList[FloatingIP]:
+        provider = cast("AzureCloudProvider", self.provider)
+        floating_ips = [AzureFloatingIP(provider, floating_ip)
+                        for floating_ip in
+                        provider.azure_client.list_floating_ips()]
         return ClientPagedResultList(self.provider, floating_ips,
                                      limit=limit, marker=marker)
 
     @dispatch(event="provider.networking.floating_ips.create",
               priority=BaseFloatingIPService.STANDARD_EVENT_PRIORITY)
-    def create(self, gateway):
+    def create(self, gateway: Gateway) -> FloatingIP:
+        azure_client = cast("AzureCloudProvider", self.provider).azure_client
         # Basic-SKU public IPs are retired in most Azure subscriptions
         # (quota=0). Standard SKU requires Static allocation.
         public_ip_parameters = {
-            'location': self.provider.azure_client.region_name,
+            'location': azure_client.region_name,
             'public_ip_allocation_method': 'Static',
             'sku': PublicIPAddressSku(name=PublicIPAddressSkuName.STANDARD),
         }
@@ -1412,22 +1618,24 @@ class AzureFloatingIPService(BaseFloatingIPService):
         public_ip_name = AzureFloatingIP._generate_name_from_label(
             None, 'cb-fip-')
 
-        floating_ip = self.provider.azure_client.\
-            create_floating_ip(public_ip_name, public_ip_parameters)
-        return AzureFloatingIP(self.provider, floating_ip)
+        floating_ip = azure_client.create_floating_ip(
+            public_ip_name, public_ip_parameters)
+        return AzureFloatingIP(cast("AzureCloudProvider", self.provider),
+                               floating_ip)
 
     @dispatch(event="provider.networking.floating_ips.delete",
               priority=BaseFloatingIPService.STANDARD_EVENT_PRIORITY)
-    def delete(self, gateway, fip):
+    def delete(self, gateway: Gateway, fip: FloatingIP | str) -> None:
         fip_id = fip.id if isinstance(fip, AzureFloatingIP) else fip
-        self.provider.azure_client.delete_floating_ip(fip_id)
+        cast("AzureCloudProvider", self.provider).azure_client.\
+            delete_floating_ip(fip_id)
 
 
-def _strip_trailing_dot(name):
+def _strip_trailing_dot(name: str | None) -> str | None:
     return name[:-1] if name and name.endswith('.') else name
 
 
-def _to_relative_record_name(fqdn, zone_name):
+def _to_relative_record_name(fqdn: str | None, zone_name: str | None) -> str:
     """Translate a cloudbridge FQDN record name to Azure's relative form.
 
     Azure's record set API works with names relative to the zone (e.g.
@@ -1435,8 +1643,8 @@ def _to_relative_record_name(fqdn, zone_name):
     zone apex. cloudbridge callers pass either the bare zone (apex) or a
     dotted FQDN such as ``foo.example.com.``.
     """
-    name = _strip_trailing_dot(fqdn) if fqdn else ''
-    zone = _strip_trailing_dot(zone_name) if zone_name else ''
+    name = (_strip_trailing_dot(fqdn) or '') if fqdn else ''
+    zone = (_strip_trailing_dot(zone_name) or '') if zone_name else ''
     if not name or name == zone:
         return '@'
     suffix = '.' + zone
@@ -1447,7 +1655,7 @@ def _to_relative_record_name(fqdn, zone_name):
 
 class AzureDnsService(BaseDnsService):
 
-    def __init__(self, provider):
+    def __init__(self, provider: CloudProvider) -> None:
         super(AzureDnsService, self).__init__(provider)
 
         # Initialize provider services
@@ -1455,47 +1663,51 @@ class AzureDnsService(BaseDnsService):
         self._record_svc = AzureDnsRecordService(self.provider)
 
     @property
-    def host_zones(self):
+    def host_zones(self) -> AzureDnsZoneService:
         return self._zone_svc
 
     @property
-    def _records(self):
+    def _records(self) -> AzureDnsRecordService:
         return self._record_svc
 
 
 class AzureDnsZoneService(BaseDnsZoneService):
 
-    def __init__(self, provider):
+    def __init__(self, provider: CloudProvider) -> None:
         super(AzureDnsZoneService, self).__init__(provider)
 
     @dispatch(event="provider.dns.host_zones.get",
               priority=BaseDnsZoneService.STANDARD_EVENT_PRIORITY)
-    def get(self, dns_zone_id):
+    def get(self, dns_zone_id: str) -> DnsZone | None:
+        provider = cast("AzureCloudProvider", self.provider)
         try:
-            zone = self.provider.azure_client.get_dns_zone(
+            zone = provider.azure_client.get_dns_zone(
                 _strip_trailing_dot(dns_zone_id))
-            return AzureDnsZone(self.provider, zone)
+            return AzureDnsZone(provider, zone)
         except ResourceNotFoundError:
             return None
 
     @dispatch(event="provider.dns.host_zones.list",
               priority=BaseDnsZoneService.STANDARD_EVENT_PRIORITY)
-    def list(self, limit=None, marker=None):
-        zones = [AzureDnsZone(self.provider, z)
-                 for z in self.provider.azure_client.list_dns_zones()]
+    def list(self, limit: int | None = None,
+             marker: str | None = None) -> ResultList[DnsZone]:
+        provider = cast("AzureCloudProvider", self.provider)
+        zones = [AzureDnsZone(provider, z)
+                 for z in provider.azure_client.list_dns_zones()]
         return ClientPagedResultList(self.provider, zones, limit, marker)
 
     @dispatch(event="provider.dns.host_zones.find",
               priority=BaseDnsZoneService.STANDARD_EVENT_PRIORITY)
-    def find(self, **kwargs):
+    def find(self, **kwargs: Any) -> ResultList[DnsZone]:
         filters = ['name']
-        matches = cb_helpers.generic_find(filters, kwargs, self)
+        obj_list: builtins.list[DnsZone] = list(self)
+        matches = cb_helpers.generic_find(filters, kwargs, obj_list)
         return ClientPagedResultList(self.provider, list(matches),
                                      limit=None, marker=None)
 
     @dispatch(event="provider.dns.host_zones.create",
               priority=BaseDnsZoneService.STANDARD_EVENT_PRIORITY)
-    def create(self, name, admin_email):
+    def create(self, name: str, admin_email: str) -> DnsZone:
         AzureDnsZone.assert_valid_resource_name(name)
         zone_name = _strip_trailing_dot(name)
         params = {
@@ -1504,33 +1716,40 @@ class AzureDnsZoneService(BaseDnsZoneService):
             'location': 'global',
             'tags': {'admin_email': admin_email},
         }
-        zone = self.provider.azure_client.create_dns_zone(zone_name, params)
-        return AzureDnsZone(self.provider, zone)
+        provider = cast("AzureCloudProvider", self.provider)
+        zone = provider.azure_client.create_dns_zone(zone_name, params)
+        return AzureDnsZone(provider, zone)
 
     @dispatch(event="provider.dns.host_zones.delete",
               priority=BaseDnsZoneService.STANDARD_EVENT_PRIORITY)
-    def delete(self, dns_zone):
-        zone_name = (dns_zone.id if isinstance(dns_zone, AzureDnsZone)
+    def delete(self, dns_zone: DnsZone | str) -> None:
+        zone_name = (dns_zone.id if isinstance(dns_zone, DnsZone)
                      else dns_zone)
-        self.provider.azure_client.delete_dns_zone(
-            _strip_trailing_dot(zone_name))
+        cast("AzureCloudProvider", self.provider).azure_client.\
+            delete_dns_zone(_strip_trailing_dot(zone_name))
 
 
 class AzureDnsRecordService(BaseDnsRecordService):
 
-    def __init__(self, provider):
+    def __init__(self, provider: CloudProvider) -> None:
         super(AzureDnsRecordService, self).__init__(provider)
 
-    def _to_record_params(self, rec_type, data, ttl):
+    def _to_record_params(self, rec_type: str, data: str | builtins.list[str],
+                          ttl: int | None) -> dict[str, Any]:
         """Translate cloudbridge data to Azure record-set parameters."""
         # Local imports keep the module importable when azure-mgmt-dns
         # isn't installed (e.g. on AWS-only test environments).
-        from azure.mgmt.dns.models import (AaaaRecord, ARecord, CnameRecord,
-                                           MxRecord, NsRecord, PtrRecord,
-                                           SrvRecord, TxtRecord)
+        from azure.mgmt.dns.models import AaaaRecord
+        from azure.mgmt.dns.models import ARecord
+        from azure.mgmt.dns.models import CnameRecord
+        from azure.mgmt.dns.models import MxRecord
+        from azure.mgmt.dns.models import NsRecord
+        from azure.mgmt.dns.models import PtrRecord
+        from azure.mgmt.dns.models import SrvRecord
+        from azure.mgmt.dns.models import TxtRecord
 
         values = data if isinstance(data, list) else [data]
-        params = {'ttl': ttl or 300}
+        params: dict[str, Any] = {'ttl': ttl or 300}
 
         if rec_type == 'A':
             params['a_records'] = [ARecord(ipv4_address=v) for v in values]
@@ -1571,42 +1790,60 @@ class AzureDnsRecordService(BaseDnsRecordService):
                 "Unsupported DNS record type: %s" % rec_type)
         return params
 
-    def get(self, dns_zone, rec_id):
+    def get(self, dns_zone: DnsZone | str,
+            rec_id: str) -> DnsRecord | None:
         if not rec_id or ':' not in rec_id:
             return None
         rec_name, rec_type = rec_id.split(':', 1)
+        provider = cast("AzureCloudProvider", self.provider)
+        azure_zone = cast("AzureDnsZone", dns_zone)
         try:
-            rec = self.provider.azure_client.get_dns_record(
-                dns_zone.id, rec_name, rec_type)
-            return AzureDnsRecord(self.provider, dns_zone, rec)
+            rec = provider.azure_client.get_dns_record(
+                cast(Any, dns_zone).id, rec_name, rec_type)
+            return AzureDnsRecord(provider, azure_zone, rec)
         except ResourceNotFoundError:
             return None
 
-    def list(self, dns_zone, limit=None, marker=None):
-        records = [AzureDnsRecord(self.provider, dns_zone, r)
-                   for r in self.provider.azure_client.list_dns_records(
-                       dns_zone.id)]
+    # Intentional arguments-differ: the BasePageableObjectMixin.list takes
+    # (limit, marker); DnsRecord listing requires a leading dns_zone.
+    def list(self,  # type: ignore[override]
+             dns_zone: DnsZone | str, limit: int | None = None,
+             marker: str | None = None) -> ResultList[DnsRecord]:
+        provider = cast("AzureCloudProvider", self.provider)
+        azure_zone = cast("AzureDnsZone", dns_zone)
+        records = [AzureDnsRecord(provider, azure_zone, r)
+                   for r in provider.azure_client.list_dns_records(
+                       cast(Any, dns_zone).id)]
         return ClientPagedResultList(self.provider, records, limit, marker)
 
-    def find(self, dns_zone, **kwargs):
+    def find(self, dns_zone: DnsZone | str,
+             **kwargs: Any) -> ResultList[DnsRecord]:
         filters = ['name']
-        matches = cb_helpers.generic_find(filters, kwargs, dns_zone.records)
+        matches = cb_helpers.generic_find(filters, kwargs,
+                                          cast(Any, dns_zone).records)
         return ClientPagedResultList(self.provider, list(matches),
                                      limit=None, marker=None)
 
-    def create(self, dns_zone, name, type, data, ttl=None):
+    def create(self, dns_zone: DnsZone | str, name: str, type: str,
+               data: str, ttl: int | None = None) -> DnsRecord:
         AzureDnsRecord.assert_valid_resource_name(name)
-        relative_name = _to_relative_record_name(name, dns_zone.id)
+        relative_name = _to_relative_record_name(name, cast(Any, dns_zone).id)
         params = self._to_record_params(type, data, ttl)
-        self.provider.azure_client.create_dns_record(
-            dns_zone.id, relative_name, type, params)
-        return self.get(dns_zone, relative_name + ':' + type)
+        cast("AzureCloudProvider", self.provider).azure_client.\
+            create_dns_record(
+                cast(Any, dns_zone).id, relative_name, type, params)
+        record = self.get(dns_zone, relative_name + ':' + type)
+        if record is None:
+            raise ProviderInternalException(
+                "DNS record %s could not be retrieved after creation" % name)
+        return record
 
-    def delete(self, dns_zone, record):
+    def delete(self, dns_zone: DnsZone | str,
+               record: DnsRecord | str) -> None:
         if isinstance(record, AzureDnsRecord):
             rec_name = record.name
             rec_type = record.type
         else:
-            rec_name, rec_type = record.split(':', 1)
-        self.provider.azure_client.delete_dns_record(
-            dns_zone.id, rec_name, rec_type)
+            rec_name, rec_type = cast(str, record).split(':', 1)
+        cast("AzureCloudProvider", self.provider).azure_client.\
+            delete_dns_record(cast(Any, dns_zone).id, rec_name, rec_type)

--- a/cloudbridge/providers/azure/subservices.py
+++ b/cloudbridge/providers/azure/subservices.py
@@ -6,40 +6,47 @@ from cloudbridge.base.subservices import BaseFloatingIPSubService
 from cloudbridge.base.subservices import BaseGatewaySubService
 from cloudbridge.base.subservices import BaseSubnetSubService
 from cloudbridge.base.subservices import BaseVMFirewallRuleSubService
+from cloudbridge.interfaces.provider import CloudProvider
+from cloudbridge.interfaces.resources import Bucket
+from cloudbridge.interfaces.resources import DnsZone
+from cloudbridge.interfaces.resources import Gateway
+from cloudbridge.interfaces.resources import Network
+from cloudbridge.interfaces.resources import VMFirewall
 
 log = logging.getLogger(__name__)
 
 
 class AzureBucketObjectSubService(BaseBucketObjectSubService):
 
-    def __init__(self, provider, bucket):
+    def __init__(self, provider: CloudProvider, bucket: Bucket) -> None:
         super(AzureBucketObjectSubService, self).__init__(provider, bucket)
 
 
 class AzureGatewaySubService(BaseGatewaySubService):
-    def __init__(self, provider, network):
+    def __init__(self, provider: CloudProvider, network: Network) -> None:
         super(AzureGatewaySubService, self).__init__(provider, network)
 
 
 class AzureVMFirewallRuleSubService(BaseVMFirewallRuleSubService):
 
-    def __init__(self, provider, firewall):
+    def __init__(self, provider: CloudProvider,
+                 firewall: VMFirewall) -> None:
         super(AzureVMFirewallRuleSubService, self).__init__(provider, firewall)
 
 
 class AzureFloatingIPSubService(BaseFloatingIPSubService):
 
-    def __init__(self, provider, gateway):
+    def __init__(self, provider: CloudProvider, gateway: Gateway) -> None:
         super(AzureFloatingIPSubService, self).__init__(provider, gateway)
 
 
 class AzureSubnetSubService(BaseSubnetSubService):
 
-    def __init__(self, provider, network):
+    def __init__(self, provider: CloudProvider, network: Network) -> None:
         super(AzureSubnetSubService, self).__init__(provider, network)
 
 
 class AzureDnsRecordSubService(BaseDnsRecordSubService):
 
-    def __init__(self, provider, dns_zone):
+    def __init__(self, provider: CloudProvider, dns_zone: DnsZone) -> None:
         super(AzureDnsRecordSubService, self).__init__(provider, dns_zone)

--- a/cloudbridge/providers/gcp/helpers.py
+++ b/cloudbridge/providers/gcp/helpers.py
@@ -3,6 +3,10 @@ import collections
 import datetime
 import hashlib
 import re
+from typing import Any
+from typing import Callable
+from typing import Iterator
+from typing import TYPE_CHECKING
 from urllib.parse import quote
 
 from googleapiclient.errors import HttpError
@@ -11,12 +15,15 @@ import tenacity
 
 from cloudbridge.interfaces.exceptions import ProviderInternalException
 
+if TYPE_CHECKING:
+    from .provider import GCPCloudProvider
 
-def gcp_projects(provider):
+
+def gcp_projects(provider: "GCPCloudProvider") -> Any:
     return provider.gcp_compute.projects()
 
 
-def iter_all(resource, **kwargs):
+def iter_all(resource: Any, **kwargs: Any) -> Iterator[Any]:
     token = None
     while True:
         response = resource.list(pageToken=token, **kwargs).execute()
@@ -27,7 +34,7 @@ def iter_all(resource, **kwargs):
         token = response['nextPageToken']
 
 
-def get_common_metadata(provider):
+def get_common_metadata(provider: "GCPCloudProvider") -> Any:
     """
     Get a project's commonInstanceMetadata entry
     """
@@ -36,7 +43,7 @@ def get_common_metadata(provider):
     return metadata["commonInstanceMetadata"]
 
 
-def __if_fingerprint_differs(e):
+def __if_fingerprint_differs(e: BaseException) -> bool:
     # return True if the CloudError exception is due to subnet being in use
     if isinstance(e, HttpError):
         expected_message = 'Supplied fingerprint does not match current ' \
@@ -50,7 +57,8 @@ def __if_fingerprint_differs(e):
                 retry=tenacity.retry_if_exception(__if_fingerprint_differs),
                 wait=tenacity.wait_exponential(max=10),
                 reraise=True)
-def gcp_metadata_save_op(provider, callback):
+def gcp_metadata_save_op(provider: "GCPCloudProvider",
+                         callback: Callable[[Any], Any]) -> None:
     """
     Carries out a metadata save operation. In GCP, a fingerprint based
     locking mechanism is used to prevent lost updates. A new fingerprint
@@ -59,7 +67,7 @@ def gcp_metadata_save_op(provider, callback):
     metadata, and saves the metadata using the original fingerprint
     immediately afterwards, ensuring that update conflicts can be detected.
     """
-    def _save_common_metadata(provider):
+    def _save_common_metadata(provider: "GCPCloudProvider") -> None:
         # get the latest metadata (so we get the latest fingerprint)
         metadata = get_common_metadata(provider)
         # allow callback to do processing on it
@@ -73,8 +81,9 @@ def gcp_metadata_save_op(provider, callback):
     _save_common_metadata(provider)
 
 
-def modify_or_add_metadata_item(provider, key, value):
-    def _update_metadata_key(metadata):
+def modify_or_add_metadata_item(provider: "GCPCloudProvider", key: str,
+                                value: str) -> None:
+    def _update_metadata_key(metadata: Any) -> None:
         entries = [item for item in metadata.get('items', [])
                    if item['key'] == key]
         if entries:
@@ -92,8 +101,9 @@ def modify_or_add_metadata_item(provider, key, value):
 # This function will raise an HttpError with message containing
 # "Metadata has duplicate key" if it's not unique, unlike the previous
 # method which either adds or updates the value corresponding to that key
-def add_metadata_item(provider, key, value):
-    def _add_metadata_key(metadata):
+def add_metadata_item(provider: "GCPCloudProvider", key: str,
+                      value: str) -> None:
+    def _add_metadata_key(metadata: Any) -> None:
         entry = {'key': key, 'value': value}
         entries = metadata.get('items', [])
         entries.append(entry)
@@ -104,7 +114,9 @@ def add_metadata_item(provider, key, value):
     gcp_metadata_save_op(provider, _add_metadata_key)
 
 
-def find_matching_metadata_items(provider, key_regex):
+def find_matching_metadata_items(provider: "GCPCloudProvider",
+                                 key_regex: str | re.Pattern[str]
+                                 ) -> list[Any]:
     metadata = get_common_metadata(provider)
     items = metadata.get('items', [])
     if not items:
@@ -113,7 +125,7 @@ def find_matching_metadata_items(provider, key_regex):
             if re.search(key_regex, item['key'])]
 
 
-def get_metadata_item_value(provider, key):
+def get_metadata_item_value(provider: "GCPCloudProvider", key: str) -> Any:
     metadata = get_common_metadata(provider)
     entries = [item['value'] for item in metadata.get('items', [])
                if item['key'] == key]
@@ -123,8 +135,8 @@ def get_metadata_item_value(provider, key):
         return None
 
 
-def remove_metadata_item(provider, key):
-    def _remove_metadata_by_key(metadata):
+def remove_metadata_item(provider: "GCPCloudProvider", key: str) -> bool:
+    def _remove_metadata_by_key(metadata: Any) -> bool | None:
         items = metadata.get('items', [])
         # No metadata to delete
         if not items:
@@ -144,12 +156,13 @@ def remove_metadata_item(provider, key):
 
             else:
                 metadata['items'] = entries
+                return None
 
     gcp_metadata_save_op(provider, _remove_metadata_by_key)
     return True
 
 
-def __if_label_fingerprint_differs(e):
+def __if_label_fingerprint_differs(e: BaseException) -> bool:
     # return True if the CloudError exception is due to subnet being in use
     if isinstance(e, HttpError):
         expected_message = 'Labels fingerprint either invalid or ' \
@@ -164,7 +177,8 @@ def __if_label_fingerprint_differs(e):
                     __if_label_fingerprint_differs),
                 wait=tenacity.wait_exponential(max=10),
                 reraise=True)
-def change_label(resource, key, value, res_att, request):
+def change_label(resource: Any, key: str, value: str, res_att: str,
+                 request: Any) -> None:
     resource.assert_valid_resource_label(value)
     labels = getattr(resource, res_att).get("labels", {})
     labels[key] = str(value)
@@ -188,9 +202,11 @@ def change_label(resource, key, value, res_att, request):
 
 
 # https://cloud.google.com/storage/docs/access-control/signing-urls-manually#python-sample
-def generate_signed_url(credentials, bucket_name, object_name,
-                        subresource=None, expiration=604800, http_method='GET',
-                        query_parameters=None, headers=None):
+def generate_signed_url(credentials: Any, bucket_name: str, object_name: str,
+                        subresource: str | None = None,
+                        expiration: int = 604800, http_method: str = 'GET',
+                        query_parameters: dict[str, Any] | None = None,
+                        headers: dict[str, str] | None = None) -> str:
 
     if expiration > 604800:
         # max allowed expiration time is 7 days

--- a/cloudbridge/providers/gcp/provider.py
+++ b/cloudbridge/providers/gcp/provider.py
@@ -8,8 +8,13 @@ import os
 import re
 import time
 from string import Template
+from typing import Any
+from typing import Callable
 
 import google.auth
+from google.auth.credentials import with_scopes_if_required
+from google.oauth2.service_account import Credentials
+
 import google_auth_httplib2
 
 import googleapiclient
@@ -17,12 +22,13 @@ from googleapiclient import discovery
 
 import httplib2
 
-from google.auth.credentials import with_scopes_if_required
-
-from google.oauth2.service_account import Credentials
-
 from cloudbridge.base import BaseCloudProvider
 from cloudbridge.interfaces.exceptions import ProviderConnectionException
+from cloudbridge.interfaces.services import ComputeService
+from cloudbridge.interfaces.services import DnsService
+from cloudbridge.interfaces.services import NetworkingService
+from cloudbridge.interfaces.services import SecurityService
+from cloudbridge.interfaces.services import StorageService
 
 from .services import GCPComputeService
 from .services import GCPDnsService
@@ -37,12 +43,12 @@ CLOUD_SCOPES = ['https://www.googleapis.com/auth/cloud-platform']
 
 class GCPResourceUrl(object):
 
-    def __init__(self, resource, connection):
+    def __init__(self, resource: str, connection: Any) -> None:
         self._resource = resource
         self._connection = connection
-        self.parameters = {}
+        self.parameters: dict[str, Any] = {}
 
-    def get_resource(self):
+    def get_resource(self) -> Any:
         """
         The format of the returned resource is explained in details in
         https://cloud.google.com/compute/docs/reference/latest/ and
@@ -71,7 +77,7 @@ class GCPResourceUrl(object):
 
 class GCPResources(object):
 
-    def __init__(self, connection, **kwargs):
+    def __init__(self, connection: Any, **kwargs: Any) -> None:
         self._connection = connection
         self._parameter_defaults = kwargs
 
@@ -116,7 +122,7 @@ class GCPResources(object):
         self.RESOURCE_REGEX = re.compile(
             r"(https://.*\.googleapis\.com/{0})(.*)".format(
                 desc['servicePath']))
-        self._resources = {}
+        self._resources: dict[str, dict[str, Any]] = {}
 
         # We will not mutate self._desc; it's OK to use items() in Python 2.x.
         for resource, resource_desc in desc['resources'].items():
@@ -149,7 +155,7 @@ class GCPResources(object):
             self._resources[resource] = {'parameters': parameters,
                                          'pattern': re.compile(pattern)}
 
-    def parse_url(self, url):
+    def parse_url(self, url: str) -> "GCPResourceUrl | None":
         """
         Build a GCPResourceUrl from a resource's URL string. One can then call
         the get() method on the returned object to fetch resource details from
@@ -180,8 +186,11 @@ class GCPResources(object):
             for index, parameter in enumerate(desc['parameters']):
                 out.parameters[parameter] = m.group(index + 1)
             return out
+        return None
 
-    def get_resource_url_with_default(self, resource, url_or_name, **kwargs):
+    def get_resource_url_with_default(
+            self, resource: str, url_or_name: str,
+            **kwargs: Any) -> "GCPResourceUrl | None":
         """
         Build a GCPResourceUrl from a service's name and resource url or name.
         If the url_or_name is a valid GCP resource URL, then we build the
@@ -210,7 +219,7 @@ class GCPResources(object):
 class GCPCloudProvider(BaseCloudProvider):
     PROVIDER_ID = 'gcp'
 
-    def __init__(self, config):
+    def __init__(self, config: dict[str, Any]) -> None:
         super(GCPCloudProvider, self).__init__(config)
 
         # Disable warnings about file_cache not being available when using
@@ -248,12 +257,12 @@ class GCPCloudProvider(BaseCloudProvider):
             self.project_name = os.environ.get('GCP_PROJECT_NAME')
 
         # service connections, lazily initialized
-        self._gcp_compute = None
-        self._gcp_storage = None
-        self._gcp_dns = None
-        self._compute_resources_cache = None
-        self._storage_resources_cache = None
-        self._dns_resources_cache = None
+        self._gcp_compute: Any = None
+        self._gcp_storage: Any = None
+        self._gcp_dns: Any = None
+        self._compute_resources_cache: GCPResources | None = None
+        self._storage_resources_cache: GCPResources | None = None
+        self._dns_resources_cache: GCPResources | None = None
 
         # Initialize provider services
         self._compute = GCPComputeService(self)
@@ -265,49 +274,49 @@ class GCPCloudProvider(BaseCloudProvider):
     # Override base class implementation because it will cause
     # an infinite loop
     @property
-    def zone_name(self):
+    def zone_name(self) -> str | None:
         return self._zone_name
 
     @property
-    def compute(self):
+    def compute(self) -> ComputeService:
         return self._compute
 
     @property
-    def networking(self):
+    def networking(self) -> NetworkingService:
         return self._networking
 
     @property
-    def security(self):
+    def security(self) -> SecurityService:
         return self._security
 
     @property
-    def storage(self):
+    def storage(self) -> StorageService:
         return self._storage
 
     @property
-    def dns(self):
+    def dns(self) -> DnsService:
         return self._dns
 
     @property
-    def gcp_compute(self):
+    def gcp_compute(self) -> Any:
         if not self._gcp_compute:
             self._gcp_compute = self._connect_gcp_compute()
         return self._gcp_compute
 
     @property
-    def gcp_storage(self):
+    def gcp_storage(self) -> Any:
         if not self._gcp_storage:
             self._gcp_storage = self._connect_gcp_storage()
         return self._gcp_storage
 
     @property
-    def gcp_dns(self):
+    def gcp_dns(self) -> Any:
         if not self._gcp_dns:
             self._gcp_dns = self._connect_gcp_dns()
         return self._gcp_dns
 
     @property
-    def _compute_resources(self):
+    def _compute_resources(self) -> GCPResources:
         if not self._compute_resources_cache:
             self._compute_resources_cache = GCPResources(
                 self.gcp_compute,
@@ -317,13 +326,13 @@ class GCPCloudProvider(BaseCloudProvider):
         return self._compute_resources_cache
 
     @property
-    def _storage_resources(self):
+    def _storage_resources(self) -> GCPResources:
         if not self._storage_resources_cache:
             self._storage_resources_cache = GCPResources(self.gcp_storage)
         return self._storage_resources_cache
 
     @property
-    def _dns_resources(self):
+    def _dns_resources(self) -> GCPResources:
         if not self._dns_resources_cache:
             self._dns_resources_cache = GCPResources(
                 self.gcp_dns,
@@ -331,7 +340,7 @@ class GCPCloudProvider(BaseCloudProvider):
         return self._dns_resources_cache
 
     @property
-    def _credentials(self):
+    def _credentials(self) -> Any:
         if not self.credentials_obj:
             if self.credentials_dict:
                 self.credentials_obj = Credentials.from_service_account_info(
@@ -341,42 +350,43 @@ class GCPCloudProvider(BaseCloudProvider):
         return self.credentials_obj
 
     @property
-    def client_id(self):
+    def client_id(self) -> str:
         return self._credentials.service_account_email
 
-    def _get_build_request(self):
+    def _get_build_request(self) -> Callable[..., Any]:
         credentials = with_scopes_if_required(
             self._credentials, list(CLOUD_SCOPES))
 
         # FROM: https://github.com/googleapis/google-api-python-client/blob/
         # master/docs/thread_safety.md
         # Create a new Http() object for every request
-        def build_request(http, *args, **kwargs):
+        def build_request(http: Any, *args: Any, **kwargs: Any) -> Any:
             new_http = google_auth_httplib2.AuthorizedHttp(
                 credentials, http=httplib2.Http())
             return googleapiclient.http.HttpRequest(new_http, *args, **kwargs)
 
         return build_request
 
-    def _connect_gcp_storage(self):
+    def _connect_gcp_storage(self) -> Any:
         return discovery.build('storage', 'v1', credentials=self._credentials,
                                cache_discovery=False,
                                requestBuilder=self._get_build_request()
                                )
 
-    def _connect_gcp_compute(self):
+    def _connect_gcp_compute(self) -> Any:
         return discovery.build('compute', 'v1', credentials=self._credentials,
                                cache_discovery=False,
                                requestBuilder=self._get_build_request()
                                )
 
-    def _connect_gcp_dns(self):
+    def _connect_gcp_dns(self) -> Any:
         return discovery.build('dns', 'v1', credentials=self._credentials,
                                cache_discovery=False,
                                requestBuilder=self._get_build_request()
                                )
 
-    def wait_for_operation(self, operation, region=None, zone=None):
+    def wait_for_operation(self, operation: Any, region: str | None = None,
+                           zone: str | None = None) -> Any:
         args = {'project': self.project_name, 'operation': operation['name']}
         if not region and not zone:
             operations = self.gcp_compute.globalOperations()
@@ -396,11 +406,12 @@ class GCPCloudProvider(BaseCloudProvider):
 
             time.sleep(0.5)
 
-    def parse_url(self, url):
+    def parse_url(self, url: str) -> "GCPResourceUrl | None":
         out = self._compute_resources.parse_url(url)
         return out if out else self._storage_resources.parse_url(url)
 
-    def get_resource(self, resource, url_or_name, **kwargs):
+    def get_resource(self, resource: str, url_or_name: str,
+                     **kwargs: Any) -> Any:
         if not url_or_name:
             return None
         resource_url = (
@@ -424,7 +435,7 @@ class GCPCloudProvider(BaseCloudProvider):
             else:
                 raise
 
-    def authenticate(self):
+    def authenticate(self) -> bool:
         try:
             self.gcp_compute
             return True

--- a/cloudbridge/providers/gcp/resources.py
+++ b/cloudbridge/providers/gcp/resources.py
@@ -1,6 +1,8 @@
 """
 DataTypes used by this provider
 """
+from __future__ import annotations
+
 import hashlib
 import inspect
 import io
@@ -9,9 +11,17 @@ import math
 import re
 import uuid
 from collections import namedtuple
+from collections.abc import Iterable
 from datetime import datetime
+from typing import Any
+from typing import IO
+from typing import Iterator
+from typing import TYPE_CHECKING
+from typing import cast
 
 import googleapiclient
+import googleapiclient.errors
+import googleapiclient.http
 
 from cloudbridge.base.resources import BaseAttachmentInfo
 from cloudbridge.base.resources import BaseBucket
@@ -34,6 +44,7 @@ from cloudbridge.base.resources import BaseVMFirewall
 from cloudbridge.base.resources import BaseVMFirewallRule
 from cloudbridge.base.resources import BaseVMType
 from cloudbridge.base.resources import BaseVolume
+from cloudbridge.interfaces.exceptions import ProviderInternalException
 from cloudbridge.interfaces.resources import GatewayState
 from cloudbridge.interfaces.resources import InstanceState
 from cloudbridge.interfaces.resources import MachineImageState
@@ -52,6 +63,33 @@ from .subservices import GCPGatewaySubService
 from .subservices import GCPSubnetSubService
 from .subservices import GCPVMFirewallRuleSubService
 
+if TYPE_CHECKING:
+    from cloudbridge.base.services import BaseNetworkService
+    from cloudbridge.interfaces.resources import AttachmentInfo
+    from cloudbridge.interfaces.resources import Bucket
+    from cloudbridge.interfaces.resources import BucketObject
+    from cloudbridge.interfaces.resources import BucketObjectSubService
+    from cloudbridge.interfaces.resources import DnsRecordSubService
+    from cloudbridge.interfaces.resources import FloatingIP
+    from cloudbridge.interfaces.resources import FloatingIPSubService
+    from cloudbridge.interfaces.resources import Gateway
+    from cloudbridge.interfaces.resources import GatewaySubService
+    from cloudbridge.interfaces.resources import Instance
+    from cloudbridge.interfaces.resources import MachineImage
+    from cloudbridge.interfaces.resources import Network
+    from cloudbridge.interfaces.resources import PlacementZone
+    from cloudbridge.interfaces.resources import Snapshot
+    from cloudbridge.interfaces.resources import Subnet
+    from cloudbridge.interfaces.resources import SubnetSubService
+    from cloudbridge.interfaces.resources import UploadConfig
+    from cloudbridge.interfaces.resources import VMFirewall
+    from cloudbridge.interfaces.resources import VMFirewallRuleSubService
+    from cloudbridge.interfaces.resources import VMType
+    from cloudbridge.interfaces.resources import Volume
+    from cloudbridge.providers.gcp.provider import GCPCloudProvider
+    from cloudbridge.providers.gcp.provider import GCPResourceUrl
+    from cloudbridge.providers.gcp.services import GCPVMFirewallService
+
 # Older versions of Python do not have a built-in set data-structure.
 
 try:
@@ -62,76 +100,99 @@ except NameError:
 log = logging.getLogger(__name__)
 
 
+def _parse_url(provider: "GCPCloudProvider", url: str) -> "GCPResourceUrl":
+    """
+    Parse ``url`` and return the resulting :class:`GCPResourceUrl`.
+
+    ``GCPCloudProvider.parse_url`` returns ``None`` for an unrecognized URL.
+    Every caller here parses a URL that the provider itself produced and then
+    immediately dereferences the result, so a ``None`` indicates a genuine
+    internal inconsistency rather than user input.
+    """
+    parsed = provider.parse_url(url)
+    if parsed is None:
+        raise ProviderInternalException(
+            "Could not parse GCP resource URL: {0}".format(url))
+    return parsed
+
+
 class GCPKeyPair(BaseKeyPair):
 
     KP_TAG_PREFIX = "cb_key_pair_"
     KP_TAG_REGEX = re.compile("^" + KP_TAG_PREFIX + ".*")
     GCPKeyInfo = namedtuple('GCPKeyInfo', ['name', 'public_key'])
 
-    def __init__(self, provider, kp_info, private_key=None):
+    def __init__(self, provider: GCPCloudProvider, kp_info: Any,
+                 private_key: str | None = None) -> None:
         super(GCPKeyPair, self).__init__(provider, None)
         self._key_pair = kp_info
         self._private_key = private_key
 
     @property
-    def id(self):
+    def id(self) -> str:
         return self._key_pair.name
 
     @property
-    def name(self):
+    def name(self) -> str:
         return self._key_pair.name
 
-    def delete(self):
+    def delete(self) -> None:
         self._provider.security.key_pairs.delete(self.id)
 
     @property
-    def material(self):
+    def material(self) -> str | None:
         return self._private_key
+
+    @material.setter
+    # pylint:disable=arguments-differ
+    def material(self, value: str | None) -> None:
+        self._private_key = value
 
 
 class GCPVMType(BaseVMType):
-    def __init__(self, provider, instance_dict):
+    def __init__(self, provider: GCPCloudProvider,
+                 instance_dict: Any) -> None:
         super(GCPVMType, self).__init__(provider)
         self._inst_dict = instance_dict
 
     @property
-    def resource_url(self):
+    def resource_url(self) -> str:
         return self._inst_dict.get('selfLink')
 
     @property
-    def id(self):
+    def id(self) -> str:
         return self._inst_dict.get('selfLink')
 
     @property
-    def name(self):
+    def name(self) -> str:
         return self._inst_dict.get('name')
 
     @property
-    def family(self):
+    def family(self) -> str | None:
         return self._inst_dict.get('kind')
 
     @property
-    def vcpus(self):
+    def vcpus(self) -> int:
         return self._inst_dict.get('guestCpus')
 
     @property
-    def ram(self):
+    def ram(self) -> float:
         return float("{0:.2f}".format(self._inst_dict.get('memoryMb') / 1024))
 
     @property
-    def size_root_disk(self):
+    def size_root_disk(self) -> int:
         return 0
 
     @property
-    def size_ephemeral_disks(self):
+    def size_ephemeral_disks(self) -> int:
         return int(self._inst_dict.get('maximumPersistentDisksSizeGb'))
 
     @property
-    def num_ephemeral_disks(self):
+    def num_ephemeral_disks(self) -> int:
         return self._inst_dict.get('maximumPersistentDisks')
 
     @property
-    def extra_data(self):
+    def extra_data(self) -> dict[str, Any]:
         return {key: val for key, val in self._inst_dict.items()
                 if key not in ['id', 'name', 'kind', 'guestCpus', 'memoryMb',
                                'maximumPersistentDisksSizeGb',
@@ -140,12 +201,12 @@ class GCPVMType(BaseVMType):
 
 class GCPPlacementZone(BasePlacementZone):
 
-    def __init__(self, provider, zone):
+    def __init__(self, provider: GCPCloudProvider, zone: Any) -> None:
         super(GCPPlacementZone, self).__init__(provider)
         self._zone = zone
 
     @property
-    def id(self):
+    def id(self) -> str:
         """
         Get the zone id
         :rtype: ``str``
@@ -154,7 +215,7 @@ class GCPPlacementZone(BasePlacementZone):
         return self._zone['selfLink']
 
     @property
-    def name(self):
+    def name(self) -> str:
         """
         Get the zone name.
         :rtype: ``str``
@@ -163,54 +224,56 @@ class GCPPlacementZone(BasePlacementZone):
         return self._zone['name']
 
     @property
-    def region_name(self):
+    def region_name(self) -> str:
         """
         Get the region that this zone belongs to.
         :rtype: ``str``
         :return: Name of this zone's region as returned by the cloud middleware
         """
-        parsed_region_url = self._provider.parse_url(self._zone['region'])
+        provider = cast("GCPCloudProvider", self._provider)
+        parsed_region_url = _parse_url(provider, self._zone['region'])
         return parsed_region_url.parameters['region']
 
 
 class GCPRegion(BaseRegion):
 
-    def __init__(self, provider, gcp_region):
+    def __init__(self, provider: GCPCloudProvider, gcp_region: Any) -> None:
         super(GCPRegion, self).__init__(provider)
         self._gcp_region = gcp_region
 
     @property
-    def id(self):
+    def id(self) -> str:
         return self._gcp_region.get('selfLink')
 
     @property
-    def name(self):
+    def name(self) -> str:
         return self._gcp_region.get('name')
 
     @property
-    def zones(self):
+    def zones(self) -> list[GCPPlacementZone]:
         """
         Accesss information about placement zones within this region.
         """
-        zones_response = (self._provider
-                              .gcp_compute
-                              .zones()
-                              .list(project=self._provider.project_name)
-                              .execute())
+        provider = cast("GCPCloudProvider", self._provider)
+        zones_response = (provider
+                          .gcp_compute
+                          .zones()
+                          .list(project=provider.project_name)
+                          .execute())
         zones = [zone for zone in zones_response['items']
                  if zone['region'] == self._gcp_region['selfLink']]
-        return [GCPPlacementZone(self._provider, zone) for zone in zones]
+        return [GCPPlacementZone(provider, zone) for zone in zones]
 
 
 class GCPFirewallsDelegate(object):
     _NETWORK_URL_PREFIX = 'global/networks/'
 
-    def __init__(self, provider):
+    def __init__(self, provider: GCPCloudProvider) -> None:
         self._provider = provider
-        self._list_response = None
+        self._list_response: list[Any] | None = None
 
     @staticmethod
-    def tag_network_id(tag, network_name):
+    def tag_network_id(tag: str, network_name: str) -> str:
         """
         Generate an ID for a (tag, network name) pair.
         """
@@ -219,31 +282,33 @@ class GCPFirewallsDelegate(object):
         return md5.hexdigest()
 
     @property
-    def provider(self):
+    def provider(self) -> GCPCloudProvider:
         return self._provider
 
     @property
-    def tag_networks(self):
+    def tag_networks(self) -> set[tuple[str, str]]:
         """
         List all (tag, network name) pairs that are in at least one firewall.
         """
-        out = set()
+        out: set[tuple[str, str]] = set()
         for firewall in self.iter_firewalls():
             network_name = self.network_name(firewall)
             if network_name is not None:
                 out.add((firewall['targetTags'][0], network_name))
         return out
 
-    def network_name(self, firewall):
+    def network_name(self, firewall: Any) -> str:
         """
         Extract the network name of a firewall.
         """
         if 'network' not in firewall:
             return GCPNetwork.CB_DEFAULT_NETWORK_LABEL
-        url = self._provider.parse_url(firewall['network'])
+        url = _parse_url(self._provider, firewall['network'])
         return url.parameters['network']
 
-    def get_tag_network_from_id(self, tag_network_id):
+    def get_tag_network_from_id(
+            self, tag_network_id: str
+    ) -> tuple[str | None, str | None]:
         """
         Map an ID back to the (tag, network name) pair.
         """
@@ -253,7 +318,7 @@ class GCPFirewallsDelegate(object):
                 return (tag, network_name)
         return (None, None)
 
-    def delete_tag_network_with_id(self, tag_network_id):
+    def delete_tag_network_with_id(self, tag_network_id: str) -> None:
         """
         Delete all firewalls in a given network with a specific target tag.
         """
@@ -264,8 +329,12 @@ class GCPFirewallsDelegate(object):
             self._delete_firewall(firewall)
         self._update_list_response()
 
-    def add_firewall(self, tag, direction, protocol, priority, port,
-                     src_dest_range, src_dest_tag, description, network_name):
+    def add_firewall(self, tag: str, direction: TrafficDirection,
+                     protocol: str | None, priority: int | None,
+                     port: str | int | None,
+                     src_dest_range: str | list[str] | None,
+                     src_dest_tag: str | None,
+                     description: str | None, network_name: str) -> bool:
         """
         Create a new firewall.
         """
@@ -277,7 +346,7 @@ class GCPFirewallsDelegate(object):
         # explicitly specifying the source.
         if src_dest_tag is None and src_dest_range is None:
             return False
-        firewall = {
+        firewall: dict[str, Any] = {
             'name': 'firewall-{0}'.format(uuid.uuid4()),
             'network': GCPFirewallsDelegate._NETWORK_URL_PREFIX + network_name,
             'allowed': [{'IPProtocol': str(protocol)}],
@@ -316,8 +385,11 @@ class GCPFirewallsDelegate(object):
             self._update_list_response()
         return True
 
-    def find_firewall(self, tag, direction, protocol, port, src_dest_range,
-                      src_dest_tag, network_name):
+    def find_firewall(self, tag: str, direction: TrafficDirection,
+                      protocol: str | None, port: str | int | None,
+                      src_dest_range: str | list[str] | None,
+                      src_dest_tag: str | None,
+                      network_name: str) -> str | None:
         """
         Find a firewall with give parameters.
         """
@@ -342,11 +414,11 @@ class GCPFirewallsDelegate(object):
             return firewall['id']
         return None
 
-    def get_firewall_info(self, firewall_id):
+    def get_firewall_info(self, firewall_id: str) -> dict[str, Any]:
         """
         Extract firewall properties to into a dictionary for easy of use.
         """
-        info = {}
+        info: dict[str, Any] = {}
         for firewall in self.iter_firewalls():
             if firewall['id'] != firewall_id:
                 continue
@@ -373,7 +445,7 @@ class GCPFirewallsDelegate(object):
             return info
         return info
 
-    def delete_firewall_id(self, firewall_id):
+    def delete_firewall_id(self, firewall_id: str) -> None:
         """
         Delete a firewall with a given ID.
         """
@@ -382,14 +454,15 @@ class GCPFirewallsDelegate(object):
                 self._delete_firewall(firewall)
         self._update_list_response()
 
-    def iter_firewalls(self, tag=None, network_name=None):
+    def iter_firewalls(self, tag: str | None = None,
+                       network_name: str | None = None) -> Iterator[Any]:
         """
         Iterate through all firewalls. Can optionally iterate through firewalls
         with a given tag and/or in a network.
         """
         if self._list_response is None:
             self._update_list_response()
-        for firewall in self._list_response:
+        for firewall in self._list_response or []:
             if ('targetTags' not in firewall or
                     len(firewall['targetTags']) != 1):
                 continue
@@ -404,7 +477,7 @@ class GCPFirewallsDelegate(object):
             if firewall_network_name == network_name:
                 yield firewall
 
-    def _delete_firewall(self, firewall):
+    def _delete_firewall(self, firewall: Any) -> bool:
         """
         Delete a given firewall.
         """
@@ -424,7 +497,7 @@ class GCPFirewallsDelegate(object):
                         '"{}" when deleted.'.format(name))
         return True
 
-    def _update_list_response(self):
+    def _update_list_response(self) -> None:
         """
         Sync the local cache of all firewalls with the server.
         """
@@ -432,7 +505,8 @@ class GCPFirewallsDelegate(object):
                 helpers.iter_all(self._provider.gcp_compute.firewalls(),
                                  project=self._provider.project_name))
 
-    def _check_list_in_dict(self, dictionary, field_name, value):
+    def _check_list_in_dict(self, dictionary: Any, field_name: str,
+                            value: Any) -> bool:
         """
         Verify that a given field in a dictionary is a singlton list [value].
         """
@@ -446,20 +520,23 @@ class GCPFirewallsDelegate(object):
 
 class GCPVMFirewall(BaseVMFirewall):
 
-    def __init__(self, delegate, tag, network=None, description=None):
+    def __init__(self, delegate: GCPFirewallsDelegate, tag: str,
+                 network: Network | None = None,
+                 description: str | None = None) -> None:
         super(GCPVMFirewall, self).__init__(delegate.provider, tag)
         self._delegate = delegate
         self._description = description
         if network is None:
-            self._network = (delegate.provider.networking.networks
-                             .get_or_create_default())
+            networks = cast(
+                "BaseNetworkService", delegate.provider.networking.networks)
+            self._network = networks.get_or_create_default()
         else:
             self._network = network
         self._rule_container = GCPVMFirewallRuleSubService(self._provider,
                                                            self)
 
     @property
-    def id(self):
+    def id(self) -> str:
         """
         Return the ID of this VM firewall which is determined based on the
         network and the target tag corresponding to this VM firewall.
@@ -468,7 +545,7 @@ class GCPVMFirewall(BaseVMFirewall):
                                                    self._network.name)
 
     @property
-    def name(self):
+    def name(self) -> str:
         """
         Return the name of the VM firewall which is the same as the
         corresponding tag name.
@@ -476,18 +553,20 @@ class GCPVMFirewall(BaseVMFirewall):
         return self._vm_firewall
 
     @property
-    def label(self):
+    def label(self) -> str | None:
+        provider = cast("GCPCloudProvider", self._provider)
         tag_name = "_".join(["firewall", self.name, "label"])
-        return helpers.get_metadata_item_value(self._provider, tag_name)
+        return helpers.get_metadata_item_value(provider, tag_name)
 
     @label.setter
-    def label(self, value):
+    def label(self, value: str) -> None:
+        provider = cast("GCPCloudProvider", self._provider)
         self.assert_valid_resource_label(value)
         tag_name = "_".join(["firewall", self.name, "label"])
-        helpers.modify_or_add_metadata_item(self._provider, tag_name, value)
+        helpers.modify_or_add_metadata_item(provider, tag_name, value)
 
     @property
-    def description(self):
+    def description(self) -> str | None:
         """
         The description of the VM firewall is even explicitly given when the
         VM firewall is created or is determined from a VM firewall rule, i.e. a
@@ -506,40 +585,42 @@ class GCPVMFirewall(BaseVMFirewall):
         return self._description
 
     @description.setter
-    def description(self, value):
+    def description(self, value: str | None) -> None:
         # Change the description on all rules
+        provider = cast("GCPCloudProvider", self._provider)
         for fw in self._delegate.iter_firewalls(self._vm_firewall,
                                                 self._network.name):
             fw['description'] = value or ''
-            response = (self._provider
+            response = (provider
                         .gcp_compute
                         .firewalls()
-                        .update(project=self._provider.project_name,
+                        .update(project=provider.project_name,
                                 firewall=fw['name'],
                                 body=fw)
                         .execute())
-            self._provider.wait_for_operation(response)
+            provider.wait_for_operation(response)
         # Set back to None so that the next time the user gets it, it updates
         # but don't force update here to avoid more overhead
         self._description = None
 
     @property
-    def network_id(self):
+    def network_id(self) -> str | None:
         return self._network.id
 
     @property
-    def rules(self):
+    def rules(self) -> VMFirewallRuleSubService:
         return self._rule_container
 
-    def to_json(self):
+    def to_json(self) -> dict[str, Any]:
         attr = inspect.getmembers(self, lambda a: not (inspect.isroutine(a)))
         js = {k: v for (k, v) in attr if not k.startswith('_')}
         json_rules = [r.to_json() for r in self.rules]
         js['rules'] = json_rules
         return js
 
-    def refresh(self):
-        fw = self._provider.security.vm_firewalls.get(self.id)
+    def refresh(self) -> None:
+        fw = cast("GCPVMFirewall | None",
+                  self._provider.security.vm_firewalls.get(self.id))
         # restore all internal state
         if fw:
             # pylint:disable=protected-access
@@ -552,43 +633,45 @@ class GCPVMFirewall(BaseVMFirewall):
             self._rule_container = fw._rule_container
 
     @property
-    def network(self):
+    def network(self) -> Network:
         return self._network
 
     @property
-    def delegate(self):
+    def delegate(self) -> GCPFirewallsDelegate:
         return self._delegate
 
 
 class GCPVMFirewallRule(BaseVMFirewallRule):
 
-    def __init__(self, parent_fw, rule):
+    def __init__(self, parent_fw: VMFirewall, rule: Any) -> None:
         super(GCPVMFirewallRule, self).__init__(parent_fw, rule)
 
     @property
-    def id(self):
+    def _gcp_firewall(self) -> GCPVMFirewall:
+        return cast(GCPVMFirewall, self.firewall)
+
+    @property
+    def id(self) -> str:
         return self._rule
 
     @property
-    def direction(self):
-        info = self.firewall.delegate.get_firewall_info(self._rule)
-        if info is None:
-            return None
+    def direction(self) -> TrafficDirection:
+        info = self._gcp_firewall.delegate.get_firewall_info(self._rule)
         if 'direction' in info and info['direction'] == 'EGRESS':
             return TrafficDirection.OUTBOUND
         return TrafficDirection.INBOUND
 
     @property
-    def protocol(self):
-        info = self.firewall.delegate.get_firewall_info(self._rule)
-        if info is None or 'protocol' not in info:
+    def protocol(self) -> str | None:
+        info = self._gcp_firewall.delegate.get_firewall_info(self._rule)
+        if 'protocol' not in info:
             return None
         return info['protocol']
 
     @property
-    def from_port(self):
-        info = self.firewall.delegate.get_firewall_info(self._rule)
-        if info is None or 'port' not in info:
+    def from_port(self) -> int:
+        info = self._gcp_firewall.delegate.get_firewall_info(self._rule)
+        if 'port' not in info:
             return 0
         port = info['port']
         if port.isdigit():
@@ -601,9 +684,9 @@ class GCPVMFirewallRule(BaseVMFirewallRule):
         return 0
 
     @property
-    def to_port(self):
-        info = self.firewall.delegate.get_firewall_info(self._rule)
-        if info is None or 'port' not in info:
+    def to_port(self) -> int:
+        info = self._gcp_firewall.delegate.get_firewall_info(self._rule)
+        if 'port' not in info:
             return 0
         port = info['port']
         if port.isdigit():
@@ -616,44 +699,44 @@ class GCPVMFirewallRule(BaseVMFirewallRule):
         return 0
 
     @property
-    def cidr(self):
-        info = self.firewall.delegate.get_firewall_info(self._rule)
-        if info is None or 'src_dest_range' not in info:
+    def cidr(self) -> str | None:
+        info = self._gcp_firewall.delegate.get_firewall_info(self._rule)
+        if 'src_dest_range' not in info:
             return None
         return info['src_dest_range']
 
     @property
-    def src_dest_fw_id(self):
+    def src_dest_fw_id(self) -> str | None:
         """
         Return the VM firewall given access by this rule.
         """
-        info = self.firewall.delegate.get_firewall_info(self._rule)
-        if info is None or 'src_dest_tag' not in info:
+        info = self._gcp_firewall.delegate.get_firewall_info(self._rule)
+        if 'src_dest_tag' not in info:
             return None
-        return GCPFirewallsDelegate.tag_network_id(info['src_dest_tag'],
-                                                   self.firewall.network.name)
+        return GCPFirewallsDelegate.tag_network_id(
+            info['src_dest_tag'], self._gcp_firewall.network.name)
 
     @property
-    def src_dest_fw(self):
+    def src_dest_fw(self) -> VMFirewall | None:
         """
         Return the VM firewall given access by this rule.
         """
-        info = self.firewall.delegate.get_firewall_info(self._rule)
-        if info is None or 'src_dest_tag' not in info:
+        info = self._gcp_firewall.delegate.get_firewall_info(self._rule)
+        if 'src_dest_tag' not in info:
             return None
         return GCPVMFirewall(
-                self.firewall.delegate, info['src_dest_tag'],
-                self.firewall.network)
+                self._gcp_firewall.delegate, info['src_dest_tag'],
+                self._gcp_firewall.network)
 
     @property
-    def priority(self):
-        info = self.firewall.delegate.get_firewall_info(self._rule)
+    def priority(self) -> int:
+        info = self._gcp_firewall.delegate.get_firewall_info(self._rule)
         # The default firewall rule priority, when not specified, is 1000.
-        if info is None or 'priority' not in info:
+        if 'priority' not in info:
             return 1000
         return info['priority']
 
-    def is_dummy_rule(self):
+    def is_dummy_rule(self) -> bool:
         if self.priority != 65534:
             return False
         if self.direction != TrafficDirection.OUTBOUND:
@@ -673,8 +756,9 @@ class GCPMachineImage(BaseMachineImage):
         'FAILED': MachineImageState.ERROR
     }
 
-    def __init__(self, provider, image):
+    def __init__(self, provider: GCPCloudProvider, image: Any) -> None:
         super(GCPMachineImage, self).__init__(provider)
+        self._gcp_image: Any
         if isinstance(image, GCPMachineImage):
             # pylint:disable=protected-access
             self._gcp_image = image._gcp_image
@@ -682,11 +766,11 @@ class GCPMachineImage(BaseMachineImage):
             self._gcp_image = image
 
     @property
-    def resource_url(self):
+    def resource_url(self) -> str:
         return self._gcp_image.get('selfLink')
 
     @property
-    def id(self):
+    def id(self) -> str:
         """
         Get the image identifier.
         :rtype: ``str``
@@ -695,7 +779,7 @@ class GCPMachineImage(BaseMachineImage):
         return self._gcp_image.get('selfLink')
 
     @property
-    def name(self):
+    def name(self) -> str:
         """
         Get the image name.
         :rtype: ``str``
@@ -704,24 +788,25 @@ class GCPMachineImage(BaseMachineImage):
         return self._gcp_image['name']
 
     @property
-    def label(self):
+    def label(self) -> str | None:
         labels = self._gcp_image.get('labels')
         return labels.get('cblabel', '') if labels else ''
 
     @label.setter
     # pylint:disable=arguments-differ
-    def label(self, value):
-        req = (self._provider
-                   .gcp_compute
-                   .images()
-                   .setLabels(project=self._provider.project_name,
-                              resource=self.name,
-                              body={}))
+    def label(self, value: str) -> None:
+        provider = cast("GCPCloudProvider", self._provider)
+        req = (provider
+               .gcp_compute
+               .images()
+               .setLabels(project=provider.project_name,
+                          resource=self.name,
+                          body={}))
 
         helpers.change_label(self, 'cblabel', value, '_gcp_image', req)
 
     @property
-    def description(self):
+    def description(self) -> str | None:
         """
         Get the image description.
         :rtype: ``str``
@@ -730,7 +815,7 @@ class GCPMachineImage(BaseMachineImage):
         return self._gcp_image.get('description', '')
 
     @property
-    def min_disk(self):
+    def min_disk(self) -> int | None:
         """
         Returns the minimum size of the disk that's required to
         boot this image (in GB)
@@ -739,28 +824,30 @@ class GCPMachineImage(BaseMachineImage):
         """
         return int(math.ceil(float(self._gcp_image.get('diskSizeGb'))))
 
-    def delete(self):
+    def delete(self) -> None:
         """
         Delete this image
         """
-        (self._provider
-             .gcp_compute
-             .images()
-             .delete(project=self._provider.project_name,
-                     image=self.name)
-             .execute())
+        provider = cast("GCPCloudProvider", self._provider)
+        (provider
+         .gcp_compute
+         .images()
+         .delete(project=provider.project_name,
+                 image=self.name)
+         .execute())
 
     @property
-    def state(self):
+    def state(self) -> str:
         return GCPMachineImage.IMAGE_STATE_MAP.get(
             self._gcp_image['status'], MachineImageState.UNKNOWN)
 
-    def refresh(self):
+    def refresh(self) -> None:
         """
         Refreshes the state of this instance by re-querying the cloud provider
         for its latest state.
         """
-        image = self._provider.compute.images.get(self.id)
+        image = cast("GCPMachineImage | None",
+                     self._provider.compute.images.get(self.id))
         if image:
             # pylint:disable=protected-access
             self._gcp_image = image._gcp_image
@@ -784,17 +871,18 @@ class GCPInstance(BaseInstance):
         'SUSPENDED': InstanceState.STOPPED
     }
 
-    def __init__(self, provider, gcp_instance):
+    def __init__(self, provider: GCPCloudProvider,
+                 gcp_instance: Any) -> None:
         super(GCPInstance, self).__init__(provider)
         self._gcp_instance = gcp_instance
-        self._inet_gateway = None
+        self._inet_gateway: GCPInternetGateway | None = None
 
     @property
-    def resource_url(self):
+    def resource_url(self) -> str:
         return self._gcp_instance.get('selfLink')
 
     @property
-    def id(self):
+    def id(self) -> str:
         """
         Get the instance identifier.
 
@@ -804,32 +892,33 @@ class GCPInstance(BaseInstance):
         return self._gcp_instance.get('selfLink')
 
     @property
-    def name(self):
+    def name(self) -> str:
         """
         Get the instance name.
         """
         return self._gcp_instance['name']
 
     @property
-    def label(self):
+    def label(self) -> str | None:
         labels = self._gcp_instance.get('labels')
         return labels.get('cblabel', '') if labels else ''
 
     @label.setter
     # pylint:disable=arguments-differ
-    def label(self, value):
-        req = (self._provider
-                   .gcp_compute
-                   .instances()
-                   .setLabels(project=self._provider.project_name,
-                              zone=self.zone_name,
-                              instance=self.name,
-                              body={}))
+    def label(self, value: str) -> None:
+        provider = cast("GCPCloudProvider", self._provider)
+        req = (provider
+               .gcp_compute
+               .instances()
+               .setLabels(project=provider.project_name,
+                          zone=self.zone_name,
+                          instance=self.name,
+                          body={}))
 
         helpers.change_label(self, 'cblabel', value, '_gcp_instance', req)
 
     @property
-    def public_ips(self):
+    def public_ips(self) -> list[str]:
         """
         Get all the public IP addresses for this instance.
         """
@@ -853,7 +942,7 @@ class GCPInstance(BaseInstance):
         return ips
 
     @property
-    def private_ips(self):
+    def private_ips(self) -> list[str]:
         """
         Get all the private IP addresses for this instance.
         """
@@ -866,116 +955,147 @@ class GCPInstance(BaseInstance):
             return []
 
     @property
-    def vm_type_id(self):
+    def vm_type_id(self) -> str:
         """
         Get the instance type name.
         """
         return self._gcp_instance.get('machineType')
 
     @property
-    def vm_type(self):
+    def vm_type(self) -> VMType:
         """
         Get the instance type.
         """
+        provider = cast("GCPCloudProvider", self._provider)
         machine_type_uri = self._gcp_instance.get('machineType')
         if machine_type_uri is None:
-            return None
-        parsed_uri = self._provider.parse_url(machine_type_uri)
-        return GCPVMType(self._provider, parsed_uri.get_resource())
+            raise ProviderInternalException(
+                "Instance has no associated machine type")
+        parsed_uri = _parse_url(provider, machine_type_uri)
+        return GCPVMType(provider, parsed_uri.get_resource())
 
     @property
-    def create_time(self):
+    def create_time(self) -> str | datetime:
         """
         Get the instance creation time
         """
-        return datetime.fromisoformat(self._gcp_instance.get("creationTimestamp"))
+        return datetime.fromisoformat(
+            self._gcp_instance.get("creationTimestamp"))
 
     @property
-    def subnet_id(self):
+    def subnet_id(self) -> str:
         """
         Get the zone for this instance.
         """
-        return (self._gcp_instance.get('networkInterfaces', [{}])[0]
-                .get('subnetwork'))
+        subnet_id = (self._gcp_instance.get('networkInterfaces', [{}])[0]
+                     .get('subnetwork'))
+        if subnet_id is None:
+            raise ProviderInternalException(
+                "Instance has no associated subnet")
+        return subnet_id
 
-    def reboot(self):
+    def reboot(self) -> None:
         """
         Reboot this instance.
         """
+        provider = cast("GCPCloudProvider", self._provider)
         if self.state == InstanceState.STOPPED:
-            (self._provider
+            (provider
              .gcp_compute
              .instances()
-             .start(project=self._provider.project_name,
+             .start(project=provider.project_name,
                     zone=self.zone_name,
                     instance=self.name)
              .execute())
         else:
-            (self._provider
+            (provider
              .gcp_compute
              .instances()
-             .reset(project=self._provider.project_name,
+             .reset(project=provider.project_name,
                     zone=self.zone_name,
                     instance=self.name)
              .execute())
 
-    def stop(self):
+    def start(self) -> None:
+        """
+        Start this instance.
+        """
+        provider = cast("GCPCloudProvider", self._provider)
+        (provider
+         .gcp_compute
+         .instances()
+         .start(project=provider.project_name,
+                zone=self.zone_name,
+                instance=self.name)
+         .execute())
+
+    def stop(self) -> None:
         """
         Stop this instance.
         """
-        (self._provider
+        provider = cast("GCPCloudProvider", self._provider)
+        (provider
          .gcp_compute
          .instances()
-         .stop(project=self._provider.project_name,
+         .stop(project=provider.project_name,
                zone=self.zone_name,
                instance=self.name)
          .execute())
 
     @property
-    def image_id(self):
+    def image_id(self) -> str:
         """
         Get the image ID for this insance.
         """
+        provider = cast("GCPCloudProvider", self._provider)
         if 'disks' not in self._gcp_instance:
-            return None
+            raise ProviderInternalException(
+                "Instance has no associated disks")
         for disk in self._gcp_instance['disks']:
             if 'boot' in disk and disk['boot']:
-                disk_url = self._provider.parse_url(disk['source'])
+                disk_url = _parse_url(provider, disk['source'])
                 return disk_url.get_resource().get('sourceImage')
-        return None
+        raise ProviderInternalException(
+            "Instance has no boot disk with a source image")
 
     @property
-    def zone_id(self):
+    def zone_id(self) -> str:
         """
         Get the placement zone id where this instance is running.
         """
-        return self._gcp_instance.get('zone')
+        zone_id = self._gcp_instance.get('zone')
+        if zone_id is None:
+            raise ProviderInternalException(
+                "Instance has no associated zone")
+        return zone_id
 
     @property
-    def zone_name(self):
-        return self._provider.parse_url(self.zone_id).parameters['zone']
+    def zone_name(self) -> str:
+        provider = cast("GCPCloudProvider", self._provider)
+        return _parse_url(provider, self.zone_id).parameters['zone']
 
     @property
-    def vm_firewalls(self):
+    def vm_firewalls(self) -> list[VMFirewall]:
         """
         Get the VM firewalls associated with this instance.
         """
+        provider = cast("GCPCloudProvider", self._provider)
         network_url = self._gcp_instance.get('networkInterfaces')[0].get(
             'network')
-        url = self._provider.parse_url(network_url)
+        url = _parse_url(provider, network_url)
         network_name = url.parameters['network']
         if 'items' not in self._gcp_instance['tags']:
             return []
         tags = self._gcp_instance['tags']['items']
         # Tags are mapped to non-empty VM firewalls under the instance network.
         # Unmatched tags are ignored.
-        sgs = (self._provider.security
-               .vm_firewalls.find_by_network_and_tags(
-                   network_name, tags))
-        return sgs
+        vm_firewalls = cast(
+            "GCPVMFirewallService", self._provider.security.vm_firewalls)
+        sgs = vm_firewalls.find_by_network_and_tags(network_name, tags)
+        return cast("list[VMFirewall]", sgs)
 
     @property
-    def vm_firewall_ids(self):
+    def vm_firewall_ids(self) -> list[str]:
         """
         Get the VM firewall IDs associated with this instance.
         """
@@ -985,13 +1105,14 @@ class GCPInstance(BaseInstance):
         return sg_ids
 
     @property
-    def key_pair_id(self):
+    def key_pair_id(self) -> str | None:
         """
         Get the id of the key pair associated with this instance.
         Assume there is only 1 key pair
         """
         # Get instance again to avoid stale metadata
-        ins = self._provider.compute.instances.get(self.id)
+        ins = cast("GCPInstance",
+                   self._provider.compute.instances.get(self.id))
         # pylint:disable=protected-access
         meta = ins._gcp_instance.get('metadata', {})
         if meta:
@@ -1003,24 +1124,28 @@ class GCPInstance(BaseInstance):
         return None
 
     @property
-    def inet_gateway(self):
+    def inet_gateway(self) -> GCPInternetGateway:
         if self._inet_gateway:
             return self._inet_gateway
         network_url = self._gcp_instance.get('networkInterfaces')[0].get(
             'network')
-        network = self._provider.networking.networks.get(network_url)
-        self._inet_gateway = network.gateways.get_or_create()
+        network = cast(
+            "GCPNetwork", self._provider.networking.networks.get(network_url))
+        self._inet_gateway = cast(
+            GCPInternetGateway, network.gateways.get_or_create())
         return self._inet_gateway
 
-    def create_image(self, label):
+    def create_image(self, label: str) -> MachineImage:
         """
         Create a new image based on this instance.
         """
+        provider = cast("GCPCloudProvider", self._provider)
         self.assert_valid_resource_label(label)
         name = self._generate_name_from_label(label, 'cb-img')
         if 'disks' not in self._gcp_instance:
             log.error('Failed to create image: no disks found.')
-            return
+            raise ProviderInternalException(
+                "Failed to create image: no disks found")
         for disk in self._gcp_instance['disks']:
             if 'boot' in disk and disk['boot']:
                 image_body = {
@@ -1028,42 +1153,49 @@ class GCPInstance(BaseInstance):
                     'sourceDisk': disk['source'],
                     'labels': {'cblabel': label.replace(' ', '_').lower()},
                 }
-                operation = (self._provider
+                operation = (provider
                              .gcp_compute
                              .images()
-                             .insert(project=self._provider.project_name,
+                             .insert(project=provider.project_name,
                                      body=image_body,
                                      forceCreate=True)
                              .execute())
-                self._provider.wait_for_operation(operation)
-                img = self._provider.get_resource('images', name)
-                return GCPMachineImage(self._provider, img) if img else None
+                provider.wait_for_operation(operation)
+                img = provider.get_resource('images', name)
+                if not img:
+                    raise ProviderInternalException(
+                        "Image '{0}' not found after creation".format(name))
+                return GCPMachineImage(provider, img)
         log.error('Failed to create image: no boot disk found.')
+        raise ProviderInternalException(
+            "Failed to create image: no boot disk found")
 
-    def _get_existing_target_instance(self):
+    def _get_existing_target_instance(self) -> Any:
         """
         Return the target instance corresponding to this instance.
 
         If there is no target instance for this instance, return None.
         """
+        provider = cast("GCPCloudProvider", self._provider)
         try:
             for target_instance in helpers.iter_all(
-                    self._provider.gcp_compute.targetInstances(),
-                    project=self._provider.project_name,
+                    provider.gcp_compute.targetInstances(),
+                    project=provider.project_name,
                     zone=self.zone_name):
-                url = self._provider.parse_url(target_instance['instance'])
+                url = _parse_url(provider, target_instance['instance'])
                 if url.parameters['instance'] == self.name:
                     return target_instance
         except Exception as e:
             log.warning('Exception while listing target instances: %s', e)
         return None
 
-    def _get_target_instance(self):
+    def _get_target_instance(self) -> Any:
         """
         Return the target instance corresponding to this instance.
 
         If there is no target instance for this instance, create one.
         """
+        provider = cast("GCPCloudProvider", self._provider)
         existing_target_instance = self._get_existing_target_instance()
         if existing_target_instance:
             return existing_target_instance
@@ -1072,14 +1204,14 @@ class GCPInstance(BaseInstance):
         body = {'name': 'target-instance-{0}'.format(uuid.uuid4()),
                 'instance': self._gcp_instance['selfLink']}
         try:
-            response = (self._provider
-                            .gcp_compute
-                            .targetInstances()
-                            .insert(project=self._provider.project_name,
-                                    zone=self.zone_name,
-                                    body=body)
-                            .execute())
-            self._provider.wait_for_operation(response, zone=self.zone_name)
+            response = (provider
+                        .gcp_compute
+                        .targetInstances()
+                        .insert(project=provider.project_name,
+                                zone=self.zone_name,
+                                body=body)
+                        .execute())
+            provider.wait_for_operation(response, zone=self.zone_name)
         except Exception as e:
             log.warning('Exception while inserting a target instance: %s', e)
             return None
@@ -1088,84 +1220,89 @@ class GCPInstance(BaseInstance):
         # successfully created above.
         return self._get_existing_target_instance()
 
-    def _redirect_existing_rule(self, ip, target_instance):
+    def _redirect_existing_rule(self, ip: GCPFloatingIP,
+                                target_instance: Any) -> bool:
         """
         Redirect the forwarding rule of the given IP to the given Instance.
         """
-        new_zone = (self._provider.parse_url(target_instance['zone'])
-                                  .parameters['zone'])
+        provider = cast("GCPCloudProvider", self._provider)
+        new_zone = (_parse_url(provider, target_instance['zone'])
+                    .parameters['zone'])
         new_name = target_instance['name']
         new_url = target_instance['selfLink']
         try:
             for rule in helpers.iter_all(
-                    self._provider.gcp_compute.forwardingRules(),
-                    project=self._provider.project_name,
+                    provider.gcp_compute.forwardingRules(),
+                    project=provider.project_name,
                     region=ip.region_name):
                 if rule['IPAddress'] != ip.public_ip:
                     continue
-                parsed_target_url = self._provider.parse_url(rule['target'])
+                parsed_target_url = _parse_url(provider, rule['target'])
                 old_zone = parsed_target_url.parameters['zone']
                 old_name = parsed_target_url.parameters['targetInstance']
                 if old_zone == new_zone and old_name == new_name:
                     return True
-                response = (self._provider
-                                .gcp_compute
-                                .forwardingRules()
-                                .setTarget(
-                                    project=self._provider.project_name,
-                                    region=ip.region_name,
-                                    forwardingRule=rule['name'],
-                                    body={'target': new_url})
-                                .execute())
-                self._provider.wait_for_operation(response,
-                                                  region=ip.region_name)
+                response = (provider
+                            .gcp_compute
+                            .forwardingRules()
+                            .setTarget(
+                                project=provider.project_name,
+                                region=ip.region_name,
+                                forwardingRule=rule['name'],
+                                body={'target': new_url})
+                            .execute())
+                provider.wait_for_operation(response,
+                                            region=ip.region_name)
                 return True
         except Exception as e:
             log.warning(
                 'Exception while listing/changing forwarding rules: %s', e)
         return False
 
-    def _forward(self, ip, target_instance):
+    def _forward(self, ip: GCPFloatingIP, target_instance: Any) -> bool:
         """
         Forward the traffic to a given IP to a given instance.
 
         If there is already a forwarding rule for the IP, it is redirected;
         otherwise, a new forwarding rule is created.
         """
+        provider = cast("GCPCloudProvider", self._provider)
         if self._redirect_existing_rule(ip, target_instance):
             return True
         body = {'name': 'forwarding-rule-{0}'.format(uuid.uuid4()),
                 'IPAddress': ip.public_ip,
                 'target': target_instance['selfLink']}
         try:
-            response = (self._provider
-                            .gcp_compute
-                            .forwardingRules()
-                            .insert(project=self._provider.project_name,
-                                    region=ip.region_name,
-                                    body=body)
-                            .execute())
-            self._provider.wait_for_operation(response, region=ip.region_name)
+            response = (provider
+                        .gcp_compute
+                        .forwardingRules()
+                        .insert(project=provider.project_name,
+                                region=ip.region_name,
+                                body=body)
+                        .execute())
+            provider.wait_for_operation(response, region=ip.region_name)
         except Exception as e:
             log.warning('Exception while inserting a forwarding rule: %s', e)
             return False
         return True
 
-    def _delete_existing_rule(self, ip, target_instance):
+    def _delete_existing_rule(self, ip: GCPFloatingIP,
+                              target_instance: Any) -> bool:
         """
         Stop forwarding traffic to an instance by deleting the forwarding rule.
         """
-        zone = (self._provider.parse_url(target_instance['zone'])
-                              .parameters['zone'])
+        provider = cast("GCPCloudProvider", self._provider)
+        zone = (_parse_url(provider, target_instance['zone'])
+                .parameters['zone'])
         name = target_instance['name']
         try:
             for rule in helpers.iter_all(
-                    self._provider.gcp_compute.forwardingRules(),
-                    project=self._provider.project_name,
+                    provider.gcp_compute.forwardingRules(),
+                    project=provider.project_name,
                     region=ip.region_name):
                 if rule['IPAddress'] != ip.public_ip:
                     continue
-                parsed_target_url = self._provider.parse_url(rule['target'])
+                parsed_target_url = _parse_url(provider, rule['target'])
                 temp_zone = parsed_target_url.parameters['zone']
                 temp_name = parsed_target_url.parameters['targetInstance']
                 if temp_zone != zone or temp_name != name:
@@ -1173,16 +1310,16 @@ class GCPInstance(BaseInstance):
                             '"%s" is forwarded to "%s" in zone "%s"',
                             ip.public_ip, temp_name, temp_zone)
                     return False
-                response = (self._provider
-                                .gcp_compute
-                                .forwardingRules()
-                                .delete(
-                                    project=self._provider.project_name,
-                                    region=ip.region_name,
-                                    forwardingRule=rule['name'])
-                                .execute())
-                self._provider.wait_for_operation(response,
-                                                  region=ip.region_name)
+                response = (provider
+                            .gcp_compute
+                            .forwardingRules()
+                            .delete(
+                                project=provider.project_name,
+                                region=ip.region_name,
+                                forwardingRule=rule['name'])
+                            .execute())
+                provider.wait_for_operation(response,
+                                            region=ip.region_name)
                 return True
         except Exception as e:
             log.warning(
@@ -1190,12 +1327,14 @@ class GCPInstance(BaseInstance):
             return False
         return True
 
-    def add_floating_ip(self, floating_ip):
+    def add_floating_ip(self, floating_ip: FloatingIP | str) -> None:
         """
         Add an elastic IP address to this instance.
         """
-        fip = (floating_ip if isinstance(floating_ip, GCPFloatingIP)
-               else self.inet_gateway.floating_ips.get(floating_ip))
+        fip = cast(GCPFloatingIP,
+                   floating_ip if isinstance(floating_ip, GCPFloatingIP)
+                   else self.inet_gateway.floating_ips.get(
+                       cast(str, floating_ip)))
         if fip.in_use:
             if fip.private_ip not in self.private_ips:
                 log.warning('Floating IP "%s" is not associated to "%s"',
@@ -1210,12 +1349,14 @@ class GCPInstance(BaseInstance):
             log.warning('Could not forward "%s" to "%s"',
                         fip.public_ip, target_instance['selfLink'])
 
-    def remove_floating_ip(self, floating_ip):
+    def remove_floating_ip(self, floating_ip: FloatingIP | str) -> None:
         """
         Remove a elastic IP address from this instance.
         """
-        fip = (floating_ip if isinstance(floating_ip, GCPFloatingIP)
-               else self.inet_gateway.floating_ips.get(floating_ip))
+        fip = cast(GCPFloatingIP,
+                   floating_ip if isinstance(floating_ip, GCPFloatingIP)
+                   else self.inet_gateway.floating_ips.get(
+                       cast(str, floating_ip)))
         if not fip.in_use or fip.private_ip not in self.private_ips:
             log.warning('Floating IP "%s" is not associated to "%s"',
                         fip.public_ip, self.name)
@@ -1232,16 +1373,17 @@ class GCPInstance(BaseInstance):
                 fip.public_ip, self.name)
 
     @property
-    def state(self):
+    def state(self) -> str:
         return GCPInstance.INSTANCE_STATE_MAP.get(
             self._gcp_instance['status'], InstanceState.UNKNOWN)
 
-    def refresh(self):
+    def refresh(self) -> None:
         """
         Refreshes the state of this instance by re-querying the cloud provider
         for its latest state.
         """
-        inst = self._provider.compute.instances.get(self.id)
+        inst = cast("GCPInstance | None",
+                    self._provider.compute.instances.get(self.id))
         if inst:
             # pylint:disable=protected-access
             self._gcp_instance = inst._gcp_instance
@@ -1249,75 +1391,80 @@ class GCPInstance(BaseInstance):
             # instance no longer exists
             self._gcp_instance['status'] = InstanceState.UNKNOWN
 
-    def add_vm_firewall(self, sg):
-        tag = sg.name if isinstance(sg, GCPVMFirewall) else sg
+    def add_vm_firewall(self, firewall: VMFirewall | str) -> None:
+        tag = (firewall.name if isinstance(firewall, GCPVMFirewall)
+               else firewall)
         tags = self._gcp_instance.get('tags', {}).get('items', [])
         tags.append(tag)
         self._set_tags(tags)
 
-    def remove_vm_firewall(self, sg):
-        tag = sg.name if isinstance(sg, GCPVMFirewall) else sg
+    def remove_vm_firewall(self, firewall: VMFirewall | str) -> None:
+        tag = (firewall.name if isinstance(firewall, GCPVMFirewall)
+               else firewall)
         tags = self._gcp_instance.get('tags', {}).get('items', [])
         if tag in tags:
             tags.remove(tag)
             self._set_tags(tags)
 
-    def _set_tags(self, tags):
+    def _set_tags(self, tags: list[str]) -> None:
         # Refresh to make sure we are using the most recent tags fingerprint.
+        provider = cast("GCPCloudProvider", self._provider)
         self.refresh()
         fingerprint = self._gcp_instance.get('tags', {}).get('fingerprint', '')
-        response = (self._provider
-                        .gcp_compute
-                        .instances()
-                        .setTags(project=self._provider.project_name,
-                                 zone=self.zone_name,
-                                 instance=self.name,
-                                 body={'items': tags,
-                                       'fingerprint': fingerprint})
-                        .execute())
-        self._provider.wait_for_operation(response, zone=self.zone_name)
+        response = (provider
+                    .gcp_compute
+                    .instances()
+                    .setTags(project=provider.project_name,
+                             zone=self.zone_name,
+                             instance=self.name,
+                             body={'items': tags,
+                                   'fingerprint': fingerprint})
+                    .execute())
+        provider.wait_for_operation(response, zone=self.zone_name)
 
 
 class GCPNetwork(BaseNetwork):
 
-    def __init__(self, provider, network):
+    def __init__(self, provider: GCPCloudProvider, network: Any) -> None:
         super(GCPNetwork, self).__init__(provider)
         self._network = network
         self._gateway_container = GCPGatewaySubService(provider, self)
         self._subnet_svc = GCPSubnetSubService(provider, self)
 
     @property
-    def resource_url(self):
+    def resource_url(self) -> str:
         return self._network['selfLink']
 
     @property
-    def id(self):
+    def id(self) -> str:
         return self._network['selfLink']
 
     @property
-    def name(self):
+    def name(self) -> str:
         return self._network['name']
 
     @property
-    def label(self):
+    def label(self) -> str | None:
+        provider = cast("GCPCloudProvider", self._provider)
         tag_name = "_".join(["network", self.name, "label"])
-        return helpers.get_metadata_item_value(self._provider, tag_name)
+        return helpers.get_metadata_item_value(provider, tag_name)
 
     @label.setter
-    def label(self, value):
+    def label(self, value: str) -> None:
+        provider = cast("GCPCloudProvider", self._provider)
         self.assert_valid_resource_label(value)
         tag_name = "_".join(["network", self.name, "label"])
-        helpers.modify_or_add_metadata_item(self._provider, tag_name, value)
+        helpers.modify_or_add_metadata_item(provider, tag_name, value)
 
     @property
-    def external(self):
+    def external(self) -> bool:
         """
         All GCP networks can be connected to the Internet.
         """
         return True
 
     @property
-    def state(self):
+    def state(self) -> str:
         """
         When a GCP network created by the CloudBridge API, we wait until the
         network is ready.
@@ -1327,18 +1474,19 @@ class GCPNetwork(BaseNetwork):
         return NetworkState.AVAILABLE
 
     @property
-    def cidr_block(self):
+    def cidr_block(self) -> str:
         if 'IPv4Range' in self._network:
             # This is a legacy network.
             return self._network['IPv4Range']
         return GCPNetwork.CB_DEFAULT_IPV4RANGE
 
     @property
-    def subnets(self):
+    def subnets(self) -> SubnetSubService:
         return self._subnet_svc
 
-    def refresh(self):
-        net = self._provider.networking.networks.get(self.id)
+    def refresh(self) -> None:
+        net = cast("GCPNetwork | None",
+                   self._provider.networking.networks.get(self.id))
         if net:
             # pylint:disable=protected-access
             self._network = net._network
@@ -1347,68 +1495,76 @@ class GCPNetwork(BaseNetwork):
             self._network['status'] = NetworkState.UNKNOWN
 
     @property
-    def gateways(self):
+    def gateways(self) -> GatewaySubService:
         return self._gateway_container
 
 
 class GCPFloatingIP(BaseFloatingIP):
     _DEAD_INSTANCE = 'dead instance'
 
-    def __init__(self, provider, floating_ip):
+    def __init__(self, provider: GCPCloudProvider,
+                 floating_ip: Any) -> None:
         super(GCPFloatingIP, self).__init__(provider)
         self._ip = floating_ip
+        self._rule: Any = None
+        self._target_instance: Any = None
         self._process_ip_users()
 
     @property
-    def id(self):
+    def id(self) -> str:
         return self._ip['selfLink']
 
     @property
-    def region_name(self):
+    def region_name(self) -> str:
         # We use regional IPs to simulate floating IPs not global IPs because
         # global IPs can be forwarded only to load balancing resources, not to
         # a specific instance. Find out the region to which the IP belongs.
-        url = self._provider.parse_url(self._ip['region'])
+        provider = cast("GCPCloudProvider", self._provider)
+        url = _parse_url(provider, self._ip['region'])
         return url.parameters['region']
 
     @property
-    def public_ip(self):
+    def public_ip(self) -> str:
         return self._ip.get('address')
 
     @property
-    def private_ip(self):
+    def private_ip(self) -> str | None:
         if (not self._target_instance or
                 self._target_instance == GCPFloatingIP._DEAD_INSTANCE):
             return None
         return self._target_instance['networkInterfaces'][0]['networkIP']
 
     @property
-    def in_use(self):
+    def in_use(self) -> bool:
         return True if self._target_instance else False
 
-    def refresh(self):
+    def refresh(self) -> None:
         # pylint:disable=protected-access
-        fip = self._provider.networking._floating_ips.get(None, self.id)
+        fip = cast(
+            "GCPFloatingIP",
+            self._provider.networking._floating_ips.get(
+                cast("Gateway", None), self.id))
         # pylint:disable=protected-access
         self._ip = fip._ip
         self._process_ip_users()
 
-    def _process_ip_users(self):
+    def _process_ip_users(self) -> None:
         self._rule = None
         self._target_instance = None
 
         if 'users' in self._ip and len(self._ip['users']) > 0:
-            provider = self._provider
+            provider = cast("GCPCloudProvider", self._provider)
             if len(self._ip['users']) > 1:
                 log.warning('Address "%s" in use by more than one resource',
                             self._ip.get('address'))
-            resource_parsed_url = provider.parse_url(self._ip['users'][0])
+            resource_parsed_url = _parse_url(provider, self._ip['users'][0])
             resource = resource_parsed_url.get_resource()
             if resource['kind'] == 'compute#forwardingRule':
                 self._rule = resource
-                target = provider.parse_url(resource['target']).get_resource()
+                target = _parse_url(
+                    provider, resource['target']).get_resource()
                 if target['kind'] == 'compute#targetInstance':
-                    url = provider.parse_url(target['instance'])
+                    url = _parse_url(provider, target['instance'])
                     try:
                         self._target_instance = url.get_resource()
                     except googleapiclient.errors.HttpError:
@@ -1423,36 +1579,40 @@ class GCPFloatingIP(BaseFloatingIP):
 
 class GCPRouter(BaseRouter):
 
-    def __init__(self, provider, router):
+    def __init__(self, provider: GCPCloudProvider, router: Any) -> None:
         super(GCPRouter, self).__init__(provider)
         self._router = router
 
     @property
-    def id(self):
+    def id(self) -> str:
         return self._router['selfLink']
 
     @property
-    def name(self):
+    def name(self) -> str:
         return self._router['name']
 
     @property
-    def label(self):
+    def label(self) -> str | None:
+        provider = cast("GCPCloudProvider", self._provider)
         tag_name = "_".join(["router", self.name, "label"])
-        return helpers.get_metadata_item_value(self._provider, tag_name)
+        return helpers.get_metadata_item_value(provider, tag_name)
 
     @label.setter
-    def label(self, value):
+    def label(self, value: str) -> None:
+        provider = cast("GCPCloudProvider", self._provider)
         self.assert_valid_resource_label(value)
         tag_name = "_".join(["router", self.name, "label"])
-        helpers.modify_or_add_metadata_item(self._provider, tag_name, value)
+        helpers.modify_or_add_metadata_item(provider, tag_name, value)
 
     @property
-    def region_name(self):
-        parsed_url = self._provider.parse_url(self.id)
+    def region_name(self) -> str:
+        provider = cast("GCPCloudProvider", self._provider)
+        parsed_url = _parse_url(provider, self.id)
         return parsed_url.parameters['region']
 
-    def refresh(self):
-        router = self._provider.networking.routers.get(self.id)
+    def refresh(self) -> None:
+        router = cast("GCPRouter | None",
+                      self._provider.networking.routers.get(self.id))
         if router:
             # pylint:disable=protected-access
             self._router = router._router
@@ -1461,7 +1621,7 @@ class GCPRouter(BaseRouter):
             self._router['status'] = RouterState.UNKNOWN
 
     @property
-    def state(self):
+    def state(self) -> str:
         # If the router info is refreshed after it is deleted, its status will
         # be UNKNOWN.
         if self._router.get('status') == RouterState.UNKNOWN:
@@ -1470,132 +1630,142 @@ class GCPRouter(BaseRouter):
         return RouterState.ATTACHED
 
     @property
-    def network_id(self):
-        parsed_url = self._provider.parse_url(self._router['network'])
+    def network_id(self) -> str | None:
+        provider = cast("GCPCloudProvider", self._provider)
+        parsed_url = _parse_url(provider, self._router['network'])
         network = parsed_url.get_resource()
         return network['selfLink']
 
     @property
-    def subnets(self):
-        network = self._provider.networking.networks.get(self.network_id)
+    def subnets(self) -> Iterable[Subnet]:
+        network = cast(
+            "GCPNetwork",
+            self._provider.networking.networks.get(
+                cast(str, self.network_id)))
         return network.subnets
 
-    def attach_subnet(self, subnet):
+    def attach_subnet(self, subnet: Subnet | str) -> None:
         if not isinstance(subnet, GCPSubnet):
-            subnet = self._provider.networking.subnets.get(subnet)
+            subnet = cast(
+                GCPSubnet, self._provider.networking.subnets.get(
+                    cast(str, subnet)))
         if subnet.network_id == self.network_id:
             return
         log.warning('Google Cloud Routers automatically learn new subnets '
                     'in your VPC network and announces them to your '
                     'on-premises network')
 
-    def detach_subnet(self, network_id):
+    def detach_subnet(self, subnet: Subnet | str) -> None:
         log.warning('Cannot detach from subnet. Google Cloud Routers '
                     'automatically learn new subnets in your VPC network '
                     'and announces them to your on-premises network')
 
-    def attach_gateway(self, gateway):
+    def attach_gateway(self, gateway: Gateway) -> None:
         pass
 
-    def detach_gateway(self, gateway):
+    def detach_gateway(self, gateway: Gateway) -> None:
         pass
 
 
 class GCPInternetGateway(BaseInternetGateway):
 
-    def __init__(self, provider, gateway):
+    def __init__(self, provider: GCPCloudProvider, gateway: Any) -> None:
         super(GCPInternetGateway, self).__init__(provider)
         self._gateway = gateway
         self._fip_container = GCPFloatingIPSubService(provider, self)
 
     @property
-    def id(self):
+    def id(self) -> str:
         return self._gateway['id']
 
     @property
-    def name(self):
+    def name(self) -> str:
         return self._gateway['name']
 
-    def refresh(self):
+    def refresh(self) -> None:
         pass
 
     @property
-    def state(self):
+    def state(self) -> str:
         return GatewayState.AVAILABLE
 
     @property
-    def network_id(self):
+    def network_id(self) -> str | None:
         """
         GCP internet gateways are not attached to a network.
         """
         return None
 
-    def delete(self):
+    def delete(self) -> None:
         pass
 
     @property
-    def floating_ips(self):
+    def floating_ips(self) -> FloatingIPSubService:
         return self._fip_container
 
 
 class GCPSubnet(BaseSubnet):
 
-    def __init__(self, provider, subnet):
+    def __init__(self, provider: GCPCloudProvider, subnet: Any) -> None:
         super(GCPSubnet, self).__init__(provider)
         self._subnet = subnet
 
     @property
-    def id(self):
+    def id(self) -> str:
         return self._subnet['selfLink']
 
     @property
-    def name(self):
+    def name(self) -> str:
         return self._subnet['name']
 
     @property
-    def label(self):
+    def label(self) -> str | None:
+        provider = cast("GCPCloudProvider", self._provider)
         tag_name = "_".join(["subnet", self.name, "label"])
-        return helpers.get_metadata_item_value(self._provider, tag_name)
+        return helpers.get_metadata_item_value(provider, tag_name)
 
     @label.setter
-    def label(self, value):
+    def label(self, value: str) -> None:
+        provider = cast("GCPCloudProvider", self._provider)
         self.assert_valid_resource_label(value)
         tag_name = "_".join(["subnet", self.name, "label"])
-        helpers.modify_or_add_metadata_item(self._provider, tag_name, value)
+        helpers.modify_or_add_metadata_item(provider, tag_name, value)
 
     @property
-    def cidr_block(self):
+    def cidr_block(self) -> str:
         return self._subnet['ipCidrRange']
 
     @property
-    def network_url(self):
+    def network_url(self) -> str:
         return self._subnet['network']
 
     @property
-    def network_id(self):
+    def network_id(self) -> str:
         return self.network_url
 
     @property
-    def region(self):
+    def region(self) -> str:
         return self._subnet['region']
 
     @property
-    def region_name(self):
-        parsed_url = self._provider.parse_url(self.id)
+    def region_name(self) -> str:
+        provider = cast("GCPCloudProvider", self._provider)
+        parsed_url = _parse_url(provider, self.id)
         return parsed_url.parameters['region']
 
     @property
-    def zone(self):
+    def zone(self) -> PlacementZone | None:
         return None
 
     @property
-    def state(self):
+    def state(self) -> str:
         if self._subnet.get('status') == SubnetState.UNKNOWN:
             return SubnetState.UNKNOWN
         return SubnetState.AVAILABLE
 
-    def refresh(self):
-        subnet = self._provider.networking.subnets.get(self.id)
+    def refresh(self) -> None:
+        subnet = cast("GCPSubnet | None",
+                      self._provider.networking.subnets.get(self.id))
         if subnet:
             # pylint:disable=protected-access
             self._subnet = subnet._subnet
@@ -1613,51 +1783,53 @@ class GCPVolume(BaseVolume):
         'RESTORING': VolumeState.CONFIGURING,
     }
 
-    def __init__(self, provider, volume):
+    def __init__(self, provider: GCPCloudProvider, volume: Any) -> None:
         super(GCPVolume, self).__init__(provider)
         self._volume = volume
 
     @property
-    def id(self):
+    def id(self) -> str:
         return self._volume.get('selfLink')
 
     @property
-    def name(self):
+    def name(self) -> str:
         """
         Get the volume name.
         """
         return self._volume.get('name')
 
     @property
-    def label(self):
+    def label(self) -> str | None:
         labels = self._volume.get('labels')
         return labels.get('cblabel', '') if labels else ''
 
     @label.setter
-    def label(self, value):
-        req = (self._provider
-                   .gcp_compute
-                   .disks()
-                   .setLabels(project=self._provider.project_name,
-                              zone=self.zone_name,
-                              resource=self.name,
-                              body={}))
+    def label(self, value: str) -> None:
+        provider = cast("GCPCloudProvider", self._provider)
+        req = (provider
+               .gcp_compute
+               .disks()
+               .setLabels(project=provider.project_name,
+                          zone=self.zone_name,
+                          resource=self.name,
+                          body={}))
 
         helpers.change_label(self, 'cblabel', value, '_volume', req)
 
     @property
-    def description(self):
+    def description(self) -> str:
         labels = self._volume.get('labels')
         if labels and 'description' in labels:
             return labels.get('description', '')
         return self._volume.get('description', '')
 
     @description.setter
-    def description(self, value):
-        req = (self._provider
+    def description(self, value: str) -> None:
+        provider = cast("GCPCloudProvider", self._provider)
+        req = (provider
                .gcp_compute
                .disks()
-               .setLabels(project=self._provider.project_name,
+               .setLabels(project=provider.project_name,
                           zone=self.zone_name,
                           resource=self.name,
                           body={}))
@@ -1665,37 +1837,39 @@ class GCPVolume(BaseVolume):
         helpers.change_label(self, 'description', value, '_volume', req)
 
     @property
-    def size(self):
+    def size(self) -> int:
         return int(self._volume.get('sizeGb'))
 
     @property
-    def create_time(self):
+    def create_time(self) -> str | datetime:
         return self._volume.get('creationTimestamp')
 
     @property
-    def zone_id(self):
+    def zone_id(self) -> str:
         return self._volume.get('zone')
 
     @property
-    def zone_name(self):
-        return self._provider.parse_url(self.zone_id).parameters['zone']
+    def zone_name(self) -> str:
+        provider = cast("GCPCloudProvider", self._provider)
+        return _parse_url(provider, self.zone_id).parameters['zone']
 
     @property
-    def source(self):
+    def source(self) -> Snapshot | MachineImage | None:
+        provider = cast("GCPCloudProvider", self._provider)
         if 'sourceSnapshot' in self._volume:
             snapshot_uri = self._volume.get('sourceSnapshot')
             return GCPSnapshot(
-                    self._provider,
-                    self._provider.parse_url(snapshot_uri).get_resource())
+                    provider,
+                    _parse_url(provider, snapshot_uri).get_resource())
         if 'sourceImage' in self._volume:
             image_uri = self._volume.get('sourceImage')
             return GCPMachineImage(
-                    self._provider,
-                    self._provider.parse_url(image_uri).get_resource())
+                    provider,
+                    _parse_url(provider, image_uri).get_resource())
         return None
 
     @property
-    def attachments(self):
+    def attachments(self) -> AttachmentInfo | None:
         # GCP Persistent Disk supports multiple instances attaching a READ-ONLY
         # disk. In cloudbridge, volume usage pattern is that a disk is attached
         # to a single instance in a read-write mode. Therefore, we only check
@@ -1708,7 +1882,7 @@ class GCPVolume(BaseVolume):
         else:
             return None
 
-    def attach(self, instance, device):
+    def attach(self, instance: str | Instance, device: str) -> None:
         """
         Attach this volume to an instance.
 
@@ -1719,16 +1893,19 @@ class GCPVolume(BaseVolume):
         system can use the available storage space.
         https://cloud.google.com/compute/docs/disks/add-persistent-disk
         """
+        provider = cast("GCPCloudProvider", self._provider)
         attach_disk_body = {
             "source": self.id,
             "deviceName": device.split('/')[-1],
         }
         if not isinstance(instance, GCPInstance):
-            instance = self._provider.get_resource('instances', instance)
-        response = (self._provider
+            instance = cast(
+                GCPInstance,
+                provider.get_resource('instances', cast(str, instance)))
+        response = (provider
                     .gcp_compute
                     .instances()
-                    .attachDisk(project=self._provider.project_name,
+                    .attachDisk(project=provider.project_name,
                                 zone=instance.zone_name,
                                 instance=instance.name,
                                 body=attach_disk_body)
@@ -1736,16 +1913,17 @@ class GCPVolume(BaseVolume):
         # attachDisk is asynchronous; wait for it to finish so the disk is
         # actually attached (and the instance's disk list is consistent)
         # before returning.
-        self._provider.wait_for_operation(response, zone=instance.zone_name)
+        provider.wait_for_operation(response, zone=instance.zone_name)
 
-    def detach(self, force=False):
+    def detach(self, force: bool = False) -> None:
         """
         Detach this volume from an instance.
         """
+        provider = cast("GCPCloudProvider", self._provider)
         # Check whether this volume is attached to an instance.
         if not self.attachments:
             return
-        parsed_uri = self._provider.parse_url(self.attachments.instance_id)
+        parsed_uri = _parse_url(provider, self.attachments.instance_id)
         instance_data = parsed_uri.get_resource()
         # Check whether the instance has this volume attached.
         if 'disks' not in instance_data:
@@ -1757,19 +1935,20 @@ class GCPVolume(BaseVolume):
                 device_name = disk['deviceName']
         if not device_name:
             return
-        response = (self._provider
+        response = (provider
                     .gcp_compute
                     .instances()
-                    .detachDisk(project=self._provider.project_name,
+                    .detachDisk(project=provider.project_name,
                                 zone=self.zone_name,
                                 instance=instance_data.get('name'),
                                 deviceName=device_name)
                     .execute())
         # detachDisk is asynchronous; wait for it to finish so the disk is
         # actually released before returning.
-        self._provider.wait_for_operation(response, zone=self.zone_name)
+        provider.wait_for_operation(response, zone=self.zone_name)
 
-    def create_snapshot(self, label, description=None):
+    def create_snapshot(self, label: str,
+                        description: str | None = None) -> Snapshot:
         """
         Create a snapshot of this Volume.
         """
@@ -1777,18 +1956,19 @@ class GCPVolume(BaseVolume):
             label, self, description)
 
     @property
-    def state(self):
+    def state(self) -> str:
         if len(self._volume.get('users', [])) > 0:
             return VolumeState.IN_USE
         return GCPVolume.VOLUME_STATE_MAP.get(
             self._volume.get('status'), VolumeState.UNKNOWN)
 
-    def refresh(self):
+    def refresh(self) -> None:
         """
         Refreshes the state of this volume by re-querying the cloud provider
         for its latest state.
         """
-        vol = self._provider.storage.volumes.get(self.id)
+        vol = cast("GCPVolume | None",
+                   self._provider.storage.volumes.get(self.id))
         if vol:
             # pylint:disable=protected-access
             self._volume = vol._volume
@@ -1804,79 +1984,82 @@ class GCPSnapshot(BaseSnapshot):
         'READY': SnapshotState.AVAILABLE,
     }
 
-    def __init__(self, provider, snapshot):
+    def __init__(self, provider: GCPCloudProvider, snapshot: Any) -> None:
         super(GCPSnapshot, self).__init__(provider)
         self._snapshot = snapshot
 
     @property
-    def id(self):
+    def id(self) -> str:
         return self._snapshot.get('selfLink')
 
     @property
-    def name(self):
+    def name(self) -> str:
         """
         Get the snapshot name.
         """
         return self._snapshot.get('name')
 
     @property
-    def label(self):
+    def label(self) -> str | None:
         labels = self._snapshot.get('labels')
         return labels.get('cblabel', '') if labels else ''
 
     @label.setter
     # pylint:disable=arguments-differ
-    def label(self, value):
-        req = (self._provider
-                   .gcp_compute
-                   .snapshots()
-                   .setLabels(project=self._provider.project_name,
-                              resource=self.name,
-                              body={}))
+    def label(self, value: str) -> None:
+        provider = cast("GCPCloudProvider", self._provider)
+        req = (provider
+               .gcp_compute
+               .snapshots()
+               .setLabels(project=provider.project_name,
+                          resource=self.name,
+                          body={}))
 
         helpers.change_label(self, 'cblabel', value, '_snapshot', req)
 
     @property
-    def description(self):
+    def description(self) -> str:
         labels = self._snapshot.get('labels')
         if labels and 'description' in labels:
             return labels.get('description', '')
         return self._snapshot.get('description', '')
 
     @description.setter
-    def description(self, value):
-        req = (self._provider
+    def description(self, value: str) -> None:
+        provider = cast("GCPCloudProvider", self._provider)
+        req = (provider
                .gcp_compute
                .snapshots()
-               .setLabels(project=self._provider.project_name,
+               .setLabels(project=provider.project_name,
                           resource=self.name,
                           body={}))
 
         helpers.change_label(self, 'description', value, '_snapshot', req)
 
     @property
-    def size(self):
+    def size(self) -> int:
         return int(self._snapshot.get('diskSizeGb'))
 
     @property
-    def volume_id(self):
+    def volume_id(self) -> str | None:
         return self._snapshot.get('sourceDisk')
 
     @property
-    def create_time(self):
+    def create_time(self) -> str | datetime:
         return self._snapshot.get('creationTimestamp')
 
     @property
-    def state(self):
+    def state(self) -> str:
         return GCPSnapshot.SNAPSHOT_STATE_MAP.get(
             self._snapshot.get('status'), SnapshotState.UNKNOWN)
 
-    def refresh(self):
+    def refresh(self) -> None:
         """
         Refreshes the state of this snapshot by re-querying the cloud provider
         for its latest state.
         """
-        snap = self._provider.storage.snapshots.get(self.id)
+        snap = cast("GCPSnapshot | None",
+                    self._provider.storage.snapshots.get(self.id))
         if snap:
             # pylint:disable=protected-access
             self._snapshot = snap._snapshot
@@ -1884,7 +2067,9 @@ class GCPSnapshot(BaseSnapshot):
             # snapshot no longer exists
             self._snapshot['status'] = SnapshotState.UNKNOWN
 
-    def create_volume(self, size=None, volume_type=None, iops=None):
+    def create_volume(self, size: int | None = None,
+                      volume_type: str | None = None,
+                      iops: int | None = None) -> Volume:
         """
         Create a new Volume from this Snapshot.
 
@@ -1896,7 +2081,8 @@ class GCPSnapshot(BaseSnapshot):
                 'pd-ssd'.
             iops: Not supported by GCP.
         """
-        zone_name = self._provider.zone_name
+        provider = cast("GCPCloudProvider", self._provider)
+        zone_name = provider.zone_name
         vol_type = 'zones/{0}/diskTypes/{1}'.format(
             zone_name,
             'pd-standard' if (volume_type != 'pd-standard' or
@@ -1907,53 +2093,56 @@ class GCPSnapshot(BaseSnapshot):
             'type': vol_type,
             'sourceSnapshot': self.id
         }
-        operation = (self._provider
-                         .gcp_compute
-                         .disks()
-                         .insert(project=self._provider.project_name,
-                                 zone=zone_name,
-                                 body=disk_body)
-                         .execute())
-        return self._provider.storage.volumes.get(
-            operation.get('targetLink'))
+        operation = (provider
+                     .gcp_compute
+                     .disks()
+                     .insert(project=provider.project_name,
+                             zone=zone_name,
+                             body=disk_body)
+                     .execute())
+        return cast("Volume", provider.storage.volumes.get(
+            operation.get('targetLink')))
 
 
 class GCPBucketObject(BaseBucketObject):
 
-    def __init__(self, provider, bucket, obj):
+    def __init__(self, provider: GCPCloudProvider, bucket: Bucket,
+                 obj: Any) -> None:
         super(GCPBucketObject, self).__init__(provider)
         self._bucket = bucket
         self._obj = obj
 
     @property
-    def id(self):
+    def id(self) -> str:
         return self._obj['selfLink']
 
     @property
-    def name(self):
+    def name(self) -> str:
         return self._obj['name']
 
     @property
-    def size(self):
+    def size(self) -> int:
         return int(self._obj['size'])
 
     @property
-    def last_modified(self):
+    def last_modified(self) -> str:
         return self._obj['updated']
 
-    def iter_content(self):
-        return io.BytesIO(self._provider
-                              .gcp_storage
-                              .objects()
-                              .get_media(bucket=self._obj['bucket'],
-                                         object=self.name)
-                              .execute())
+    def iter_content(self) -> io.BytesIO:
+        provider = cast("GCPCloudProvider", self._provider)
+        return io.BytesIO(provider
+                          .gcp_storage
+                          .objects()
+                          .get_media(bucket=self._obj['bucket'],
+                                     object=self.name)
+                          .execute())
 
     @property
-    def bucket(self):
+    def bucket(self) -> Bucket:
         return self._bucket
 
-    def _upload_single_shot(self, data):
+    def _upload_single_shot(self, data: str | bytes | IO[bytes]
+                            ) -> BucketObject:
         """
         Set the contents of this object in a single request. ``data`` may be
         text, bytes or a seekable file-like object. Larger uploads are handled
@@ -1967,14 +2156,16 @@ class GCPBucketObject(BaseBucketObject):
                 data, mimetype='application/octet-stream')
         # pylint:disable=protected-access
         response = (self._provider
-                        .storage._bucket_objects
+                        .storage._bucket_objects  # type: ignore[attr-defined]
                         ._create_object_with_media_body(self._bucket,
                                                         self.name,
                                                         media_body))
         if response:
             self._obj = response
+        return self
 
-    def upload_from_file(self, path, config=None):
+    def upload_from_file(self, path: str,
+                         config: UploadConfig | None = None) -> BucketObject:
         """
         Upload a binary file.
 
@@ -1987,21 +2178,23 @@ class GCPBucketObject(BaseBucketObject):
                     f, 'application/octet-stream')
             # pylint:disable=protected-access
             response = (self._provider
-                        .storage._bucket_objects
+                        .storage._bucket_objects  # type: ignore[attr-defined]
                         ._create_object_with_media_body(self._bucket,
                                                         self.name,
                                                         media_body))
             if response:
                 self._obj = response
+        return self
 
-    def delete(self):
-        (self._provider
-             .gcp_storage
-             .objects()
-             .delete(bucket=self._obj['bucket'], object=self.name)
-             .execute())
+    def delete(self) -> None:
+        provider = cast("GCPCloudProvider", self._provider)
+        (provider
+         .gcp_storage
+         .objects()
+         .delete(bucket=self._obj['bucket'], object=self.name)
+         .execute())
 
-    def generate_url(self, expires_in, writable=False):
+    def generate_url(self, expires_in: int, writable: bool = False) -> str:
         """
         Generates a signed URL accessible to everyone.
 
@@ -2010,64 +2203,69 @@ class GCPBucketObject(BaseBucketObject):
         the files with the same URL.
 
         """
+        provider = cast("GCPCloudProvider", self._provider)
         http_method = "PUT" if writable else "GET"
 
         # pylint:disable=protected-access
         return helpers.generate_signed_url(
-            self._provider._credentials, self._obj['bucket'], self.name,
+            provider._credentials, self._obj['bucket'], self.name,
             expiration=expires_in, http_method=http_method)
 
-    def refresh(self):
+    def refresh(self) -> None:
         # pylint:disable=protected-access
-        self._obj = self.bucket.objects.get(self.id)._obj
+        obj = cast("GCPBucketObject", self.bucket.objects.get(self.id))
+        self._obj = obj._obj
 
 
 class GCPBucket(BaseBucket):
 
-    def __init__(self, provider, bucket):
+    def __init__(self, provider: GCPCloudProvider, bucket: Any) -> None:
         super(GCPBucket, self).__init__(provider)
         self._bucket = bucket
         self._object_container = GCPBucketObjectSubService(provider, self)
 
     @property
-    def id(self):
+    def id(self) -> str:
         return self._bucket['selfLink']
 
     @property
-    def name(self):
+    def name(self) -> str:
         """
         Get this bucket's name.
         """
         return self._bucket['name']
 
     @property
-    def objects(self):
+    def objects(self) -> BucketObjectSubService:
         return self._object_container
 
 
 class GCPLaunchConfig(BaseLaunchConfig):
 
-    def __init__(self, provider):
+    def __init__(self, provider: GCPCloudProvider) -> None:
         super(GCPLaunchConfig, self).__init__(provider)
 
 
 class GCPDnsZone(BaseDnsZone):
 
-    def __init__(self, provider, dns_zone):
+    def __init__(self, provider: GCPCloudProvider, dns_zone: Any) -> None:
         super(GCPDnsZone, self).__init__(provider)
         self._dns_zone = dns_zone
         self._dns_record_container = GCPDnsRecordSubService(provider, self)
 
     @property
-    def id(self):
-        return self._dns_zone.get('name')
+    def id(self) -> str:
+        zone_id = self._dns_zone.get('name')
+        if zone_id is None:
+            raise ProviderInternalException("DNS zone has no name")
+        return zone_id
 
     @property
-    def name(self):
+    def name(self) -> str:
         return self._dns_zone.get('dnsName')
 
     @property
-    def admin_email(self):
+    def admin_email(self) -> str | None:
         comment = self._dns_zone.get('description')
         if comment:
             email_field = comment.split(",")[0].split("=")
@@ -2079,41 +2277,44 @@ class GCPDnsZone(BaseDnsZone):
             return None
 
     @property
-    def records(self):
+    def records(self) -> DnsRecordSubService:
         return self._dns_record_container
 
 
 class GCPDnsRecord(BaseDnsRecord):
 
-    def __init__(self, provider, dns_zone, dns_record):
+    def __init__(self, provider: GCPCloudProvider, dns_zone: GCPDnsZone,
+                 dns_record: Any) -> None:
         super(GCPDnsRecord, self).__init__(provider)
         self._dns_zone = dns_zone
         self._dns_rec = dns_record
 
     @property
-    def id(self):
+    def id(self) -> str:
         return self._dns_rec.get('name') + ":" + self._dns_rec.get('type')
 
     @property
-    def name(self):
+    def name(self) -> str:
         return self._dns_rec.get('name')
 
     @property
-    def zone_id(self):
+    def zone_id(self) -> str:
         return self._dns_zone.id
 
     @property
-    def type(self):
+    def type(self) -> str:
         return self._dns_rec.get('type')
 
     @property
-    def data(self):
+    def data(self) -> list[str]:
         return self._dns_rec.get('rrdatas')
 
     @property
-    def ttl(self):
+    def ttl(self) -> int:
         return self._dns_rec.get('ttl')
 
-    def delete(self):
+    def delete(self) -> None:
+        provider = cast("GCPCloudProvider", self._provider)
         # pylint:disable=protected-access
-        return self._provider.dns._records.delete(self._dns_zone, self)
+        provider.dns._records.delete(  # type: ignore[attr-defined]
+            self._dns_zone, self)

--- a/cloudbridge/providers/gcp/services.py
+++ b/cloudbridge/providers/gcp/services.py
@@ -1,9 +1,15 @@
+from __future__ import annotations
+
+import builtins
 import io
 import ipaddress
 import json
 import logging
 import time
 import uuid
+from typing import Any
+from typing import TYPE_CHECKING
+from typing import cast
 
 import googleapiclient
 
@@ -38,8 +44,27 @@ from cloudbridge.base.services import BaseVMTypeService
 from cloudbridge.base.services import BaseVolumeService
 from cloudbridge.interfaces.exceptions import DuplicateResourceException
 from cloudbridge.interfaces.exceptions import InvalidParamException
+from cloudbridge.interfaces.exceptions import ProviderInternalException
+from cloudbridge.interfaces.resources import Bucket
+from cloudbridge.interfaces.resources import BucketObject
+from cloudbridge.interfaces.resources import DnsZone
+from cloudbridge.interfaces.resources import FloatingIP
+from cloudbridge.interfaces.resources import Gateway
+from cloudbridge.interfaces.resources import KeyPair
+from cloudbridge.interfaces.resources import LaunchConfig
+from cloudbridge.interfaces.resources import MachineImage
+from cloudbridge.interfaces.resources import MultipartUpload
+from cloudbridge.interfaces.resources import Network
+from cloudbridge.interfaces.resources import Region
+from cloudbridge.interfaces.resources import ResultList
+from cloudbridge.interfaces.resources import Router
+from cloudbridge.interfaces.resources import Snapshot
+from cloudbridge.interfaces.resources import Subnet
 from cloudbridge.interfaces.resources import TrafficDirection
+from cloudbridge.interfaces.resources import UploadPart
 from cloudbridge.interfaces.resources import VMFirewall
+from cloudbridge.interfaces.resources import VMType
+from cloudbridge.interfaces.resources import Volume
 from cloudbridge.providers.gcp import helpers
 
 from .resources import GCPBucket
@@ -63,12 +88,16 @@ from .resources import GCPVMFirewallRule
 from .resources import GCPVMType
 from .resources import GCPVolume
 
+if TYPE_CHECKING:
+    from cloudbridge.interfaces.provider import CloudProvider
+    from cloudbridge.providers.gcp.provider import GCPCloudProvider
+
 log = logging.getLogger(__name__)
 
 
 class GCPSecurityService(BaseSecurityService):
 
-    def __init__(self, provider):
+    def __init__(self, provider: CloudProvider) -> None:
         super(GCPSecurityService, self).__init__(provider)
 
         # Initialize provider services
@@ -77,54 +106,56 @@ class GCPSecurityService(BaseSecurityService):
         self._vm_firewall_rule_svc = GCPVMFirewallRuleService(provider)
 
     @property
-    def key_pairs(self):
+    def key_pairs(self) -> GCPKeyPairService:
         return self._key_pairs
 
     @property
-    def vm_firewalls(self):
+    def vm_firewalls(self) -> GCPVMFirewallService:
         return self._vm_firewalls
 
     @property
-    def _vm_firewall_rules(self):
+    def _vm_firewall_rules(self) -> GCPVMFirewallRuleService:
         return self._vm_firewall_rule_svc
 
 
 class GCPKeyPairService(BaseKeyPairService):
 
-    def __init__(self, provider):
+    def __init__(self, provider: CloudProvider) -> None:
         super(GCPKeyPairService, self).__init__(provider)
 
     @dispatch(event="provider.security.key_pairs.get",
               priority=BaseKeyPairService.STANDARD_EVENT_PRIORITY)
-    def get(self, key_pair_id):
+    def get(self, key_pair_id: str) -> GCPKeyPair | None:
         """
         Returns a KeyPair given its ID.
         """
         for kp in self:
             if kp.id == key_pair_id:
-                return kp
+                return cast(GCPKeyPair, kp)
         else:
             return None
 
     @dispatch(event="provider.security.key_pairs.list",
               priority=BaseKeyPairService.STANDARD_EVENT_PRIORITY)
-    def list(self, limit=None, marker=None):
+    def list(self, limit: int | None = None,
+             marker: str | None = None) -> ResultList[GCPKeyPair]:
+        provider = cast("GCPCloudProvider", self.provider)
         key_pairs = []
         for item in helpers.find_matching_metadata_items(
-                self.provider, GCPKeyPair.KP_TAG_REGEX):
+                provider, GCPKeyPair.KP_TAG_REGEX):
             metadata_value = json.loads(item['value'])
             kp_info = GCPKeyPair.GCPKeyInfo(**metadata_value)
-            key_pairs.append(GCPKeyPair(self.provider, kp_info))
+            key_pairs.append(GCPKeyPair(provider, kp_info))
         return ClientPagedResultList(self.provider, key_pairs,
                                      limit=limit, marker=marker)
 
     @dispatch(event="provider.security.key_pairs.find",
               priority=BaseKeyPairService.STANDARD_EVENT_PRIORITY)
-    def find(self, **kwargs):
+    def find(self, **kwargs: Any) -> ResultList[GCPKeyPair]:
         """
         Searches for a key pair by a given list of attributes.
         """
-        obj_list = self
+        obj_list = list(self)
         filters = ['id', 'name']
         matches = cb_helpers.generic_find(filters, kwargs, obj_list)
 
@@ -134,13 +165,16 @@ class GCPKeyPairService(BaseKeyPairService):
                 "Unrecognised parameters for search: %s. Supported "
                 "attributes: %s" % (kwargs, ", ".join(filters)))
 
-        return ClientPagedResultList(self.provider,
-                                     matches if matches else [])
+        return ClientPagedResultList(
+            self.provider,
+            cast("builtins.list[GCPKeyPair]", matches) if matches else [])
 
     @dispatch(event="provider.security.key_pairs.create",
               priority=BaseKeyPairService.STANDARD_EVENT_PRIORITY)
-    def create(self, name, public_key_material=None):
+    def create(self, name: str,
+               public_key_material: str | None = None) -> GCPKeyPair:
         GCPKeyPair.assert_valid_resource_name(name)
+        provider = cast("GCPCloudProvider", self.provider)
         private_key = None
         if not public_key_material:
             public_key_material, private_key = cb_helpers.generate_key_pair()
@@ -150,10 +184,10 @@ class GCPKeyPairService(BaseKeyPairService):
         kp_info = GCPKeyPair.GCPKeyInfo(name, public_key_material)
         metadata_value = json.dumps(kp_info._asdict())
         try:
-            helpers.add_metadata_item(self.provider,
+            helpers.add_metadata_item(provider,
                                       GCPKeyPair.KP_TAG_PREFIX + name,
                                       metadata_value)
-            return GCPKeyPair(self.provider, kp_info, private_key)
+            return GCPKeyPair(provider, kp_info, private_key)
         except googleapiclient.errors.HttpError as err:
             if err.resp.get('content-type', '').startswith('application/json'):
                 message = (json.loads(err.content).get('error', {})
@@ -165,37 +199,41 @@ class GCPKeyPairService(BaseKeyPairService):
 
     @dispatch(event="provider.security.key_pairs.delete",
               priority=BaseKeyPairService.STANDARD_EVENT_PRIORITY)
-    def delete(self, key_pair):
+    def delete(self, key_pair: GCPKeyPair | str) -> None:
+        provider = cast("GCPCloudProvider", self.provider)
         key_pair = (key_pair if isinstance(key_pair, GCPKeyPair) else
                     self.get(key_pair))
         if key_pair:
             helpers.remove_metadata_item(
-                self.provider, GCPKeyPair.KP_TAG_PREFIX + key_pair.name)
+                provider,
+                GCPKeyPair.KP_TAG_PREFIX + key_pair.name)
 
 
 class GCPVMFirewallService(BaseVMFirewallService):
 
-    def __init__(self, provider):
+    def __init__(self, provider: CloudProvider) -> None:
         super(GCPVMFirewallService, self).__init__(provider)
-        self._delegate = GCPFirewallsDelegate(provider)
+        self._delegate = GCPFirewallsDelegate(
+            cast("GCPCloudProvider", provider))
 
     @dispatch(event="provider.security.vm_firewalls.get",
               priority=BaseVMFirewallService.STANDARD_EVENT_PRIORITY)
-    def get(self, vm_firewall_id):
+    def get(self, vm_firewall_id: str) -> GCPVMFirewall | None:
         tag, network_name = \
             self._delegate.get_tag_network_from_id(vm_firewall_id)
-        if tag is None:
+        if tag is None or network_name is None:
             return None
         network = self.provider.networking.networks.get(network_name)
         return GCPVMFirewall(self._delegate, tag, network)
 
     @dispatch(event="provider.security.vm_firewalls.list",
               priority=BaseVMFirewallService.STANDARD_EVENT_PRIORITY)
-    def list(self, limit=None, marker=None):
+    def list(self, limit: int | None = None,
+             marker: str | None = None) -> ResultList[GCPVMFirewall]:
         vm_firewalls = []
         for tag, network_name in self._delegate.tag_networks:
             network = self.provider.networking.networks.get(
-                    network_name)
+                network_name)
             vm_firewall = GCPVMFirewall(self._delegate, tag, network)
             vm_firewalls.append(vm_firewall)
         return ClientPagedResultList(self.provider, vm_firewalls,
@@ -203,28 +241,35 @@ class GCPVMFirewallService(BaseVMFirewallService):
 
     @dispatch(event="provider.security.vm_firewalls.create",
               priority=BaseVMFirewallService.STANDARD_EVENT_PRIORITY)
-    def create(self, label, network, description=None):
+    def create(self, label: str, network: Network | str,
+               description: str | None = None) -> GCPVMFirewall:
         GCPVMFirewall.assert_valid_resource_label(label)
-        network = (network if isinstance(network, GCPNetwork)
-                   else self.provider.networking.networks.get(network))
-        fw = GCPVMFirewall(self._delegate, label, network, description)
+        network_obj = (network if isinstance(network, GCPNetwork)
+                       else self.provider.networking.networks.get(cast(str, network)))
+        fw = GCPVMFirewall(self._delegate, label, network_obj, description)
         fw.label = label
         # This rule exists implicitly. Add it explicitly so that the firewall
         # is not empty and the rule is shown by list/get/find methods.
+        # create_with_priority is a GCP-only helper not on the public
+        # VMFirewallRuleService interface; reach it via the typed sub-service.
         # pylint:disable=protected-access
-        self.provider.security._vm_firewall_rules.create_with_priority(
+        rule_svc = cast(GCPVMFirewallRuleService,
+                        self.provider.security._vm_firewall_rules)
+        rule_svc.create_with_priority(
             fw, direction=TrafficDirection.OUTBOUND, protocol='tcp',
             priority=65534, cidr='0.0.0.0/0')
         return fw
 
     @dispatch(event="provider.security.vm_firewalls.delete",
               priority=BaseVMFirewallService.STANDARD_EVENT_PRIORITY)
-    def delete(self, vm_firewall):
-        fw_id = (vm_firewall.id if isinstance(vm_firewall, GCPVMFirewall)
+    def delete(self, vm_firewall: VMFirewall | str) -> None:
+        fw_id = (vm_firewall.id if isinstance(vm_firewall, VMFirewall)
                  else vm_firewall)
-        return self._delegate.delete_tag_network_with_id(fw_id)
+        self._delegate.delete_tag_network_with_id(fw_id)
 
-    def find_by_network_and_tags(self, network_name, tags):
+    def find_by_network_and_tags(
+            self, network_name: str,
+            tags: builtins.list[str]) -> builtins.list[GCPVMFirewall]:
         """
         Finds non-empty VM firewalls by network name and VM firewall names
         (tags). If no matching VM firewall is found, an empty list is returned.
@@ -243,16 +288,18 @@ class GCPVMFirewallService(BaseVMFirewallService):
 
 class GCPVMFirewallRuleService(BaseVMFirewallRuleService):
 
-    def __init__(self, provider):
+    def __init__(self, provider: CloudProvider) -> None:
         super(GCPVMFirewallRuleService, self).__init__(provider)
-        self._dummy_rule = None
+        self._dummy_rule: GCPVMFirewallRule | None = None
 
     @dispatch(event="provider.security.vm_firewall_rules.list",
               priority=BaseVMFirewallRuleService.STANDARD_EVENT_PRIORITY)
-    def list(self, firewall, limit=None, marker=None):
+    def list(self, firewall: VMFirewall, limit: int | None = None,
+             marker: str | None = None) -> ResultList[GCPVMFirewallRule]:
+        gcp_fw = cast(GCPVMFirewall, firewall)
         rules = []
-        for fw in firewall.delegate.iter_firewalls(
-                firewall.name, firewall.network.name):
+        for fw in gcp_fw.delegate.iter_firewalls(
+                gcp_fw.name, gcp_fw.network.name):
             rule = GCPVMFirewallRule(firewall, fw['id'])
             if rule.is_dummy_rule():
                 self._dummy_rule = rule
@@ -262,13 +309,14 @@ class GCPVMFirewallRuleService(BaseVMFirewallRuleService):
                                      limit=limit, marker=marker)
 
     @property
-    def dummy_rule(self):
+    def dummy_rule(self) -> GCPVMFirewallRule | None:
         if not self._dummy_rule:
             self.list()
         return self._dummy_rule
 
     @staticmethod
-    def to_port_range(from_port, to_port):
+    def to_port_range(from_port: int | None,
+                      to_port: int | None) -> str | int | None:
         if from_port is not None and to_port is not None:
             return '%d-%d' % (from_port, to_port)
         elif from_port is not None:
@@ -276,69 +324,89 @@ class GCPVMFirewallRuleService(BaseVMFirewallRuleService):
         else:
             return to_port
 
-    def create_with_priority(self, firewall, direction, protocol, priority,
-                             from_port=None, to_port=None, cidr=None,
-                             src_dest_fw=None):
+    def create_with_priority(
+            self, firewall: VMFirewall, direction: TrafficDirection,
+            protocol: str | None, priority: int, from_port: int | None = None,
+            to_port: int | None = None,
+            cidr: str | builtins.list[str] | None = None,
+            src_dest_fw: VMFirewall | None = None) -> GCPVMFirewallRule:
+        gcp_fw = cast(GCPVMFirewall, firewall)
         port = GCPVMFirewallRuleService.to_port_range(from_port, to_port)
         src_dest_tag = None
         src_dest_fw_id = None
         if src_dest_fw:
             src_dest_tag = src_dest_fw.name
             src_dest_fw_id = src_dest_fw.id
-        if not firewall.delegate.add_firewall(
-                firewall.name, direction, protocol, priority, port, cidr,
-                src_dest_tag, firewall.description,
-                firewall.network.name):
-            return None
+        if not gcp_fw.delegate.add_firewall(
+                gcp_fw.name, direction, protocol, priority, port, cidr,
+                src_dest_tag, gcp_fw.description,
+                gcp_fw.network.name):
+            raise ProviderInternalException(
+                "Failed to create the VM firewall rule")
         rules = self.find(firewall, direction=direction, protocol=protocol,
                           from_port=from_port, to_port=to_port, cidr=cidr,
                           src_dest_fw_id=src_dest_fw_id)
         if len(rules) < 1:
-            return None
-        return rules[0]
+            raise ProviderInternalException(
+                "VM firewall rule not found after creation")
+        return cast(GCPVMFirewallRule, rules[0])
 
+    # declares a non-optional VMFirewallRule.
     @dispatch(event="provider.security.vm_firewall_rules.create",
               priority=BaseVMFirewallRuleService.STANDARD_EVENT_PRIORITY)
-    def create(self, firewall, direction, protocol, from_port=None,
-               to_port=None, cidr=None, src_dest_fw=None):
+    def create(self, firewall: VMFirewall,
+               direction: TrafficDirection,
+               protocol: str | None = None, from_port: int | None = None,
+               to_port: int | None = None,
+               cidr: str | builtins.list[str] | None = None,
+               src_dest_fw: VMFirewall | None = None
+               ) -> GCPVMFirewallRule:
         return self.create_with_priority(firewall, direction, protocol,
                                          1000, from_port, to_port, cidr,
                                          src_dest_fw)
 
+    # The interface declares delete(firewall, rule_id: str); this impl also
+    # accepts a GCPVMFirewallRule instance.
     @dispatch(event="provider.security.vm_firewall_rules.delete",
               priority=BaseVMFirewallRuleService.STANDARD_EVENT_PRIORITY)
-    def delete(self, firewall, rule):
-        rule = (rule if isinstance(rule, GCPVMFirewallRule)
-                else self.get(firewall, rule))
+    def delete(self, firewall: VMFirewall,
+               rule: GCPVMFirewallRule | str) -> None:
+        rule = cast(GCPVMFirewallRule,
+                    rule if isinstance(rule, GCPVMFirewallRule)
+                    else self.get(firewall, rule))
         if rule.is_dummy_rule():
-            return True
-        firewall.delegate.delete_firewall_id(rule._rule)
+            return
+        cast(GCPVMFirewall, firewall).delegate.delete_firewall_id(rule._rule)
 
 
 class GCPVMTypeService(BaseVMTypeService):
 
-    def __init__(self, provider):
+    def __init__(self, provider: CloudProvider) -> None:
         super(GCPVMTypeService, self).__init__(provider)
 
     @property
-    def instance_data(self):
-        response = (self.provider
-                        .gcp_compute
-                        .machineTypes()
-                        .list(project=self.provider.project_name,
-                              zone=self.provider.zone_name)
-                        .execute())
+    def instance_data(self) -> Any:
+        provider = cast("GCPCloudProvider", self.provider)
+        response = (
+            provider
+            .gcp_compute
+            .machineTypes()
+            .list(project=provider.project_name,
+                  zone=provider.zone_name)
+            .execute())
         return response['items']
 
     @dispatch(event="provider.compute.vm_types.get",
               priority=BaseVMTypeService.STANDARD_EVENT_PRIORITY)
-    def get(self, vm_type_id):
-        vm_type = self.provider.get_resource('machineTypes', vm_type_id)
-        return GCPVMType(self.provider, vm_type) if vm_type else None
+    def get(self, vm_type_id: str) -> GCPVMType | None:
+        provider = cast("GCPCloudProvider", self.provider)
+        vm_type = provider.get_resource('machineTypes', vm_type_id)
+        return GCPVMType(provider, vm_type) if vm_type else None
 
     @dispatch(event="provider.compute.vm_types.find",
               priority=BaseVMTypeService.STANDARD_EVENT_PRIORITY)
-    def find(self, **kwargs):
+    def find(self, **kwargs: Any) -> ResultList[GCPVMType]:
+        provider = cast("GCPCloudProvider", self.provider)
         matched_inst_types = []
         for inst_type in self.instance_data:
             is_match = True
@@ -350,14 +418,15 @@ class GCPVMTypeService(BaseVMTypeService):
                     is_match = False
                     break
             if is_match:
-                matched_inst_types.append(
-                    GCPVMType(self.provider, inst_type))
-        return matched_inst_types
+                matched_inst_types.append(GCPVMType(provider, inst_type))
+        return ClientPagedResultList(self.provider, matched_inst_types)
 
     @dispatch(event="provider.compute.vm_types.list",
               priority=BaseVMTypeService.STANDARD_EVENT_PRIORITY)
-    def list(self, limit=None, marker=None):
-        inst_types = [GCPVMType(self.provider, inst_type)
+    def list(self, limit: int | None = None,
+             marker: str | None = None) -> ResultList[GCPVMType]:
+        provider = cast("GCPCloudProvider", self.provider)
+        inst_types = [GCPVMType(provider, inst_type)
                       for inst_type in self.instance_data]
         return ClientPagedResultList(self.provider, inst_types,
                                      limit=limit, marker=marker)
@@ -365,28 +434,32 @@ class GCPVMTypeService(BaseVMTypeService):
 
 class GCPRegionService(BaseRegionService):
 
-    def __init__(self, provider):
+    def __init__(self, provider: CloudProvider) -> None:
         super(GCPRegionService, self).__init__(provider)
 
     @dispatch(event="provider.compute.regions.get",
               priority=BaseRegionService.STANDARD_EVENT_PRIORITY)
-    def get(self, region_id):
-        region = self.provider.get_resource('regions', region_id,
-                                            region=region_id)
-        return GCPRegion(self.provider, region) if region else None
+    def get(self, region_id: str) -> GCPRegion | None:
+        provider = cast("GCPCloudProvider", self.provider)
+        region = provider.get_resource(
+            'regions', region_id, region=region_id)
+        return GCPRegion(provider, region) if region else None
 
     @dispatch(event="provider.compute.regions.list",
               priority=BaseRegionService.STANDARD_EVENT_PRIORITY)
-    def list(self, limit=None, marker=None):
+    def list(self, limit: int | None = None,
+             marker: str | None = None) -> ResultList[GCPRegion]:
+        provider = cast("GCPCloudProvider", self.provider)
         max_result = limit if limit is not None and limit < 500 else 500
-        regions_response = (self.provider
-                                .gcp_compute
-                                .regions()
-                                .list(project=self.provider.project_name,
-                                      maxResults=max_result,
-                                      pageToken=marker)
-                                .execute())
-        regions = [GCPRegion(self.provider, region)
+        regions_response = (
+            provider
+            .gcp_compute
+            .regions()
+            .list(project=provider.project_name,
+                  maxResults=max_result,
+                  pageToken=marker)
+            .execute())
+        regions = [GCPRegion(provider, region)
                    for region in regions_response['items']]
         if len(regions) > max_result:
             log.warning('Expected at most %d results; got %d',
@@ -396,43 +469,50 @@ class GCPRegionService(BaseRegionService):
                                      False, data=regions)
 
     @property
-    def current(self):
+    def current(self) -> GCPRegion | None:
         return self.get(self.provider.region_name)
 
 
 class GCPImageService(BaseImageService):
 
-    def __init__(self, provider):
+    def __init__(self, provider: CloudProvider) -> None:
         super(GCPImageService, self).__init__(provider)
-        self._public_images = None
+        self._public_images: builtins.list[GCPMachineImage] | None = None
 
     _PUBLIC_IMAGE_PROJECTS = ['centos-cloud', 'coreos-cloud', 'debian-cloud',
                               'opensuse-cloud', 'ubuntu-os-cloud', 'cos-cloud']
 
-    def _retrieve_public_images(self):
+    def _retrieve_public_images(self) -> None:
         if self._public_images is not None:
             return
         self._public_images = []
+        provider = cast("GCPCloudProvider", self.provider)
         for project in GCPImageService._PUBLIC_IMAGE_PROJECTS:
             for image in helpers.iter_all(
-                    self.provider.gcp_compute.images(), project=project):
+                    provider.gcp_compute.images(), project=project):
                 self._public_images.append(
-                    GCPMachineImage(self.provider, image))
+                    GCPMachineImage(provider, image))
 
-    def get(self, image_id):
+    def get(self, image_id: str) -> GCPMachineImage | None:
         """
         Returns an Image given its id
         """
-        image = self.provider.get_resource('images', image_id)
+        provider = cast("GCPCloudProvider", self.provider)
+        image = provider.get_resource(
+            'images', image_id)
         if image:
-            return GCPMachineImage(self.provider, image)
+            return GCPMachineImage(provider, image)
         self._retrieve_public_images()
-        for public_image in self._public_images:
+        for public_image in self._public_images or []:
             if public_image.id == image_id or public_image.name == image_id:
                 return public_image
         return None
 
-    def find(self, limit=None, marker=None, **kwargs):
+    # The interface declares find(self, **kwargs); this impl also accepts
+    # leading limit/marker pagination params.
+    def find(self,  # type: ignore[override]
+             limit: int | None = None, marker: str | None = None,
+             **kwargs: Any) -> ResultList[GCPMachineImage]:
         """
         Searches for an image by a given list of attributes
         """
@@ -446,54 +526,66 @@ class GCPImageService(BaseImageService):
 
         # Retrieve all available images by setting limit to sys.maxsize
         images = [image for image in self if image.label == label]
-        return ClientPagedResultList(self.provider, images,
-                                     limit=limit, marker=marker)
+        return ClientPagedResultList(
+            self.provider, cast("builtins.list[GCPMachineImage]", images),
+            limit=limit, marker=marker)
 
-    def list(self, limit=None, marker=None):
+    # The interface declares list(self, filter_by_owner, limit, marker); this
+    # impl omits filter_by_owner.
+    def list(self, limit: int | None = None,  # type: ignore[override]
+             marker: str | None = None) -> ResultList[GCPMachineImage]:
         """
         List all images.
         """
         self._retrieve_public_images()
+        provider = cast("GCPCloudProvider", self.provider)
         images = []
-        if (self.provider.project_name not in
+        if (provider.project_name not in
                 GCPImageService._PUBLIC_IMAGE_PROJECTS):
             for image in helpers.iter_all(
-                    self.provider.gcp_compute.images(),
-                    project=self.provider.project_name):
-                images.append(GCPMachineImage(self.provider, image))
-        images.extend(self._public_images)
+                    provider.gcp_compute.images(),
+                    project=provider.project_name):
+                images.append(GCPMachineImage(provider, image))
+        images.extend(self._public_images or [])
         return ClientPagedResultList(self.provider, images,
                                      limit=limit, marker=marker)
 
 
 class GCPInstanceService(BaseInstanceService):
 
-    def __init__(self, provider):
+    def __init__(self, provider: CloudProvider) -> None:
         super(GCPInstanceService, self).__init__(provider)
 
     @dispatch(event="provider.compute.instances.create",
               priority=BaseInstanceService.STANDARD_EVENT_PRIORITY)
-    def create(self, label, image, vm_type, subnet,
-               key_pair=None, vm_firewalls=None, user_data=None,
-               launch_config=None, **kwargs):
+    def create(self, label: str, image: MachineImage | str,
+               vm_type: VMType | str, subnet: Subnet | str,
+               key_pair: KeyPair | str | None = None,
+               vm_firewalls: builtins.list[VMFirewall] | builtins.list[str] | None = None,
+               user_data: str | None = None,
+               launch_config: LaunchConfig | None = None,
+               **kwargs: Any) -> GCPInstance:
         """
         Creates a new virtual machine instance.
         """
         GCPInstance.assert_valid_resource_name(label)
         zone_name = self.provider.zone_name
-        if not isinstance(vm_type, GCPVMType):
-            vm_type = self.provider.compute.vm_types.get(vm_type)
+        vm_type_obj: VMType | None = (
+            vm_type if isinstance(vm_type, GCPVMType)
+            else self.provider.compute.vm_types.get(cast(str, vm_type)))
 
-        network_interface = {'accessConfigs': [{'type': 'ONE_TO_ONE_NAT',
-                                                'name': 'External NAT'}]}
+        network_interface: dict[str, Any] = {
+            'accessConfigs': [{'type': 'ONE_TO_ONE_NAT',
+                               'name': 'External NAT'}]}
         if subnet:
-            network_interface['subnetwork'] = subnet.id
+            network_interface['subnetwork'] = cast(Subnet, subnet).id
         else:
             network_interface['network'] = 'global/networks/default'
 
         num_roots = 0
-        disks = []
-        boot_disk = None
+        disks: builtins.list[dict[str, Any]] = []
+        boot_disk: dict[str, Any] | None = None
+        source_value: Any
         if isinstance(launch_config, GCPLaunchConfig):
             for disk in launch_config.block_devices:
                 if not disk.source:
@@ -545,26 +637,27 @@ class GCPInstanceService(BaseInstanceService):
                             'contains a boot disk, too. The launch config '
                             'will be used.')
             else:
-                if not isinstance(image, GCPMachineImage):
-                    image = self.provider.compute.images.get(image)
+                image_obj: MachineImage | None = (
+                    image if isinstance(image, GCPMachineImage)
+                    else self.provider.compute.images.get(cast(str, image)))
                 # Explicitly set diskName; otherwise, instance name will be
                 # used by default which may conflict with existing disks.
                 boot_disk = {
                     'boot': True,
                     'autoDelete': True,
                     'initializeParams': {
-                        'sourceImage': image.id,
+                        'sourceImage': cast(MachineImage, image_obj).id,
                         'diskName': 'image-disk-{0}'.format(uuid.uuid4())}}
 
         if not boot_disk:
-            log.warning('No boot disk is given for instance %s.', label)
-            return None
+            raise ProviderInternalException(
+                'No boot disk is given for instance {0}.'.format(label))
         # The boot disk must be the first disk attached to the instance.
         disks.insert(0, boot_disk)
 
-        config = {
+        config: dict[str, Any] = {
             'name': GCPInstance._generate_name_from_label(label, 'cb-inst'),
-            'machineType': vm_type.resource_url,
+            'machineType': cast(GCPVMType, vm_type_obj).resource_url,
             'disks': disks,
             'networkInterfaces': [network_interface]
         }
@@ -574,11 +667,12 @@ class GCPInstanceService(BaseInstanceService):
             config['serviceAccounts'] = service_accounts
 
         if vm_firewalls and isinstance(vm_firewalls, list):
-            vm_firewall_names = []
+            vm_firewall_names: builtins.list[str] = []
             if isinstance(vm_firewalls[0], VMFirewall):
-                vm_firewall_names = [f.name for f in vm_firewalls]
+                vm_firewall_names = [
+                    f.name for f in cast("list[VMFirewall]", vm_firewalls)]
             elif isinstance(vm_firewalls[0], str):
-                vm_firewall_names = vm_firewalls
+                vm_firewall_names = cast("list[str]", vm_firewalls)
             if len(vm_firewall_names) > 0:
                 config['tags'] = {}
                 config['tags']['items'] = vm_firewall_names
@@ -588,18 +682,20 @@ class GCPInstanceService(BaseInstanceService):
             config['metadata'] = {'items': [entry]}
 
         if key_pair:
-            if not isinstance(key_pair, GCPKeyPair):
-                key_pair = self._provider.security.key_pairs.get(key_pair)
-            if key_pair:
-                kp = key_pair._key_pair
+            key_pair_obj: KeyPair | None = (
+                key_pair if isinstance(key_pair, GCPKeyPair)
+                else self._provider.security.key_pairs.get(cast(str, key_pair)))
+            if key_pair_obj:
+                kp = cast(GCPKeyPair, key_pair_obj)._key_pair
                 kp_entry = {
                     "key": "ssh-keys",
                     # Format is not removed from public key portion
                     "value": "{}:{} {}".format(
-                        self.provider.vm_default_user_name,
+                        cast("GCPCloudProvider",
+                             self.provider).vm_default_user_name,
                         kp.public_key,
                         kp.name)
-                    }
+                }
                 meta = config.get('metadata', {})
                 if meta:
                     items = meta.get('items', [])
@@ -609,20 +705,22 @@ class GCPInstanceService(BaseInstanceService):
 
         config['labels'] = {'cblabel': label}
 
-        operation = (self.provider
-                         .gcp_compute.instances()
-                         .insert(project=self.provider.project_name,
-                                 zone=zone_name,
-                                 body=config)
-                         .execute())
+        provider = cast("GCPCloudProvider", self.provider)
+        operation = (
+            provider
+            .gcp_compute.instances()
+            .insert(project=provider.project_name,
+                    zone=zone_name,
+                    body=config)
+            .execute())
         instance_id = operation.get('targetLink')
-        self.provider.wait_for_operation(operation, zone=zone_name)
+        provider.wait_for_operation(operation, zone=zone_name)
         cb_inst = self.get(instance_id)
         return cb_inst
 
     @dispatch(event="provider.compute.instances.get",
               priority=BaseInstanceService.STANDARD_EVENT_PRIORITY)
-    def get(self, instance_id):
+    def get(self, instance_id: str) -> GCPInstance | None:
         """
         Returns an instance given its name. Returns None
         if the object does not exist.
@@ -630,12 +728,15 @@ class GCPInstanceService(BaseInstanceService):
         A GCP instance is uniquely identified by its selfLink, which is used
         as its id.
         """
-        instance = self.provider.get_resource('instances', instance_id)
-        return GCPInstance(self.provider, instance) if instance else None
+        provider = cast("GCPCloudProvider", self.provider)
+        instance = provider.get_resource('instances', instance_id)
+        return (GCPInstance(provider, instance)
+                if instance else None)
 
     @dispatch(event="provider.compute.instances.find",
               priority=BaseInstanceService.STANDARD_EVENT_PRIORITY)
-    def find(self, limit=None, marker=None, **kwargs):
+    def find(self, limit: int | None = None, marker: str | None = None,
+             **kwargs: Any) -> ResultList[GCPInstance]:
         """
         Searches for instances by instance label.
         :return: a list of Instance objects
@@ -655,23 +756,27 @@ class GCPInstanceService(BaseInstanceService):
 
     @dispatch(event="provider.compute.instances.list",
               priority=BaseInstanceService.STANDARD_EVENT_PRIORITY)
-    def list(self, limit=None, marker=None):
+    def list(self, limit: int | None = None,
+             marker: str | None = None) -> ResultList[GCPInstance]:
         """
         List all instances.
         """
+        provider = cast("GCPCloudProvider", self.provider)
         # For GCP API, Acceptable values are 0 to 500, inclusive.
         # (Default: 500).
         max_result = limit if limit is not None and limit < 500 else 500
-        response = (self.provider
-                        .gcp_compute
-                        .instances()
-                        .list(project=self.provider.project_name,
-                              zone=self.provider.zone_name,
-                              maxResults=max_result,
-                              pageToken=marker)
-                        .execute())
-        instances = [GCPInstance(self.provider, inst)
-                     for inst in response.get('items', [])]
+        response = (
+            provider
+            .gcp_compute
+            .instances()
+            .list(project=provider.project_name,
+                  zone=provider.zone_name,
+                  maxResults=max_result,
+                  pageToken=marker)
+            .execute())
+        instances = [
+            GCPInstance(provider, inst)
+            for inst in response.get('items', [])]
         if len(instances) > max_result:
             log.warning('Expected at most %d results; got %d',
                         max_result, len(instances))
@@ -681,25 +786,28 @@ class GCPInstanceService(BaseInstanceService):
 
     @dispatch(event="provider.compute.instances.delete",
               priority=BaseInstanceService.STANDARD_EVENT_PRIORITY)
-    def delete(self, instance):
+    def delete(self, instance: GCPInstance | str) -> None:
+        provider = cast("GCPCloudProvider", self.provider)
         instance = (instance if isinstance(instance, GCPInstance) else
                     self.get(instance))
         if instance:
-            (self._provider
+            (provider
              .gcp_compute
              .instances()
-             .delete(project=self.provider.project_name,
+             .delete(project=cast("GCPCloudProvider",
+                                  self.provider).project_name,
                      zone=instance.zone_name,
                      instance=instance.name)
              .execute())
 
-    def create_launch_config(self):
-        return GCPLaunchConfig(self.provider)
+    def create_launch_config(self) -> GCPLaunchConfig:
+        provider = cast("GCPCloudProvider", self.provider)
+        return GCPLaunchConfig(provider)
 
 
 class GCPComputeService(BaseComputeService):
     # TODO: implement GCPComputeService
-    def __init__(self, provider):
+    def __init__(self, provider: CloudProvider) -> None:
         super(GCPComputeService, self).__init__(provider)
         self._instance_svc = GCPInstanceService(self.provider)
         self._vm_type_svc = GCPVMTypeService(self.provider)
@@ -707,25 +815,25 @@ class GCPComputeService(BaseComputeService):
         self._images_svc = GCPImageService(self.provider)
 
     @property
-    def images(self):
+    def images(self) -> GCPImageService:
         return self._images_svc
 
     @property
-    def vm_types(self):
+    def vm_types(self) -> GCPVMTypeService:
         return self._vm_type_svc
 
     @property
-    def instances(self):
+    def instances(self) -> GCPInstanceService:
         return self._instance_svc
 
     @property
-    def regions(self):
+    def regions(self) -> GCPRegionService:
         return self._region_svc
 
 
 class GCPNetworkingService(BaseNetworkingService):
 
-    def __init__(self, provider):
+    def __init__(self, provider: CloudProvider) -> None:
         super(GCPNetworkingService, self).__init__(provider)
         self._network_service = GCPNetworkService(self.provider)
         self._subnet_service = GCPSubnetService(self.provider)
@@ -734,94 +842,104 @@ class GCPNetworkingService(BaseNetworkingService):
         self._floating_ip_service = GCPFloatingIPService(self.provider)
 
     @property
-    def networks(self):
+    def networks(self) -> GCPNetworkService:
         return self._network_service
 
     @property
-    def subnets(self):
+    def subnets(self) -> GCPSubnetService:
         return self._subnet_service
 
     @property
-    def routers(self):
+    def routers(self) -> GCPRouterService:
         return self._router_service
 
     @property
-    def _gateways(self):
+    def _gateways(self) -> GCPGatewayService:
         return self._gateway_service
 
     @property
-    def _floating_ips(self):
+    def _floating_ips(self) -> GCPFloatingIPService:
         return self._floating_ip_service
 
 
 class GCPNetworkService(BaseNetworkService):
 
-    def __init__(self, provider):
+    def __init__(self, provider: CloudProvider) -> None:
         super(GCPNetworkService, self).__init__(provider)
 
     @dispatch(event="provider.networking.networks.get",
               priority=BaseNetworkService.STANDARD_EVENT_PRIORITY)
-    def get(self, network_id):
-        network = self.provider.get_resource('networks', network_id)
-        return GCPNetwork(self.provider, network) if network else None
+    def get(self, network_id: str) -> GCPNetwork | None:
+        provider = cast("GCPCloudProvider", self.provider)
+        network = provider.get_resource(
+            'networks', network_id)
+        return GCPNetwork(provider, network) if network else None
 
     @dispatch(event="provider.networking.networks.find",
               priority=BaseNetworkService.STANDARD_EVENT_PRIORITY)
-    def find(self, limit=None, marker=None, **kwargs):
+    def find(self, limit: int | None = None, marker: str | None = None,
+             **kwargs: Any) -> ResultList[GCPNetwork]:
         """
         GCP networks are global. There is at most one network with a given
         name.
         """
-        obj_list = self
+        obj_list = list(self)
         filters = ['name', 'label']
         matches = cb_helpers.generic_find(filters, kwargs, obj_list)
-        return ClientPagedResultList(self._provider, list(matches),
-                                     limit=limit, marker=marker)
+        return ClientPagedResultList(
+            self._provider, cast("builtins.list[GCPNetwork]", matches),
+            limit=limit, marker=marker)
 
     @dispatch(event="provider.networking.networks.list",
               priority=BaseNetworkService.STANDARD_EVENT_PRIORITY)
-    def list(self, limit=None, marker=None, filter=None):
+    def list(self, limit: int | None = None, marker: str | None = None,
+             filter: str | None = None) -> ResultList[GCPNetwork]:
         # TODO: Decide whether we keep filter in 'list'
+        provider = cast("GCPCloudProvider", self.provider)
         networks = []
-        response = (self.provider
-                        .gcp_compute
-                        .networks()
-                        .list(project=self.provider.project_name,
-                              filter=filter)
-                        .execute())
+        response = (
+            provider
+            .gcp_compute
+            .networks()
+            .list(project=provider.project_name,
+                  filter=filter)
+            .execute())
         for network in response.get('items', []):
-            networks.append(GCPNetwork(self.provider, network))
+            networks.append(GCPNetwork(provider, network))
         return ClientPagedResultList(self.provider, networks,
                                      limit=limit, marker=marker)
 
     @dispatch(event="provider.networking.networks.create",
               priority=BaseNetworkService.STANDARD_EVENT_PRIORITY)
-    def create(self, label, cidr_block):
+    def create(self, label: str, cidr_block: str) -> GCPNetwork:
         """
         Creates an auto mode VPC network with default subnets. It is possible
         to add additional subnets later.
         """
         GCPNetwork.assert_valid_resource_label(label)
         name = GCPNetwork._generate_name_from_label(label, 'cbnet')
-        body = {'name': name}
+        body: dict[str, Any] = {'name': name}
         # This results in a custom mode network
         body['autoCreateSubnetworks'] = False
-        response = (self.provider
-                        .gcp_compute
-                        .networks()
-                        .insert(project=self.provider.project_name,
-                                body=body)
-                        .execute())
-        self.provider.wait_for_operation(response)
-        cb_net = self.get(name)
+        provider = cast("GCPCloudProvider", self.provider)
+        response = (
+            provider
+            .gcp_compute
+            .networks()
+            .insert(project=provider.project_name,
+                    body=body)
+            .execute())
+        provider.wait_for_operation(response)
+        # The network is expected to exist immediately after creation.
+        cb_net = cast(GCPNetwork, self.get(name))
         cb_net.label = label
         return cb_net
 
-    def get_or_create_default(self):
+    def get_or_create_default(self) -> GCPNetwork:
         default_nets = self.provider.networking.networks.find(
             label=GCPNetwork.CB_DEFAULT_NETWORK_LABEL)
         if default_nets:
-            return default_nets[0]
+            return cast(GCPNetwork, default_nets[0])
         else:
             log.info("Creating a CloudBridge-default network labeled %s",
                      GCPNetwork.CB_DEFAULT_NETWORK_LABEL)
@@ -831,67 +949,75 @@ class GCPNetworkService(BaseNetworkService):
 
     @dispatch(event="provider.networking.networks.delete",
               priority=BaseNetworkService.STANDARD_EVENT_PRIORITY)
-    def delete(self, network):
+    def delete(self, network: Network | str) -> None:
         # Accepts network object
-        if isinstance(network, GCPNetwork):
+        if not isinstance(network, str):
             name = network.name
         # Accepts both name and ID
         elif 'googleapis' in network:
             name = network.split('/')[-1]
         else:
             name = network
-        response = (self.provider
-                        .gcp_compute
-                        .networks()
-                        .delete(project=self.provider.project_name,
-                                network=name)
-                        .execute())
-        self.provider.wait_for_operation(response)
+        provider = cast("GCPCloudProvider", self.provider)
+        response = (
+            provider
+            .gcp_compute
+            .networks()
+            .delete(project=provider.project_name,
+                    network=name)
+            .execute())
+        provider.wait_for_operation(response)
         # Remove label
         tag_name = "_".join(["network", name, "label"])
-        if not helpers.remove_metadata_item(self.provider, tag_name):
+        if not helpers.remove_metadata_item(
+                provider, tag_name):
             log.warning('No label was found associated with this network '
                         '"{}" when deleted.'.format(network))
-        return True
 
 
 class GCPRouterService(BaseRouterService):
 
-    def __init__(self, provider):
+    def __init__(self, provider: CloudProvider) -> None:
         super(GCPRouterService, self).__init__(provider)
 
     @dispatch(event="provider.networking.routers.get",
               priority=BaseRouterService.STANDARD_EVENT_PRIORITY)
-    def get(self, router_id):
-        router = self.provider.get_resource(
+    def get(self, router_id: str) -> GCPRouter | None:
+        provider = cast("GCPCloudProvider", self.provider)
+        router = provider.get_resource(
             'routers', router_id, region=self.provider.region_name)
-        return GCPRouter(self.provider, router) if router else None
+        return GCPRouter(provider, router) if router else None
 
     @dispatch(event="provider.networking.routers.find",
               priority=BaseRouterService.STANDARD_EVENT_PRIORITY)
-    def find(self, limit=None, marker=None, **kwargs):
-        obj_list = self
+    def find(self, limit: int | None = None, marker: str | None = None,
+             **kwargs: Any) -> ResultList[GCPRouter]:
+        obj_list = list(self)
         filters = ['name', 'label']
         matches = cb_helpers.generic_find(filters, kwargs, obj_list)
-        return ClientPagedResultList(self._provider, list(matches),
-                                     limit=limit, marker=marker)
+        return ClientPagedResultList(
+            self._provider, cast("builtins.list[GCPRouter]", matches),
+            limit=limit, marker=marker)
 
     @dispatch(event="provider.networking.routers.list",
               priority=BaseRouterService.STANDARD_EVENT_PRIORITY)
-    def list(self, limit=None, marker=None):
+    def list(self, limit: int | None = None,
+             marker: str | None = None) -> ResultList[GCPRouter]:
+        provider = cast("GCPCloudProvider", self.provider)
         region = self.provider.region_name
         max_result = limit if limit is not None and limit < 500 else 500
-        response = (self.provider
-                        .gcp_compute
-                        .routers()
-                        .list(project=self.provider.project_name,
-                              region=region,
-                              maxResults=max_result,
-                              pageToken=marker)
-                        .execute())
+        response = (
+            provider
+            .gcp_compute
+            .routers()
+            .list(project=provider.project_name,
+                  region=region,
+                  maxResults=max_result,
+                  pageToken=marker)
+            .execute())
         routers = []
         for router in response.get('items', []):
-            routers.append(GCPRouter(self.provider, router))
+            routers.append(GCPRouter(provider, router))
         if len(routers) > max_result:
             log.warning('Expected at most %d results; go %d',
                         max_result, len(routers))
@@ -901,94 +1027,108 @@ class GCPRouterService(BaseRouterService):
 
     @dispatch(event="provider.networking.routers.create",
               priority=BaseRouterService.STANDARD_EVENT_PRIORITY)
-    def create(self, label, network):
+    def create(self, label: str, network: Network | str) -> GCPRouter:
         log.debug("Creating GCP Router Service with params "
                   "[label: %s network: %s]", label, network)
         GCPRouter.assert_valid_resource_label(label)
         name = GCPRouter._generate_name_from_label(label, 'cb-router')
 
-        if not isinstance(network, GCPNetwork):
-            network = self.provider.networking.networks.get(network)
-        network_url = network.resource_url
+        network_obj = (network if isinstance(network, GCPNetwork)
+                       else self.provider.networking.networks.get(cast(str, network)))
+        network_url = cast(GCPNetwork, network_obj).resource_url
+        provider = cast("GCPCloudProvider", self.provider)
         region_name = self.provider.region_name
-        response = (self.provider
-                        .gcp_compute
-                        .routers()
-                        .insert(project=self.provider.project_name,
-                                region=region_name,
-                                body={'name': name,
-                                      'network': network_url})
-                        .execute())
-        self.provider.wait_for_operation(response, region=region_name)
-        cb_router = self.get(name)
+        response = (
+            provider
+            .gcp_compute
+            .routers()
+            .insert(project=provider.project_name,
+                    region=region_name,
+                    body={'name': name,
+                          'network': network_url})
+            .execute())
+        provider.wait_for_operation(response, region=region_name)
+        # The router is expected to exist immediately after creation.
+        cb_router = cast(GCPRouter, self.get(name))
         cb_router.label = label
         return cb_router
 
     @dispatch(event="provider.networking.routers.delete",
               priority=BaseRouterService.STANDARD_EVENT_PRIORITY)
-    def delete(self, router):
+    def delete(self, router: Router | str) -> None:
         r = router if isinstance(router, GCPRouter) else self.get(router)
         if r:
-            (self.provider
+            provider = cast("GCPCloudProvider", self.provider)
+            (provider
              .gcp_compute
              .routers()
-             .delete(project=self.provider.project_name,
+             .delete(project=provider.project_name,
                      region=r.region_name,
                      router=r.name)
              .execute())
             # Remove label
             tag_name = "_".join(["router", r.name, "label"])
-            if not helpers.remove_metadata_item(self.provider, tag_name):
+            if not helpers.remove_metadata_item(
+                    provider, tag_name):
                 log.warning('No label was found associated with this router '
                             '"{}" when deleted.'.format(r.name))
 
-    def _get_in_region(self, router_id, region=None):
+    def _get_in_region(self, router_id: str,
+                       region: Region | str | None = None) -> GCPRouter | None:
         region_name = self.provider.region_name
         if region:
-            if not isinstance(region, GCPRegion):
-                region = self.provider.compute.regions.get(region)
-            region_name = region.name
-        router = self.provider.get_resource(
+            region_obj = (region if isinstance(region, GCPRegion)
+                          else self.provider.compute.regions.get(cast(str, region)))
+            region_name = cast(GCPRegion, region_obj).name
+        provider = cast("GCPCloudProvider", self.provider)
+        router = provider.get_resource(
             'routers', router_id, region=region_name)
-        return GCPRouter(self.provider, router) if router else None
+        return GCPRouter(provider, router) if router else None
 
 
 class GCPSubnetService(BaseSubnetService):
 
-    def __init__(self, provider):
+    def __init__(self, provider: CloudProvider) -> None:
         super(GCPSubnetService, self).__init__(provider)
 
     @dispatch(event="provider.networking.subnets.get",
               priority=BaseSubnetService.STANDARD_EVENT_PRIORITY)
-    def get(self, subnet_id):
-        subnet = self.provider.get_resource('subnetworks', subnet_id)
-        return GCPSubnet(self.provider, subnet) if subnet else None
+    def get(self, subnet_id: str) -> GCPSubnet | None:
+        provider = cast("GCPCloudProvider", self.provider)
+        subnet = provider.get_resource('subnetworks', subnet_id)
+        return GCPSubnet(provider, subnet) if subnet else None
 
     @dispatch(event="provider.networking.subnets.list",
               priority=BaseSubnetService.STANDARD_EVENT_PRIORITY)
-    def list(self, network=None, limit=None, marker=None):
+    def list(self, network: Network | str | None = None,
+             limit: int | None = None,
+             marker: str | None = None) -> ResultList[GCPSubnet]:
         filter = None
         if network is not None:
-            network = (network if isinstance(network, GCPNetwork)
-                       else self.provider.networking.networks.get(network))
-            filter = 'network eq %s' % network.resource_url
+            network_obj = (network if isinstance(network, GCPNetwork)
+                           else self.provider.networking.networks.get(cast(str, network)))
+            filter = ('network eq %s'
+                      % cast(GCPNetwork, network_obj).resource_url)
+        provider = cast("GCPCloudProvider", self.provider)
         region_name = self.provider.region_name
         subnets = []
-        response = (self.provider
-                        .gcp_compute
-                        .subnetworks()
-                        .list(project=self.provider.project_name,
-                              region=region_name,
-                              filter=filter)
-                        .execute())
+        response = (
+            provider
+            .gcp_compute
+            .subnetworks()
+            .list(project=provider.project_name,
+                  region=region_name,
+                  filter=filter)
+            .execute())
         for subnet in response.get('items', []):
-            subnets.append(GCPSubnet(self.provider, subnet))
+            subnets.append(GCPSubnet(provider, subnet))
         return ClientPagedResultList(self.provider, subnets,
                                      limit=limit, marker=marker)
 
     @dispatch(event="provider.networking.subnets.create",
               priority=BaseSubnetService.STANDARD_EVENT_PRIORITY)
-    def create(self, label, network, cidr_block):
+    def create(self, label: str, network: Network | str,
+               cidr_block: str) -> GCPSubnet:
         """
         GCP subnets are regional. The default region, as set in the
         provider, is used.
@@ -1010,42 +1150,48 @@ class GCPSubnetService(BaseSubnetService):
 
         body = {'ipCidrRange': cidr_block,
                 'name': name,
-                'network': network.resource_url,
+                'network': cast(GCPNetwork, network).resource_url,
                 'region': region_name
                 }
-        response = (self.provider
-                        .gcp_compute
-                        .subnetworks()
-                        .insert(project=self.provider.project_name,
-                                region=region_name,
-                                body=body)
-                        .execute())
-        self.provider.wait_for_operation(response, region=region_name)
-        cb_subnet = self.get(name)
+        provider = cast("GCPCloudProvider", self.provider)
+        response = (
+            provider
+            .gcp_compute
+            .subnetworks()
+            .insert(project=provider.project_name,
+                    region=region_name,
+                    body=body)
+            .execute())
+        provider.wait_for_operation(response, region=region_name)
+        # The subnet is expected to exist immediately after creation.
+        cb_subnet = cast(GCPSubnet, self.get(name))
         cb_subnet.label = label
         return cb_subnet
 
     @dispatch(event="provider.networking.subnets.delete",
               priority=BaseSubnetService.STANDARD_EVENT_PRIORITY)
-    def delete(self, subnet):
+    def delete(self, subnet: Subnet | str) -> None:
         sn = subnet if isinstance(subnet, GCPSubnet) else self.get(subnet)
         if not sn:
             return
-        response = (self.provider
-                    .gcp_compute
-                    .subnetworks()
-                    .delete(project=self.provider.project_name,
-                            region=sn.region_name,
-                            subnetwork=sn.name)
-                    .execute())
-        self.provider.wait_for_operation(response, region=sn.region_name)
+        provider = cast("GCPCloudProvider", self.provider)
+        response = (
+            provider
+            .gcp_compute
+            .subnetworks()
+            .delete(project=provider.project_name,
+                    region=sn.region_name,
+                    subnetwork=sn.name)
+            .execute())
+        provider.wait_for_operation(response, region=sn.region_name)
         # Remove label
         tag_name = "_".join(["subnet", sn.name, "label"])
-        if not helpers.remove_metadata_item(self._provider, tag_name):
+        if not helpers.remove_metadata_item(
+                provider, tag_name):
             log.warning('No label was found associated with this subnet '
                         '"{}" when deleted.'.format(sn.name))
 
-    def get_or_create_default(self):
+    def get_or_create_default(self) -> GCPSubnet:
         """
         Return an existing or create a new subnet in the provider default zone.
 
@@ -1056,20 +1202,23 @@ class GCPSubnetService(BaseSubnetService):
         # Check if a default subnet already exists for the given region/zone
         for sn in self.find(label=GCPSubnet.CB_DEFAULT_SUBNET_LABEL):
             if sn.region_name == region_name:
-                return sn
+                return cast(GCPSubnet, sn)
         # No default subnet in the current zone. Look for a default network,
         # then create a subnet whose address space does not overlap with any
         # other existing subnets. If there are existing subnets, this process
         # largely assumes the subnet address spaces are contiguous when it
         # does the calculations (e.g., 10.0.0.0/24, 10.0.1.0/24).
         cidr_block = GCPSubnet.CB_DEFAULT_SUBNET_IPV4RANGE
-        net = self.provider.networking.networks.get_or_create_default()
+        # get_or_create_default lives on the GCP/base service, not the public
+        # NetworkService/RouterService interface.
+        nets = cast(GCPNetworkService, self.provider.networking.networks)
+        net = nets.get_or_create_default()
         subnet_list = list(net.subnets)
         if subnet_list:
             max_sn = subnet_list[0]
             # Find the maximum address subnet address space within the network
             for esn in net.subnets:
-                if (ipaddress.ip_network(esn.cidr_block) >
+                if (cast(Any, ipaddress.ip_network(esn.cidr_block)) >
                         ipaddress.ip_network(max_sn.cidr_block)):
                     max_sn = esn
             max_sn_ipa = ipaddress.ip_network(max_sn.cidr_block)
@@ -1079,18 +1228,19 @@ class GCPSubnetService(BaseSubnetService):
                 next(max_sn_ipa.hosts()) + max_sn_ipa.num_addresses - 1)
             cidr_block = "{}/{}".format(next_sn_address, max_sn_ipa.prefixlen)
         sn = self.provider.networking.subnets.create(
-                label=GCPSubnet.CB_DEFAULT_SUBNET_LABEL,
-                cidr_block=cidr_block, network=net)
-        router = self.provider.networking.routers.get_or_create_default(net)
+            label=GCPSubnet.CB_DEFAULT_SUBNET_LABEL,
+            cidr_block=cidr_block, network=net)
+        routers = cast(GCPRouterService, self.provider.networking.routers)
+        router = routers.get_or_create_default(net)
         router.attach_subnet(sn)
         gateway = net.gateways.get_or_create()
         router.attach_gateway(gateway)
-        return sn
+        return cast(GCPSubnet, sn)
 
 
 class GCPStorageService(BaseStorageService):
 
-    def __init__(self, provider):
+    def __init__(self, provider: CloudProvider) -> None:
         super(GCPStorageService, self).__init__(provider)
 
         # Initialize provider services
@@ -1100,36 +1250,39 @@ class GCPStorageService(BaseStorageService):
         self._bucket_obj_svc = GCPBucketObjectService(self.provider)
 
     @property
-    def volumes(self):
+    def volumes(self) -> GCPVolumeService:
         return self._volume_svc
 
     @property
-    def snapshots(self):
+    def snapshots(self) -> GCPSnapshotService:
         return self._snapshot_svc
 
     @property
-    def buckets(self):
+    def buckets(self) -> GCPBucketService:
         return self._bucket_svc
 
     @property
-    def _bucket_objects(self):
+    def _bucket_objects(self) -> GCPBucketObjectService:
         return self._bucket_obj_svc
 
 
 class GCPVolumeService(BaseVolumeService):
 
-    def __init__(self, provider):
+    def __init__(self, provider: CloudProvider) -> None:
         super(GCPVolumeService, self).__init__(provider)
 
     @dispatch(event="provider.storage.volumes.get",
               priority=BaseVolumeService.STANDARD_EVENT_PRIORITY)
-    def get(self, volume_id):
-        vol = self.provider.get_resource('disks', volume_id)
-        return GCPVolume(self.provider, vol) if vol else None
+    def get(self, volume_id: str) -> GCPVolume | None:
+        provider = cast("GCPCloudProvider", self.provider)
+        vol = provider.get_resource(
+            'disks', volume_id)
+        return GCPVolume(provider, vol) if vol else None
 
     @dispatch(event="provider.storage.volumes.find",
               priority=BaseVolumeService.STANDARD_EVENT_PRIORITY)
-    def find(self, limit=None, marker=None, **kwargs):
+    def find(self, limit: int | None = None, marker: str | None = None,
+             **kwargs: Any) -> ResultList[GCPVolume]:
         """
         Searches for a volume by a given list of attributes.
         """
@@ -1142,17 +1295,19 @@ class GCPVolumeService(BaseVolumeService):
                 "attributes: %s" % (kwargs, 'label'))
 
         filtr = 'labels.cblabel eq ' + label
+        provider = cast("GCPCloudProvider", self.provider)
         max_result = limit if limit is not None and limit < 500 else 500
-        response = (self.provider
-                        .gcp_compute
-                        .disks()
-                        .list(project=self.provider.project_name,
-                              zone=self.provider.zone_name,
-                              filter=filtr,
-                              maxResults=max_result,
-                              pageToken=marker)
-                        .execute())
-        gcp_vols = [GCPVolume(self.provider, vol)
+        response = (
+            provider
+            .gcp_compute
+            .disks()
+            .list(project=provider.project_name,
+                  zone=provider.zone_name,
+                  filter=filtr,
+                  maxResults=max_result,
+                  pageToken=marker)
+            .execute())
+        gcp_vols = [GCPVolume(provider, vol)
                     for vol in response.get('items', [])]
         if len(gcp_vols) > max_result:
             log.warning('Expected at most %d results; got %d',
@@ -1163,7 +1318,8 @@ class GCPVolumeService(BaseVolumeService):
 
     @dispatch(event="provider.storage.volumes.list",
               priority=BaseVolumeService.STANDARD_EVENT_PRIORITY)
-    def list(self, limit=None, marker=None):
+    def list(self, limit: int | None = None,
+             marker: str | None = None) -> ResultList[GCPVolume]:
         """
         List all volumes.
 
@@ -1171,18 +1327,20 @@ class GCPVolumeService(BaseVolumeService):
                ResultList's is_truncated property can be used to determine
                whether more records are available.
         """
+        provider = cast("GCPCloudProvider", self.provider)
         # For GCP API, Acceptable values are 0 to 500, inclusive.
         # (Default: 500).
         max_result = limit if limit is not None and limit < 500 else 500
-        response = (self.provider
-                        .gcp_compute
-                        .disks()
-                        .list(project=self.provider.project_name,
-                              zone=self.provider.zone_name,
-                              maxResults=max_result,
-                              pageToken=marker)
-                        .execute())
-        gcp_vols = [GCPVolume(self.provider, vol)
+        response = (
+            provider
+            .gcp_compute
+            .disks()
+            .list(project=provider.project_name,
+                  zone=provider.zone_name,
+                  maxResults=max_result,
+                  pageToken=marker)
+            .execute())
+        gcp_vols = [GCPVolume(provider, vol)
                     for vol in response.get('items', [])]
         if len(gcp_vols) > max_result:
             log.warning('Expected at most %d results; got %d',
@@ -1193,7 +1351,9 @@ class GCPVolumeService(BaseVolumeService):
 
     @dispatch(event="provider.storage.volumes.create",
               priority=BaseVolumeService.STANDARD_EVENT_PRIORITY)
-    def create(self, label, size, snapshot=None, description=None):
+    def create(self, label: str, size: int,
+               snapshot: Snapshot | str | None = None,
+               description: str | None = None) -> GCPVolume:
         GCPVolume.assert_valid_resource_label(label)
         name = GCPVolume._generate_name_from_label(label, 'cb-vol')
         zone_name = self.provider.zone_name
@@ -1209,44 +1369,50 @@ class GCPVolumeService(BaseVolumeService):
             'sourceSnapshot': snapshot_id,
             'labels': labels
         }
-        operation = (self.provider
-                         .gcp_compute
-                         .disks()
-                         .insert(
-                             project=self._provider.project_name,
-                             zone=zone_name,
-                             body=disk_body)
-                         .execute())
+        provider = cast("GCPCloudProvider", self.provider)
+        operation = (
+            provider
+            .gcp_compute
+            .disks()
+            .insert(
+                project=provider.project_name,
+                zone=zone_name,
+                body=disk_body)
+            .execute())
         cb_vol = self.get(operation.get('targetLink'))
         return cb_vol
 
     @dispatch(event="provider.storage.volumes.delete",
               priority=BaseVolumeService.STANDARD_EVENT_PRIORITY)
-    def delete(self, volume):
+    def delete(self, volume: Volume | str) -> None:
         volume = volume if isinstance(volume, GCPVolume) else self.get(volume)
         if volume:
-            (self._provider.gcp_compute
-                           .disks()
-                           .delete(project=self.provider.project_name,
-                                   zone=volume.zone_name,
-                                   disk=volume.name)
-                           .execute())
+            provider = cast("GCPCloudProvider", self.provider)
+            (provider.gcp_compute
+                     .disks()
+                     .delete(project=provider.project_name,
+                             zone=volume.zone_name,
+                             disk=volume.name)
+                     .execute())
 
 
 class GCPSnapshotService(BaseSnapshotService):
 
-    def __init__(self, provider):
+    def __init__(self, provider: CloudProvider) -> None:
         super(GCPSnapshotService, self).__init__(provider)
 
     @dispatch(event="provider.storage.snapshots.get",
               priority=BaseSnapshotService.STANDARD_EVENT_PRIORITY)
-    def get(self, snapshot_id):
-        snapshot = self.provider.get_resource('snapshots', snapshot_id)
-        return GCPSnapshot(self.provider, snapshot) if snapshot else None
+    def get(self, snapshot_id: str) -> GCPSnapshot | None:
+        provider = cast("GCPCloudProvider", self.provider)
+        snapshot = provider.get_resource(
+            'snapshots', snapshot_id)
+        return GCPSnapshot(provider, snapshot) if snapshot else None
 
     @dispatch(event="provider.storage.snapshots.find",
               priority=BaseSnapshotService.STANDARD_EVENT_PRIORITY)
-    def find(self, limit=None, marker=None, **kwargs):
+    def find(self, limit: int | None = None, marker: str | None = None,
+             **kwargs: Any) -> ResultList[GCPSnapshot]:
         label = kwargs.pop('label', None)
 
         # All kwargs should have been popped at this time.
@@ -1256,16 +1422,18 @@ class GCPSnapshotService(BaseSnapshotService):
                 "attributes: %s" % (kwargs, 'label'))
 
         filtr = 'labels.cblabel eq ' + label
+        provider = cast("GCPCloudProvider", self.provider)
         max_result = limit if limit is not None and limit < 500 else 500
-        response = (self.provider
-                        .gcp_compute
-                        .snapshots()
-                        .list(project=self.provider.project_name,
-                              filter=filtr,
-                              maxResults=max_result,
-                              pageToken=marker)
-                        .execute())
-        snapshots = [GCPSnapshot(self.provider, snapshot)
+        response = (
+            provider
+            .gcp_compute
+            .snapshots()
+            .list(project=provider.project_name,
+                  filter=filtr,
+                  maxResults=max_result,
+                  pageToken=marker)
+            .execute())
+        snapshots = [GCPSnapshot(provider, snapshot)
                      for snapshot in response.get('items', [])]
         if len(snapshots) > max_result:
             log.warning('Expected at most %d results; got %d',
@@ -1276,16 +1444,19 @@ class GCPSnapshotService(BaseSnapshotService):
 
     @dispatch(event="provider.storage.snapshots.list",
               priority=BaseSnapshotService.STANDARD_EVENT_PRIORITY)
-    def list(self, limit=None, marker=None):
+    def list(self, limit: int | None = None,
+             marker: str | None = None) -> ResultList[GCPSnapshot]:
+        provider = cast("GCPCloudProvider", self.provider)
         max_result = limit if limit is not None and limit < 500 else 500
-        response = (self.provider
-                        .gcp_compute
-                        .snapshots()
-                        .list(project=self.provider.project_name,
-                              maxResults=max_result,
-                              pageToken=marker)
-                        .execute())
-        snapshots = [GCPSnapshot(self.provider, snapshot)
+        response = (
+            provider
+            .gcp_compute
+            .snapshots()
+            .list(project=provider.project_name,
+                  maxResults=max_result,
+                  pageToken=marker)
+            .execute())
+        snapshots = [GCPSnapshot(provider, snapshot)
                      for snapshot in response.get('items', [])]
         if len(snapshots) > max_result:
             log.warning('Expected at most %d results; got %d',
@@ -1296,7 +1467,8 @@ class GCPSnapshotService(BaseSnapshotService):
 
     @dispatch(event="provider.storage.snapshots.create",
               priority=BaseSnapshotService.STANDARD_EVENT_PRIORITY)
-    def create(self, label, volume, description=None):
+    def create(self, label: str, volume: Volume | str,
+               description: str | None = None) -> GCPSnapshot:
         GCPSnapshot.assert_valid_resource_label(label)
         name = GCPSnapshot._generate_name_from_label(label, 'cbsnap')
         volume_name = volume.name if isinstance(volume, GCPVolume) else volume
@@ -1307,54 +1479,59 @@ class GCPSnapshotService(BaseSnapshotService):
             "name": name,
             "labels": labels
         }
-        operation = (self.provider
-                         .gcp_compute
-                         .disks()
-                         .createSnapshot(
-                             project=self.provider.project_name,
-                             zone=self.provider.zone_name,
-                             disk=volume_name, body=snapshot_body)
-                         .execute())
+        provider = cast("GCPCloudProvider", self.provider)
+        operation = (
+            provider
+            .gcp_compute
+            .disks()
+            .createSnapshot(
+                project=provider.project_name,
+                zone=provider.zone_name,
+                disk=volume_name, body=snapshot_body)
+            .execute())
         if 'zone' not in operation:
-            return None
-        self.provider.wait_for_operation(operation,
-                                         zone=self.provider.zone_name)
+            raise ProviderInternalException(
+                "Snapshot creation did not return a zoned operation")
+        provider.wait_for_operation(operation, zone=provider.zone_name)
         cb_snap = self.get(name)
         return cb_snap
 
     @dispatch(event="provider.storage.snapshots.delete",
               priority=BaseSnapshotService.STANDARD_EVENT_PRIORITY)
-    def delete(self, snapshot):
+    def delete(self, snapshot: Snapshot | str) -> None:
         snapshot = (snapshot if isinstance(snapshot, GCPSnapshot)
                     else self.get(snapshot))
         if snapshot:
-            (self.provider
-                 .gcp_compute
-                 .snapshots()
-                 .delete(project=self.provider.project_name,
-                         snapshot=snapshot.name)
-                 .execute())
+            provider = cast("GCPCloudProvider", self.provider)
+            (provider
+             .gcp_compute
+             .snapshots()
+             .delete(project=provider.project_name,
+                     snapshot=snapshot.name)
+             .execute())
 
 
 class GCPBucketService(BaseBucketService):
 
-    def __init__(self, provider):
+    def __init__(self, provider: CloudProvider) -> None:
         super(GCPBucketService, self).__init__(provider)
 
     @dispatch(event="provider.storage.buckets.get",
               priority=BaseBucketService.STANDARD_EVENT_PRIORITY)
-    def get(self, bucket_id):
+    def get(self, bucket_id: str) -> GCPBucket | None:
         """
         Returns a bucket given its ID. Returns ``None`` if the bucket
         does not exist or if the user does not have permission to access the
         bucket.
         """
-        bucket = self.provider.get_resource('buckets', bucket_id)
-        return GCPBucket(self.provider, bucket) if bucket else None
+        provider = cast("GCPCloudProvider", self.provider)
+        bucket = provider.get_resource(
+            'buckets', bucket_id)
+        return GCPBucket(provider, bucket) if bucket else None
 
     @dispatch(event="provider.storage.buckets.find",
               priority=BaseBucketService.STANDARD_EVENT_PRIORITY)
-    def find(self, limit=None, marker=None, **kwargs):
+    def find(self, **kwargs: Any) -> ResultList[GCPBucket]:
         name = kwargs.pop('name', None)
 
         # All kwargs should have been popped at this time.
@@ -1364,26 +1541,29 @@ class GCPBucketService(BaseBucketService):
                 "attributes: %s" % (kwargs, 'name'))
 
         buckets = [bucket for bucket in self if name in bucket.name]
-        return ClientPagedResultList(self.provider, buckets, limit=limit,
-                                     marker=marker)
+        return ClientPagedResultList(
+            self.provider, cast("builtins.list[GCPBucket]", buckets))
 
     @dispatch(event="provider.storage.buckets.list",
               priority=BaseBucketService.STANDARD_EVENT_PRIORITY)
-    def list(self, limit=None, marker=None):
+    def list(self, limit: int | None = None,
+             marker: str | None = None) -> ResultList[GCPBucket]:
         """
         List all containers.
         """
+        provider = cast("GCPCloudProvider", self.provider)
         max_result = limit if limit is not None and limit < 500 else 500
-        response = (self.provider
-                        .gcp_storage
-                        .buckets()
-                        .list(project=self.provider.project_name,
-                              maxResults=max_result,
-                              pageToken=marker)
-                        .execute())
+        response = (
+            provider
+            .gcp_storage
+            .buckets()
+            .list(project=provider.project_name,
+                  maxResults=max_result,
+                  pageToken=marker)
+            .execute())
         buckets = []
         for bucket in response.get('items', []):
-            buckets.append(GCPBucket(self.provider, bucket))
+            buckets.append(GCPBucket(provider, bucket))
         if len(buckets) > max_result:
             log.warning('Expected at most %d results; got %d',
                         max_result, len(buckets))
@@ -1393,23 +1573,26 @@ class GCPBucketService(BaseBucketService):
 
     @dispatch(event="provider.storage.buckets.create",
               priority=BaseBucketService.STANDARD_EVENT_PRIORITY)
-    def create(self, name, location=None):
+    def create(self, name: str,
+               location: Region | str | None = None) -> GCPBucket:
         GCPBucket.assert_valid_resource_name(name)
-        body = {'name': name}
+        body: dict[str, Any] = {'name': name}
         if location:
             body['location'] = location
         try:
-            response = (self.provider
-                            .gcp_storage
-                            .buckets()
-                            .insert(project=self.provider.project_name,
-                                    body=body)
-                            .execute())
+            provider = cast("GCPCloudProvider", self.provider)
+            response = (
+                provider
+                .gcp_storage
+                .buckets()
+                .insert(project=provider.project_name,
+                        body=body)
+                .execute())
             # GCP has a rate limit of 1 operation per 2 seconds for bucket
             # creation/deletion: https://cloud.google.com/storage/quotas.
             # Throttle here to avoid future failures.
             time.sleep(2)
-            return GCPBucket(self.provider, response)
+            return GCPBucket(provider, response)
         except googleapiclient.errors.HttpError as http_error:
             # 409 = conflict
             if http_error.resp.status in [409]:
@@ -1420,17 +1603,18 @@ class GCPBucketService(BaseBucketService):
 
     @dispatch(event="provider.storage.buckets.delete",
               priority=BaseBucketService.STANDARD_EVENT_PRIORITY)
-    def delete(self, bucket):
+    def delete(self, bucket: Bucket | str) -> None:
         """
         Delete this bucket.
         """
+        provider = cast("GCPCloudProvider", self.provider)
         b = bucket if isinstance(bucket, GCPBucket) else self.get(bucket)
         if b:
-            (self.provider
-                 .gcp_storage
-                 .buckets()
-                 .delete(bucket=b.name)
-                 .execute())
+            (provider
+             .gcp_storage
+             .buckets()
+             .delete(bucket=b.name)
+             .execute())
             # GCP has a rate limit of 1 operation per 2 seconds for bucket
             # creation/deletion: https://cloud.google.com/storage/quotas.
             # Throttle here to avoid future failures.
@@ -1439,33 +1623,41 @@ class GCPBucketService(BaseBucketService):
 
 class GCPBucketObjectService(BaseBucketObjectService):
 
-    def __init__(self, provider):
+    def __init__(self, provider: CloudProvider) -> None:
         super(GCPBucketObjectService, self).__init__(provider)
 
-    def get(self, bucket, name):
+    def get(self, bucket: Bucket | str,
+            name: str) -> GCPBucketObject | None:
         """
         Retrieve a given object from this bucket.
         """
-        obj = self.provider.get_resource('objects', name,
-                                         bucket=bucket.name)
-        return GCPBucketObject(self.provider, bucket, obj) if obj else None
+        provider = cast("GCPCloudProvider", self.provider)
+        obj = provider.get_resource(
+            'objects', name, bucket=cast(GCPBucket, bucket).name)
+        return GCPBucketObject(provider, cast(Bucket, bucket), obj) if obj else None
 
-    def list(self, bucket, limit=None, marker=None, prefix=None):
+    # The interface declares list(bucket, prefix, limit, marker); this impl
+    # orders the optional parameters as (limit, marker, prefix).
+    def list(self, bucket: Bucket | str,  # type: ignore[override]
+             limit: int | None = None, marker: str | None = None,
+             prefix: str | None = None) -> ResultList[GCPBucketObject]:
         """
         List all objects within this bucket.
         """
+        provider = cast("GCPCloudProvider", self.provider)
         max_result = limit if limit is not None and limit < 500 else 500
-        response = (self.provider
-                        .gcp_storage
-                        .objects()
-                        .list(bucket=bucket.name,
-                              prefix=prefix if prefix else '',
-                              maxResults=max_result,
-                              pageToken=marker)
-                        .execute())
+        response = (
+            provider
+            .gcp_storage
+            .objects()
+            .list(bucket=cast(GCPBucket, bucket).name,
+                  prefix=prefix if prefix else '',
+                  maxResults=max_result,
+                  pageToken=marker)
+            .execute())
         objects = []
         for obj in response.get('items', []):
-            objects.append(GCPBucketObject(self.provider, bucket, obj))
+            objects.append(GCPBucketObject(provider, cast(Bucket, bucket), obj))
         if len(objects) > max_result:
             log.warning('Expected at most %d results; got %d',
                         max_result, len(objects))
@@ -1473,31 +1665,41 @@ class GCPBucketObjectService(BaseBucketObjectService):
                                      response.get('nextPageToken'),
                                      False, data=objects)
 
-    def find(self, bucket, limit=None, marker=None, **kwargs):
+    # ResultList is invariant, so the return is typed with the interface
+    # element type (BucketObject) rather than GCPBucketObject.
+    def find(self, bucket: Bucket | str,
+             **kwargs: Any) -> ResultList[BucketObject]:
         filters = ['name']
-        matches = cb_helpers.generic_find(filters, kwargs, bucket.objects)
-        return ClientPagedResultList(self._provider, list(matches),
-                                     limit=limit, marker=marker)
+        matches = cb_helpers.generic_find(
+            filters, kwargs, list(cast(GCPBucket, bucket).objects))
+        return ClientPagedResultList(
+            self._provider, list(matches), limit=None, marker=None)
 
-    def _create_object_with_media_body(self, bucket, name, media_body):
-        response = (self.provider
-                    .gcp_storage
-                    .objects()
-                    .insert(bucket=bucket.name,
-                            body={'name': name},
-                            media_body=media_body)
-                    .execute())
+    def _create_object_with_media_body(self, bucket: Bucket | str,
+                                       name: str, media_body: Any) -> Any:
+        provider = cast("GCPCloudProvider", self.provider)
+        response = (
+            provider
+            .gcp_storage
+            .objects()
+            .insert(bucket=cast(GCPBucket, bucket).name,
+                    body={'name': name},
+                    media_body=media_body)
+            .execute())
         return response
 
-    def create(self, bucket, name):
+    def create(self, bucket: Bucket | str,
+               name: str) -> GCPBucketObject:
+        provider = cast("GCPCloudProvider", self.provider)
         response = self._create_object_with_media_body(
-                            bucket,
-                            name,
-                            googleapiclient.http.MediaIoBaseUpload(
-                                io.BytesIO(b''), mimetype='plain/text'))
-        return GCPBucketObject(self._provider,
-                               bucket,
-                               response) if response else None
+            bucket,
+            name,
+            googleapiclient.http.MediaIoBaseUpload(
+                io.BytesIO(b''), mimetype='plain/text'))
+        if not response:
+            raise ProviderInternalException(
+                "Failed to create bucket object {0}".format(name))
+        return GCPBucketObject(provider, cast(Bucket, bucket), response)
 
     # GCS has no independent "upload part" API, so multipart is emulated by
     # uploading each part as a temporary object and assembling them with the
@@ -1506,24 +1708,27 @@ class GCPBucketObjectService(BaseBucketObjectService):
     _MAX_COMPOSE_SOURCES = 32
 
     @staticmethod
-    def _temp_prefix(upload):
+    def _temp_prefix(upload: MultipartUpload) -> str:
         return ".cb-mpu/{0}/{1}/".format(upload.object_name, upload.id)
 
     @classmethod
-    def _temp_part_name(cls, upload, part_number):
+    def _temp_part_name(cls, upload: MultipartUpload,
+                        part_number: int) -> str:
         return "{0}part-{1:05d}".format(cls._temp_prefix(upload), part_number)
 
     @dispatch(event="provider.storage._bucket_objects.create_multipart_upload",
               priority=BaseBucketObjectService.STANDARD_EVENT_PRIORITY)
-    def create_multipart_upload(self, bucket, object_name):
+    def create_multipart_upload(self, bucket: Bucket | str,
+                                object_name: str) -> MultipartUpload:
         # No server-side initiation; the upload id namespaces this upload's
         # temporary part objects.
-        return BaseMultipartUpload(self.provider, bucket, object_name,
-                                   uuid.uuid4().hex)
+        return BaseMultipartUpload(self.provider, cast(Bucket, bucket),
+                                   object_name, uuid.uuid4().hex)
 
     @dispatch(event="provider.storage._bucket_objects.upload_part",
               priority=BaseBucketObjectService.STANDARD_EVENT_PRIORITY)
-    def upload_part(self, bucket, upload, part_number, data):
+    def upload_part(self, bucket: Bucket | str, upload: MultipartUpload,
+                    part_number: int, data: Any) -> UploadPart:
         if isinstance(data, str):
             data = data.encode()
         if isinstance(data, (bytes, bytearray)):
@@ -1537,9 +1742,12 @@ class GCPBucketObjectService(BaseBucketObjectService):
     @dispatch(event="provider.storage._bucket_objects."
                     "complete_multipart_upload",
               priority=BaseBucketObjectService.STANDARD_EVENT_PRIORITY)
-    def complete_multipart_upload(self, bucket, upload, parts):
+    def complete_multipart_upload(self, bucket: Bucket | str,
+                                  upload: MultipartUpload,
+                                  parts: builtins.list[UploadPart]
+                                  ) -> GCPBucketObject | None:
         ordered = sorted(parts, key=lambda p: p.part_number)
-        sources = [p.etag for p in ordered]
+        sources = cast("builtins.list[str]", [p.etag for p in ordered])
         intermediates = self._compose(bucket, upload, upload.object_name,
                                       sources)
         # The temporary part objects and any compose intermediates are real,
@@ -1550,11 +1758,13 @@ class GCPBucketObjectService(BaseBucketObjectService):
 
     @dispatch(event="provider.storage._bucket_objects.abort_multipart_upload",
               priority=BaseBucketObjectService.STANDARD_EVENT_PRIORITY)
-    def abort_multipart_upload(self, bucket, upload):
+    def abort_multipart_upload(self, bucket: Bucket | str,
+                               upload: MultipartUpload) -> None:
         self._delete_objects(bucket, self._list_temp_objects(bucket, upload),
                              ignore_missing=True)
 
-    def _compose(self, bucket, upload, destination, sources):
+    def _compose(self, bucket: Bucket | str, upload: MultipartUpload,
+                 destination: str, sources: builtins.list[str]) -> builtins.list[str]:
         """
         Compose ``sources`` into ``destination``, chaining through
         intermediate objects when there are more than ``_MAX_COMPOSE_SOURCES``.
@@ -1578,39 +1788,46 @@ class GCPBucketObjectService(BaseBucketObjectService):
         self._compose_once(bucket, destination, level)
         return intermediates
 
-    def _compose_once(self, bucket, destination, sources):
-        (self.provider
-             .gcp_storage
-             .objects()
-             .compose(destinationBucket=bucket.name,
-                      destinationObject=destination,
-                      body={'sourceObjects': [{'name': s} for s in sources]})
-             .execute())
+    def _compose_once(self, bucket: Bucket | str, destination: str,
+                      sources: builtins.list[str]) -> None:
+        provider = cast("GCPCloudProvider", self.provider)
+        (provider
+         .gcp_storage
+         .objects()
+         .compose(destinationBucket=cast(GCPBucket, bucket).name,
+                  destinationObject=destination,
+                  body={'sourceObjects': [{'name': s} for s in sources]})
+         .execute())
 
-    def _list_temp_objects(self, bucket, upload):
+    def _list_temp_objects(self, bucket: Bucket | str,
+                           upload: MultipartUpload) -> builtins.list[str]:
         prefix = self._temp_prefix(upload)
-        names = []
+        names: builtins.list[str] = []
         page_token = None
+        provider = cast("GCPCloudProvider", self.provider)
         while True:
-            response = (self.provider
-                            .gcp_storage
-                            .objects()
-                            .list(bucket=bucket.name, prefix=prefix,
-                                  pageToken=page_token)
-                            .execute())
+            response = (
+                provider
+                .gcp_storage
+                .objects()
+                .list(bucket=cast(GCPBucket, bucket).name,
+                      prefix=prefix, pageToken=page_token)
+                .execute())
             names.extend(o['name'] for o in response.get('items', []))
             page_token = response.get('nextPageToken')
             if not page_token:
                 return names
 
-    def _delete_objects(self, bucket, names, ignore_missing=False):
+    def _delete_objects(self, bucket: Bucket | str, names: builtins.list[str],
+                        ignore_missing: bool = False) -> None:
+        provider = cast("GCPCloudProvider", self.provider)
         for name in names:
             try:
-                (self.provider
-                     .gcp_storage
-                     .objects()
-                     .delete(bucket=bucket.name, object=name)
-                     .execute())
+                (provider
+                 .gcp_storage
+                 .objects()
+                 .delete(bucket=cast(GCPBucket, bucket).name, object=name)
+                 .execute())
             except googleapiclient.errors.HttpError:
                 if not ignore_missing:
                     raise
@@ -1620,27 +1837,28 @@ class GCPGatewayService(BaseGatewayService):
     _DEFAULT_GATEWAY_NAME = 'default-internet-gateway'
     _GATEWAY_URL_PREFIX = 'global/gateways/'
 
-    def __init__(self, provider):
+    def __init__(self, provider: CloudProvider) -> None:
         super(GCPGatewayService, self).__init__(provider)
         self._default_internet_gateway = GCPInternetGateway(
-            provider,
+            cast("GCPCloudProvider", provider),
             {'id': (GCPGatewayService._GATEWAY_URL_PREFIX +
                     GCPGatewayService._DEFAULT_GATEWAY_NAME),
              'name': GCPGatewayService._DEFAULT_GATEWAY_NAME})
 
     @dispatch(event="provider.networking.gateways.get_or_create",
               priority=BaseGatewayService.STANDARD_EVENT_PRIORITY)
-    def get_or_create(self, network):
+    def get_or_create(self, network: Network | str) -> GCPInternetGateway:
         return self._default_internet_gateway
 
     @dispatch(event="provider.networking.gateways.delete",
               priority=BaseGatewayService.STANDARD_EVENT_PRIORITY)
-    def delete(self, network, gateway):
+    def delete(self, network: Network | str, gateway: Gateway) -> None:
         pass
 
     @dispatch(event="provider.networking.gateways.list",
               priority=BaseGatewayService.STANDARD_EVENT_PRIORITY)
-    def list(self, network, limit=None, marker=None):
+    def list(self, network: Network | str, limit: int | None = None,
+             marker: str | None = None) -> ResultList[GCPInternetGateway]:
         gws = [self._default_internet_gateway]
         return ClientPagedResultList(self._provider,
                                      gws,
@@ -1649,29 +1867,35 @@ class GCPGatewayService(BaseGatewayService):
 
 class GCPFloatingIPService(BaseFloatingIPService):
 
-    def __init__(self, provider):
+    def __init__(self, provider: CloudProvider) -> None:
         super(GCPFloatingIPService, self).__init__(provider)
 
     @dispatch(event="provider.networking.floating_ips.get",
               priority=BaseFloatingIPService.STANDARD_EVENT_PRIORITY)
-    def get(self, gateway, floating_ip_id):
-        fip = self.provider.get_resource('addresses', floating_ip_id)
-        return (GCPFloatingIP(self.provider, fip)
+    def get(self, gateway: Gateway,
+            floating_ip_id: str) -> GCPFloatingIP | None:
+        provider = cast("GCPCloudProvider", self.provider)
+        fip = provider.get_resource(
+            'addresses', floating_ip_id)
+        return (GCPFloatingIP(provider, fip)
                 if fip else None)
 
     @dispatch(event="provider.networking.floating_ips.list",
               priority=BaseFloatingIPService.STANDARD_EVENT_PRIORITY)
-    def list(self, gateway, limit=None, marker=None):
+    def list(self, gateway: Gateway, limit: int | None = None,
+             marker: str | None = None) -> ResultList[GCPFloatingIP]:
+        provider = cast("GCPCloudProvider", self.provider)
         max_result = limit if limit is not None and limit < 500 else 500
-        response = (self.provider
-                        .gcp_compute
-                        .addresses()
-                        .list(project=self.provider.project_name,
-                              region=self.provider.region_name,
-                              maxResults=max_result,
-                              pageToken=marker)
-                        .execute())
-        ips = [GCPFloatingIP(self.provider, ip)
+        response = (
+            provider
+            .gcp_compute
+            .addresses()
+            .list(project=provider.project_name,
+                  region=self.provider.region_name,
+                  maxResults=max_result,
+                  pageToken=marker)
+            .execute())
+        ips = [GCPFloatingIP(provider, ip)
                for ip in response.get('items', [])]
         if len(ips) > max_result:
             log.warning('Expected at most %d results; got %d',
@@ -1682,53 +1906,57 @@ class GCPFloatingIPService(BaseFloatingIPService):
 
     @dispatch(event="provider.networking.floating_ips.create",
               priority=BaseFloatingIPService.STANDARD_EVENT_PRIORITY)
-    def create(self, gateway):
+    def create(self, gateway: Gateway) -> GCPFloatingIP:
+        provider = cast("GCPCloudProvider", self.provider)
         region_name = self.provider.region_name
         ip_name = 'ip-{0}'.format(uuid.uuid4())
-        response = (self.provider
-                    .gcp_compute
-                    .addresses()
-                    .insert(project=self.provider.project_name,
-                            region=region_name,
-                            body={'name': ip_name})
-                    .execute())
-        self.provider.wait_for_operation(response, region=region_name)
+        response = (
+            provider
+            .gcp_compute
+            .addresses()
+            .insert(project=provider.project_name,
+                    region=region_name,
+                    body={'name': ip_name})
+            .execute())
+        provider.wait_for_operation(response, region=region_name)
         return self.get(gateway, ip_name)
 
     @dispatch(event="provider.networking.floating_ips.delete",
               priority=BaseFloatingIPService.STANDARD_EVENT_PRIORITY)
-    def delete(self, gateway, fip):
-        fip = (fip if isinstance(fip, GCPFloatingIP)
-               else self.get(gateway, fip))
-        project_name = self.provider.project_name
+    def delete(self, gateway: Gateway, fip: FloatingIP | str) -> None:
+        fip = cast(GCPFloatingIP,
+                   fip if isinstance(fip, GCPFloatingIP)
+                   else self.get(gateway, fip))
+        provider = cast("GCPCloudProvider", self.provider)
+        project_name = provider.project_name
         # First, delete the forwarding rule, if there is any.
         # pylint:disable=protected-access
         if fip._rule:
-            response = (self.provider
-                        .gcp_compute
-                        .forwardingRules()
-                        .delete(project=project_name,
-                                region=fip.region_name,
-                                forwardingRule=fip._rule['name'])
-                        .execute())
-            self.provider.wait_for_operation(response,
-                                             region=fip.region_name)
+            response = (
+                provider
+                .gcp_compute
+                .forwardingRules()
+                .delete(project=project_name,
+                        region=fip.region_name,
+                        forwardingRule=fip._rule['name'])
+                .execute())
+            provider.wait_for_operation(response, region=fip.region_name)
 
         # Release the address.
-        response = (self.provider
-                    .gcp_compute
-                    .addresses()
-                    .delete(project=project_name,
-                            region=fip.region_name,
-                            address=fip._ip['name'])
-                    .execute())
-        self.provider.wait_for_operation(response,
-                                         region=fip.region_name)
+        response = (
+            provider
+            .gcp_compute
+            .addresses()
+            .delete(project=project_name,
+                    region=fip.region_name,
+                    address=fip._ip['name'])
+            .execute())
+        provider.wait_for_operation(response, region=fip.region_name)
 
 
 class GCPDnsService(BaseDnsService):
 
-    def __init__(self, provider):
+    def __init__(self, provider: CloudProvider) -> None:
         super(GCPDnsService, self).__init__(provider)
 
         # Initialize provider services
@@ -1736,40 +1964,44 @@ class GCPDnsService(BaseDnsService):
         self._record_svc = GCPDnsRecordService(self.provider)
 
     @property
-    def host_zones(self):
+    def host_zones(self) -> GCPDnsZoneService:
         return self._zone_svc
 
     @property
-    def _records(self):
+    def _records(self) -> GCPDnsRecordService:
         return self._record_svc
 
 
 class GCPDnsZoneService(BaseDnsZoneService):
 
-    def __init__(self, provider):
+    def __init__(self, provider: CloudProvider) -> None:
         super(GCPDnsZoneService, self).__init__(provider)
 
     @dispatch(event="provider.dns.host_zones.get",
               priority=BaseDnsZoneService.STANDARD_EVENT_PRIORITY)
-    def get(self, dns_zone_id):
-        dns_zone = self.provider.get_resource(
-            'managedZones', dns_zone_id, project=self._provider.project_name)
-        return GCPDnsZone(self.provider, dns_zone) if dns_zone else None
+    def get(self, dns_zone_id: str) -> GCPDnsZone | None:
+        provider = cast("GCPCloudProvider", self.provider)
+        dns_zone = provider.get_resource(
+            'managedZones', dns_zone_id, project=provider.project_name)
+        return GCPDnsZone(provider, dns_zone) if dns_zone else None
 
     @dispatch(event="provider.dns.host_zones.list",
               priority=BaseDnsZoneService.STANDARD_EVENT_PRIORITY)
-    def list(self, limit=None, marker=None):
+    def list(self, limit: int | None = None,
+             marker: str | None = None) -> ResultList[GCPDnsZone]:
+        provider = cast("GCPCloudProvider", self.provider)
         max_result = limit if limit is not None and limit < 500 else 500
-        response = (self.provider
-                        .gcp_dns
-                        .managedZones()
-                        .list(project=self.provider.project_name,
-                              maxResults=max_result,
-                              pageToken=marker)
-                        .execute())
+        response = (
+            provider
+            .gcp_dns
+            .managedZones()
+            .list(project=provider.project_name,
+                  maxResults=max_result,
+                  pageToken=marker)
+            .execute())
         dns_zones = []
         for dns_zone in response.get('managedZones', []):
-            dns_zones.append(GCPDnsZone(self.provider, dns_zone))
+            dns_zones.append(GCPDnsZone(provider, dns_zone))
         if len(dns_zones) > max_result:
             log.warning('Expected at most %d results; got %d',
                         max_result, len(dns_zones))
@@ -1779,15 +2011,17 @@ class GCPDnsZoneService(BaseDnsZoneService):
 
     @dispatch(event="provider.dns.host_zones.find",
               priority=BaseDnsZoneService.STANDARD_EVENT_PRIORITY)
-    def find(self, **kwargs):
+    def find(self, **kwargs: Any) -> ResultList[GCPDnsZone]:
         filters = ['name']
-        matches = cb_helpers.generic_find(filters, kwargs, self)
-        return ClientPagedResultList(self.provider, list(matches),
-                                     limit=None, marker=None)
+        matches = cb_helpers.generic_find(
+            filters, kwargs, list(self))
+        return ClientPagedResultList(
+            self.provider, cast("builtins.list[GCPDnsZone]", matches),
+            limit=None, marker=None)
 
     @dispatch(event="provider.dns.host_zones.create",
               priority=BaseDnsZoneService.STANDARD_EVENT_PRIORITY)
-    def create(self, name, admin_email):
+    def create(self, name: str, admin_email: str) -> GCPDnsZone:
         GCPDnsZone.assert_valid_resource_name(name)
         body = {
             'kind': 'dns#managedZone',
@@ -1796,14 +2030,16 @@ class GCPDnsZoneService(BaseDnsZoneService):
             'description': 'admin_email=' + admin_email,
             'visibility': 'public'
         }
+        provider = cast("GCPCloudProvider", self.provider)
         try:
-            response = (self.provider
-                            .gcp_dns
-                            .managedZones()
-                            .create(project=self.provider.project_name,
-                                    body=body)
-                            .execute())
-            return GCPDnsZone(self.provider, response)
+            response = (
+                provider
+                .gcp_dns
+                .managedZones()
+                .create(project=provider.project_name,
+                        body=body)
+                .execute())
+            return GCPDnsZone(provider, response)
         except googleapiclient.errors.HttpError as http_error:
             # 409 = conflict
             if http_error.resp.status in [409]:
@@ -1814,24 +2050,26 @@ class GCPDnsZoneService(BaseDnsZoneService):
 
     @dispatch(event="provider.dns.host_zones.delete",
               priority=BaseDnsZoneService.STANDARD_EVENT_PRIORITY)
-    def delete(self, dns_zone):
+    def delete(self, dns_zone: DnsZone | str) -> None:
         zone = (dns_zone if isinstance(dns_zone, GCPDnsZone)
                 else self.get(dns_zone))
         if zone:
-            (self.provider
-                 .gcp_dns
-                 .managedZones()
-                 .delete(project=self.provider.project_name,
-                         managedZone=zone.id)
-                 .execute())
+            provider = cast("GCPCloudProvider", self.provider)
+            (provider
+             .gcp_dns
+             .managedZones()
+             .delete(project=provider.project_name,
+                     managedZone=zone.id)
+             .execute())
 
 
 class GCPDnsRecordService(BaseDnsRecordService):
 
-    def __init__(self, provider):
+    def __init__(self, provider: CloudProvider) -> None:
         super(GCPDnsRecordService, self).__init__(provider)
 
-    def _to_resource_records(self, data, rec_type):
+    def _to_resource_records(self, data: str | builtins.list[str],
+                             rec_type: str) -> builtins.list[str]:
         """
         Converts a record to what GCP expects. For example, GCP
         expects a fully qualified name for all CNAME records.
@@ -1842,39 +2080,50 @@ class GCPDnsRecordService(BaseDnsRecordService):
             records = [data]
         return [self._standardize_record(r, rec_type) for r in records]
 
-    def get(self, dns_zone, rec_id):
+    def get(self, dns_zone: DnsZone | str,
+            rec_id: str) -> GCPDnsRecord | None:
         if rec_id and ":" in rec_id:
             rec_name, rec_type = rec_id.split(":")
-            response = (self.provider
-                        .gcp_dns
-                        .resourceRecordSets()
-                        .list(project=self.provider.project_name,
-                              managedZone=dns_zone.id,
-                              name=self._get_fully_qualified_dns(rec_name),
-                              type=rec_type)
-                        .execute())
+            provider = cast("GCPCloudProvider", self.provider)
+            response = (
+                provider
+                .gcp_dns
+                .resourceRecordSets()
+                .list(project=provider.project_name,
+                      managedZone=cast(GCPDnsZone, dns_zone).id,
+                      name=self._get_fully_qualified_dns(rec_name),
+                      type=rec_type)
+                .execute())
             if len(response.get('rrsets', [])) > 1:
                 log.warning('Expected at most %d results; got %d',
                             1, len(response.get('items', [])))
             for rec in response.get('rrsets', []):
-                return GCPDnsRecord(self.provider, dns_zone, rec)
+                return GCPDnsRecord(provider, cast(GCPDnsZone, dns_zone), rec)
             return None
         else:
             return None
 
-    def list(self, dns_zone, limit=None, marker=None, rec_id=None):
+    # The interface declares list(dns_zone, limit, marker); this impl also
+    # accepts a trailing rec_id filter.
+    def list(self, dns_zone: DnsZone | str,  # type: ignore[override]
+             limit: int | None = None,
+             marker: str | None = None,
+             rec_id: str | None = None) -> ResultList[GCPDnsRecord]:
+        provider = cast("GCPCloudProvider", self.provider)
         max_result = limit if limit is not None and limit < 500 else 500
-        response = (self.provider
-                        .gcp_dns
-                        .resourceRecordSets()
-                        .list(project=self.provider.project_name,
-                              managedZone=dns_zone.id,
-                              maxResults=max_result,
-                              pageToken=marker)
-                        .execute())
+        response = (
+            provider
+            .gcp_dns
+            .resourceRecordSets()
+            .list(project=provider.project_name,
+                  managedZone=cast(GCPDnsZone, dns_zone).id,
+                  maxResults=max_result,
+                  pageToken=marker)
+            .execute())
         records = []
         for rec in response.get('rrsets', []):
-            records.append(GCPDnsRecord(self.provider, dns_zone, rec))
+            records.append(
+                GCPDnsRecord(provider, cast(GCPDnsZone, dns_zone), rec))
         if len(records) > max_result:
             log.warning('Expected at most %d results; got %d',
                         max_result, len(records))
@@ -1882,13 +2131,18 @@ class GCPDnsRecordService(BaseDnsRecordService):
                                      response.get('nextPageToken'),
                                      False, data=records)
 
-    def find(self, dns_zone, **kwargs):
+    def find(self, dns_zone: DnsZone | str,
+             **kwargs: Any) -> ResultList[GCPDnsRecord]:
         filters = ['name']
-        matches = cb_helpers.generic_find(filters, kwargs, dns_zone.records)
-        return ClientPagedResultList(self.provider, list(matches),
-                                     limit=None, marker=None)
+        matches = cb_helpers.generic_find(
+            filters, kwargs, list(cast(GCPDnsZone, dns_zone).records))
+        return ClientPagedResultList(
+            self.provider, cast("builtins.list[GCPDnsRecord]", matches),
+            limit=None, marker=None)
 
-    def create(self, dns_zone, name, type, data, ttl=None):
+    def create(self,
+               dns_zone: DnsZone | str, name: str, type: str,
+               data: str, ttl: int | None = None) -> GCPDnsRecord:
         GCPDnsRecord.assert_valid_resource_name(name)
         body = {
             'kind': 'dns#change',
@@ -1902,18 +2156,28 @@ class GCPDnsRecordService(BaseDnsRecordService):
                 }
             ]
         }
-        (self.provider
-             .gcp_dns
-             .changes()
-             .create(project=self.provider.project_name,
-                     managedZone=dns_zone.id,
-                     body=body)
-             .execute())
+        provider = cast("GCPCloudProvider", self.provider)
+        (provider
+         .gcp_dns
+         .changes()
+         .create(project=provider.project_name,
+                 managedZone=cast(GCPDnsZone, dns_zone).id,
+                 body=body)
+         .execute())
         rec_id = name + ":" + type
-        return self.get(dns_zone, rec_id)
+        record = self.get(dns_zone, rec_id)
+        if record is None:
+            raise ProviderInternalException(
+                "DNS record not found after creation")
+        return record
 
-    def delete(self, dns_zone, record):
-        rec = record if isinstance(record, GCPDnsRecord) else self.get(record)
+    def delete(self, dns_zone: DnsZone | str,
+               record: GCPDnsRecord | str) -> None:
+        # NOTE: previously called self.get(record) with a single argument,
+        # which is invalid (get requires the dns_zone too). Pass dns_zone so
+        # a record id can be resolved.
+        rec = (record if isinstance(record, GCPDnsRecord)
+               else self.get(dns_zone, record))
 
         if rec:
             body = {
@@ -1929,10 +2193,11 @@ class GCPDnsRecordService(BaseDnsRecordService):
                     }
                 ]
             }
-            (self.provider
-                 .gcp_dns
-                 .changes()
-                 .create(project=self.provider.project_name,
-                         managedZone=dns_zone.id,
-                         body=body)
-                 .execute())
+            provider = cast("GCPCloudProvider", self.provider)
+            (provider
+             .gcp_dns
+             .changes()
+             .create(project=provider.project_name,
+                     managedZone=cast(GCPDnsZone, dns_zone).id,
+                     body=body)
+             .execute())

--- a/cloudbridge/providers/gcp/services.py
+++ b/cloudbridge/providers/gcp/services.py
@@ -669,10 +669,9 @@ class GCPInstanceService(BaseInstanceService):
         if vm_firewalls and isinstance(vm_firewalls, list):
             vm_firewall_names: builtins.list[str] = []
             if isinstance(vm_firewalls[0], VMFirewall):
-                vm_firewall_names = [
-                    f.name for f in cast("list[VMFirewall]", vm_firewalls)]
+                vm_firewall_names = [f.name for f in vm_firewalls]
             elif isinstance(vm_firewalls[0], str):
-                vm_firewall_names = cast("list[str]", vm_firewalls)
+                vm_firewall_names = vm_firewalls
             if len(vm_firewall_names) > 0:
                 config['tags'] = {}
                 config['tags']['items'] = vm_firewall_names

--- a/cloudbridge/providers/gcp/services.py
+++ b/cloudbridge/providers/gcp/services.py
@@ -329,7 +329,8 @@ class GCPVMFirewallRuleService(BaseVMFirewallRuleService):
             protocol: str | None, priority: int, from_port: int | None = None,
             to_port: int | None = None,
             cidr: str | builtins.list[str] | None = None,
-            src_dest_fw: VMFirewall | None = None) -> GCPVMFirewallRule:
+            src_dest_fw: VMFirewall | None = None
+            ) -> GCPVMFirewallRule | None:
         gcp_fw = cast(GCPVMFirewall, firewall)
         port = GCPVMFirewallRuleService.to_port_range(from_port, to_port)
         src_dest_tag = None
@@ -347,11 +348,13 @@ class GCPVMFirewallRuleService(BaseVMFirewallRuleService):
                           from_port=from_port, to_port=to_port, cidr=cidr,
                           src_dest_fw_id=src_dest_fw_id)
         if len(rules) < 1:
-            raise ProviderInternalException(
-                "VM firewall rule not found after creation")
+            # The implicit default-egress rule that VMFirewall creation adds is
+            # hidden by list()/find() as a "dummy" rule, so it is not findable
+            # here. Callers that add it ignore the return value; the public
+            # create() below raises for a genuinely missing rule.
+            return None
         return cast(GCPVMFirewallRule, rules[0])
 
-    # declares a non-optional VMFirewallRule.
     @dispatch(event="provider.security.vm_firewall_rules.create",
               priority=BaseVMFirewallRuleService.STANDARD_EVENT_PRIORITY)
     def create(self, firewall: VMFirewall,
@@ -361,9 +364,13 @@ class GCPVMFirewallRuleService(BaseVMFirewallRuleService):
                cidr: str | builtins.list[str] | None = None,
                src_dest_fw: VMFirewall | None = None
                ) -> GCPVMFirewallRule:
-        return self.create_with_priority(firewall, direction, protocol,
+        rule = self.create_with_priority(firewall, direction, protocol,
                                          1000, from_port, to_port, cidr,
                                          src_dest_fw)
+        if rule is None:
+            raise ProviderInternalException(
+                "VM firewall rule not found after creation")
+        return rule
 
     # The interface declares delete(firewall, rule_id: str); this impl also
     # accepts a GCPVMFirewallRule instance.

--- a/cloudbridge/providers/gcp/subservices.py
+++ b/cloudbridge/providers/gcp/subservices.py
@@ -6,6 +6,12 @@ from cloudbridge.base.subservices import BaseFloatingIPSubService
 from cloudbridge.base.subservices import BaseGatewaySubService
 from cloudbridge.base.subservices import BaseSubnetSubService
 from cloudbridge.base.subservices import BaseVMFirewallRuleSubService
+from cloudbridge.interfaces.provider import CloudProvider
+from cloudbridge.interfaces.resources import Bucket
+from cloudbridge.interfaces.resources import DnsZone
+from cloudbridge.interfaces.resources import Gateway
+from cloudbridge.interfaces.resources import Network
+from cloudbridge.interfaces.resources import VMFirewall
 
 
 log = logging.getLogger(__name__)
@@ -13,34 +19,34 @@ log = logging.getLogger(__name__)
 
 class GCPBucketObjectSubService(BaseBucketObjectSubService):
 
-    def __init__(self, provider, bucket):
+    def __init__(self, provider: CloudProvider, bucket: Bucket) -> None:
         super(GCPBucketObjectSubService, self).__init__(provider, bucket)
 
 
 class GCPGatewaySubService(BaseGatewaySubService):
-    def __init__(self, provider, network):
+    def __init__(self, provider: CloudProvider, network: Network) -> None:
         super(GCPGatewaySubService, self).__init__(provider, network)
 
 
 class GCPVMFirewallRuleSubService(BaseVMFirewallRuleSubService):
 
-    def __init__(self, provider, firewall):
+    def __init__(self, provider: CloudProvider, firewall: VMFirewall) -> None:
         super(GCPVMFirewallRuleSubService, self).__init__(provider, firewall)
 
 
 class GCPFloatingIPSubService(BaseFloatingIPSubService):
 
-    def __init__(self, provider, gateway):
+    def __init__(self, provider: CloudProvider, gateway: Gateway) -> None:
         super(GCPFloatingIPSubService, self).__init__(provider, gateway)
 
 
 class GCPSubnetSubService(BaseSubnetSubService):
 
-    def __init__(self, provider, network):
+    def __init__(self, provider: CloudProvider, network: Network) -> None:
         super(GCPSubnetSubService, self).__init__(provider, network)
 
 
 class GCPDnsRecordSubService(BaseDnsRecordSubService):
 
-    def __init__(self, provider, dns_zone):
+    def __init__(self, provider: CloudProvider, dns_zone: DnsZone) -> None:
         super(GCPDnsRecordSubService, self).__init__(provider, dns_zone)

--- a/cloudbridge/providers/mock/provider.py
+++ b/cloudbridge/providers/mock/provider.py
@@ -6,6 +6,8 @@
     boto being hijacked, which will cause AWS to malfunction.
     See notes below.
 """
+from typing import Any
+
 from moto import mock_aws
 
 from ..aws import AWSCloudProvider
@@ -22,18 +24,18 @@ class MockAWSCloudProvider(AWSCloudProvider, TestMockHelperMixin):
     """
     PROVIDER_ID = 'mock'
 
-    def __init__(self, config):
+    def __init__(self, config: dict[str, Any]) -> None:
         self.setUpMock()
         super(MockAWSCloudProvider, self).__init__(config)
 
-    def setUpMock(self):
+    def setUpMock(self) -> None:
         """
         Let Moto take over all socket communications
         """
         self.mock_aws = mock_aws()
         self.mock_aws.start()
 
-    def tearDownMock(self):
+    def tearDownMock(self) -> None:
         """
         Stop Moto intercepting all socket communications
         """

--- a/cloudbridge/providers/openstack/helpers.py
+++ b/cloudbridge/providers/openstack/helpers.py
@@ -1,13 +1,19 @@
 """
 Helper functions
 """
+from __future__ import annotations
+
 import itertools
 import logging as log
+from typing import Any
+from typing import Sequence
 
 from cloudbridge.base.resources import ServerPagedResultList
+from cloudbridge.interfaces.provider import CloudProvider
 
 
-def os_result_limit(provider, requested_limit=None):
+def os_result_limit(provider: CloudProvider,
+                    requested_limit: int | None = None) -> int:
     """
     Calculates the limit for OpenStack.
     """
@@ -21,7 +27,8 @@ def os_result_limit(provider, requested_limit=None):
     return limit + 1
 
 
-def to_server_paged_list(provider, objects, limit=None):
+def to_server_paged_list(provider: CloudProvider, objects: Sequence[Any],
+                         limit: int | None = None) -> ServerPagedResultList[Any]:
     """
     A convenience function for wrapping a list of OpenStack native objects in
     a ServerPagedResultList. OpenStack
@@ -32,9 +39,9 @@ def to_server_paged_list(provider, objects, limit=None):
     limit = limit or provider.config.default_result_limit
     is_truncated = len(objects) > limit
     next_token = objects[limit-1].id if is_truncated else None
-    results = ServerPagedResultList(is_truncated,
-                                    next_token,
-                                    False)
+    results: ServerPagedResultList[Any] = ServerPagedResultList(is_truncated,
+                                                                next_token,
+                                                                False)
     for obj in itertools.islice(objects, limit):
         results.append(obj)
     return results

--- a/cloudbridge/providers/openstack/provider.py
+++ b/cloudbridge/providers/openstack/provider.py
@@ -1,6 +1,9 @@
 """Provider implementation based on OpenStack Python clients for OpenStack."""
+from __future__ import annotations
 
 import inspect
+from collections.abc import Callable
+from typing import Any
 
 from keystoneauth1 import session
 
@@ -17,8 +20,13 @@ from swiftclient import client as swift_client
 
 from cloudbridge.base import BaseCloudProvider
 from cloudbridge.base.helpers import get_env
-
+from cloudbridge.base.services import BaseCloudService
 from cloudbridge.interfaces.exceptions import ProviderConnectionException
+from cloudbridge.interfaces.services import ComputeService
+from cloudbridge.interfaces.services import DnsService
+from cloudbridge.interfaces.services import NetworkingService
+from cloudbridge.interfaces.services import SecurityService
+from cloudbridge.interfaces.services import StorageService
 
 from .services import OpenStackComputeService
 from .services import OpenStackDnsService
@@ -30,9 +38,9 @@ from .services import OpenStackStorageService
 class OpenStackCloudProvider(BaseCloudProvider):
     """OpenStack provider implementation."""
 
-    PROVIDER_ID = 'openstack'
+    PROVIDER_ID: str = 'openstack'
 
-    def __init__(self, config):
+    def __init__(self, config: dict[str, Any]) -> None:
         super(OpenStackCloudProvider, self).__init__(config)
 
         # Initialize cloud connection fields
@@ -64,14 +72,14 @@ class OpenStackCloudProvider(BaseCloudProvider):
             get_env('OS_USER_DOMAIN_NAME'))
 
         # Service connections, lazily initialized
-        self._nova = None
-        self._keystone = None
-        self._swift = None
-        self._neutron = None
-        self._os_conn = None
+        self._nova: Any = None
+        self._keystone: Any = None
+        self._swift: Any = None
+        self._neutron: Any = None
+        self._os_conn: Any = None
 
         # Additional cached variables
-        self._cached_keystone_session = None
+        self._cached_keystone_session: Any = None
 
         # Initialize provider services
         self._compute = OpenStackComputeService(self)
@@ -81,19 +89,19 @@ class OpenStackCloudProvider(BaseCloudProvider):
         self._dns = OpenStackDnsService(self)
 
     @property
-    def nova(self):
+    def nova(self) -> Any:
         if not self._nova:
             self._nova = self._connect_nova()
         return self._nova
 
     @property
-    def keystone(self):
+    def keystone(self) -> Any:
         if not self._keystone:
             self._keystone = self._connect_keystone()
         return self._keystone
 
     @property
-    def _keystone_version(self):
+    def _keystone_version(self) -> int:
         """
         Return the numeric version of remote Keystone server.
 
@@ -106,7 +114,7 @@ class OpenStackCloudProvider(BaseCloudProvider):
         return 2
 
     @property
-    def _keystone_session(self):
+    def _keystone_session(self) -> Any:
         """
         Connect to Keystone and return a session object.
 
@@ -118,6 +126,7 @@ class OpenStackCloudProvider(BaseCloudProvider):
 
         if self._keystone_version == 3:
             from keystoneauth1.identity import v3
+            auth: Any
             if self.username and self.password:
                 auth = v3.Password(auth_url=self.auth_url,
                                    username=self.username,
@@ -143,7 +152,7 @@ class OpenStackCloudProvider(BaseCloudProvider):
             self._cached_keystone_session = session.Session(auth=auth)
         return self._cached_keystone_session
 
-    def _connect_openstack(self):
+    def _connect_openstack(self) -> Any:
         return connection.Connection(
             region_name=self.region_name,
             user_agent='cloudbridge',
@@ -152,47 +161,47 @@ class OpenStackCloudProvider(BaseCloudProvider):
         )
 
     @property
-    def swift(self):
+    def swift(self) -> Any:
         if not self._swift:
             self._swift = self._connect_swift()
         return self._swift
 
     @property
-    def neutron(self):
+    def neutron(self) -> Any:
         if not self._neutron:
             self._neutron = self._connect_neutron()
         return self._neutron
 
     @property
-    def os_conn(self):
+    def os_conn(self) -> Any:
         if not self._os_conn:
             self._os_conn = self._connect_openstack()
         return self._os_conn
 
     @property
-    def compute(self):
+    def compute(self) -> ComputeService:
         return self._compute
 
     @property
-    def networking(self):
+    def networking(self) -> NetworkingService:
         return self._networking
 
     @property
-    def security(self):
+    def security(self) -> SecurityService:
         return self._security
 
     @property
-    def storage(self):
+    def storage(self) -> StorageService:
         return self._storage
 
     @property
-    def dns(self):
+    def dns(self) -> DnsService:
         return self._dns
 
-    def _connect_nova(self):
+    def _connect_nova(self) -> Any:
         return self._connect_nova_region(self.region_name)
 
-    def _connect_nova_region(self, region_name):
+    def _connect_nova_region(self, region_name: str | None) -> Any:
         """Get an OpenStack Nova (compute) client object."""
         # Force reauthentication with Keystone
         self._cached_keystone_session = None
@@ -215,7 +224,7 @@ class OpenStackCloudProvider(BaseCloudProvider):
                 http_log_debug=True if self.config.debug_mode else False)
         return nova
 
-    def _connect_keystone(self):
+    def _connect_keystone(self) -> Any:
         """Get an OpenStack Keystone (identity) client object."""
         if self._keystone_version == 3:
             return keystone_client.Client(session=self._keystone_session,
@@ -237,7 +246,8 @@ class OpenStackCloudProvider(BaseCloudProvider):
             return keystone
 
     @staticmethod
-    def _clean_options(options, method_to_match):
+    def _clean_options(options: dict[str, Any] | None,
+                       method_to_match: Callable[..., Any]) -> dict[str, Any]:
         """
         Returns a **copy** of the source options with all keys that are not in
         the ``method_to_match`` parameter list removed.
@@ -261,20 +271,17 @@ class OpenStackCloudProvider(BaseCloudProvider):
             then this will be an empty dictionary
         :rtype: ``dict``
         """
-        result = {}
+        result: dict[str, Any] = {}
         if options:
-            try:
-                method_signature = inspect.signature(method_to_match)
-                parameters = set(method_signature.parameters.keys())
-            except AttributeError:
-                parameters = set(inspect.getargspec(method_to_match).args)
+            method_signature = inspect.signature(method_to_match)
+            parameters = set(method_signature.parameters.keys())
             result = {key: val for key, val in options.items() if
                       key in parameters}
             # Don't allow the options to override our authentication
             result.pop('os_options', None)
         return result
 
-    def _connect_swift(self, options=None):
+    def _connect_swift(self, options: dict[str, Any] | None = None) -> Any:
         """
         Get an OpenStack Swift (object store) client connection.
 
@@ -297,42 +304,57 @@ class OpenStackCloudProvider(BaseCloudProvider):
             clean_options['session'] = self._keystone_session
         return swift_client.Connection(**clean_options)
 
-    def _connect_neutron(self):
+    def _connect_neutron(self) -> Any:
         """Get an OpenStack Neutron (networking) client object cloud."""
         return neutron_client.Client(auth_url=self.auth_url,
                                      session=self._keystone_session,
                                      region_name=self.region_name)
 
-    def service_zone_name(self, service):
+    def service_zone_name(self, service: BaseCloudService) -> str | None:
+        # ``service_zone_name`` is an OpenStack-specific attribute set in each
+        # service's __init__; it is not declared on the typed service
+        # interfaces, so reach it through ``Any``.
+        networking: Any = self.networking
+        security: Any = self.security
+        compute: Any = self.compute
+        storage: Any = self.storage
+        # ``zone_name`` is typed ``str | None`` on the interface, but the base
+        # implementation may return a dict at runtime (via ast.literal_eval);
+        # bind it to ``Any`` so the dict branches type-check.
+        zone_name: Any = self.zone_name
         service_name = service._service_event_pattern
         if "networking" in service_name:
-            if self.networking.service_zone_name:
-                return self.networking.service_zone_name
-            elif (isinstance(self.zone_name, dict) and
-                  self.zone_name.get("networking_zone")):
-                return self.zone_name.get("networking_zone")
+            if networking.service_zone_name:
+                return networking.service_zone_name
+            elif (isinstance(zone_name, dict) and
+                  zone_name.get("networking_zone")):
+                return zone_name.get("networking_zone")
         elif "security" in service_name:
-            if self.security.service_zone_name:
-                return self.security.service_zone_name
-            elif (isinstance(self.zone_name, dict) and
-                  self.zone_name.get("security_zone")):
-                return self.zone_name.get("security_zone")
+            if security.service_zone_name:
+                return security.service_zone_name
+            elif (isinstance(zone_name, dict) and
+                  zone_name.get("security_zone")):
+                return zone_name.get("security_zone")
         elif "compute" in service_name:
-            if self.compute.service_zone_name:
-                return self.compute.service_zone_name
-            elif (isinstance(self.zone_name, dict) and
-                  self.zone_name.get("compute_zone")):
-                return self.zone_name.get("compute_zone")
+            if compute.service_zone_name:
+                return compute.service_zone_name
+            elif (isinstance(zone_name, dict) and
+                  zone_name.get("compute_zone")):
+                return zone_name.get("compute_zone")
         elif "storage" in service_name:
-            if self.storage.service_zone_name:
-                return self.storage.service_zone_name
-            elif (isinstance(self.zone_name, dict) and
-                  self.zone_name.get("storage_zone")):
-                return self.zone_name.get("storage_zone")
-        elif (isinstance(self.zone_name, dict) and
-              self.zone_name.get("default_zone")):
-            return self.zone_name.get("default_zone")
-        elif isinstance(self.zone_name, str):
-            return self.zone_name
+            if storage.service_zone_name:
+                return storage.service_zone_name
+            elif (isinstance(zone_name, dict) and
+                  zone_name.get("storage_zone")):
+                return zone_name.get("storage_zone")
+        elif (isinstance(zone_name, dict) and
+              zone_name.get("default_zone")):
+            return zone_name.get("default_zone")
+        elif isinstance(zone_name, str):
+            return zone_name
         else:
             return None
+        # The branches above only return when an inner condition matched;
+        # fall through to ``None`` otherwise (preserving the original
+        # implicit return).
+        return None

--- a/cloudbridge/providers/openstack/resources.py
+++ b/cloudbridge/providers/openstack/resources.py
@@ -1,19 +1,24 @@
 """
 DataTypes used by this provider
 """
+from __future__ import annotations
+
 import inspect
 import ipaddress
 import logging
 import os
 import re
-
 from datetime import datetime
+from typing import Any
+from typing import IO
+from typing import Iterable
+from typing import TYPE_CHECKING
+from typing import cast
 from urllib.parse import urljoin
 from urllib.parse import urlparse
 
-from keystoneclient.v3.regions import Region
-
 import keystoneclient.exceptions as keystoneex
+from keystoneclient.v3.regions import Region
 
 import swiftclient
 from swiftclient.service import SwiftService
@@ -40,14 +45,28 @@ from cloudbridge.base.resources import BaseVMFirewall
 from cloudbridge.base.resources import BaseVMFirewallRule
 from cloudbridge.base.resources import BaseVMType
 from cloudbridge.base.resources import BaseVolume
+from cloudbridge.interfaces.exceptions import ProviderInternalException
+from cloudbridge.interfaces.resources import AttachmentInfo
+from cloudbridge.interfaces.resources import Bucket
+from cloudbridge.interfaces.resources import BucketObject
+from cloudbridge.interfaces.resources import FloatingIP
+from cloudbridge.interfaces.resources import Gateway
 from cloudbridge.interfaces.resources import GatewayState
+from cloudbridge.interfaces.resources import Instance
 from cloudbridge.interfaces.resources import InstanceState
+from cloudbridge.interfaces.resources import MachineImage
 from cloudbridge.interfaces.resources import MachineImageState
 from cloudbridge.interfaces.resources import NetworkState
 from cloudbridge.interfaces.resources import RouterState
+from cloudbridge.interfaces.resources import Snapshot
 from cloudbridge.interfaces.resources import SnapshotState
+from cloudbridge.interfaces.resources import Subnet
 from cloudbridge.interfaces.resources import SubnetState
 from cloudbridge.interfaces.resources import TrafficDirection
+from cloudbridge.interfaces.resources import UploadConfig
+from cloudbridge.interfaces.resources import VMFirewall
+from cloudbridge.interfaces.resources import VMType
+from cloudbridge.interfaces.resources import Volume
 from cloudbridge.interfaces.resources import VolumeState
 
 from .subservices import OpenStackBucketObjectSubService
@@ -56,6 +75,9 @@ from .subservices import OpenStackFloatingIPSubService
 from .subservices import OpenStackGatewaySubService
 from .subservices import OpenStackSubnetSubService
 from .subservices import OpenStackVMFirewallRuleSubService
+
+if TYPE_CHECKING:
+    from cloudbridge.providers.openstack.provider import OpenStackCloudProvider
 
 ONE_GIG = 1048576000  # in bytes
 FIVE_GIG = ONE_GIG * 5  # in bytes
@@ -76,30 +98,31 @@ class OpenStackMachineImage(BaseMachineImage):
         'deactivated': MachineImageState.ERROR
     }
 
-    def __init__(self, provider, os_image):
+    def __init__(self, provider: OpenStackCloudProvider,
+                 os_image: Any) -> None:
         super(OpenStackMachineImage, self).__init__(provider)
         if isinstance(os_image, OpenStackMachineImage):
             # pylint:disable=protected-access
-            self._os_image = os_image._os_image
+            self._os_image = cast(Any, os_image)._os_image
         else:
             self._os_image = os_image
 
     @property
-    def id(self):
+    def id(self) -> str:
         """
         Get the image identifier.
         """
         return self._os_image.id
 
     @property
-    def name(self):
+    def name(self) -> str:
         """
         Get the image identifier.
         """
         return self._os_image.id
 
     @property
-    def label(self):
+    def label(self) -> str | None:
         """
         Get the image label.
         """
@@ -107,23 +130,23 @@ class OpenStackMachineImage(BaseMachineImage):
 
     @label.setter
     # pylint:disable=arguments-differ
-    def label(self, value):
+    def label(self, value: str) -> None:
         """
         Set the image label.
         """
         self.assert_valid_resource_label(value)
-        self._provider.os_conn.image.update_image(
-            self._os_image, name=value or "")
+        cast("OpenStackCloudProvider", self._provider).os_conn.image \
+            .update_image(self._os_image, name=value or "")
 
     @property
-    def description(self):
+    def description(self) -> str | None:
         """
         Get the image description.
         """
         return None
 
     @property
-    def min_disk(self):
+    def min_disk(self) -> int | None:
         """
         Returns the minimum size of the disk that's required to
         boot this image (in GB)
@@ -133,18 +156,19 @@ class OpenStackMachineImage(BaseMachineImage):
         """
         return self._os_image.min_disk
 
-    def delete(self):
+    def delete(self) -> None:
         """
         Delete this image
         """
-        self._os_image.delete(self._provider.os_conn.image)
+        self._os_image.delete(
+            cast("OpenStackCloudProvider", self._provider).os_conn.image)
 
     @property
-    def state(self):
+    def state(self) -> str:
         return OpenStackMachineImage.IMAGE_STATE_MAP.get(
             self._os_image.status, MachineImageState.UNKNOWN)
 
-    def refresh(self):
+    def refresh(self) -> None:
         """
         Refreshes the state of this instance by re-querying the cloud provider
         for its latest state.
@@ -153,7 +177,7 @@ class OpenStackMachineImage(BaseMachineImage):
         image = self._provider.compute.images.get(self.id)
         if image:
             # pylint:disable=protected-access
-            self._os_image = image._os_image
+            self._os_image = cast(Any, image)._os_image
         else:
             # The image no longer exists and cannot be refreshed.
             # set the status to unknown
@@ -162,19 +186,20 @@ class OpenStackMachineImage(BaseMachineImage):
 
 class OpenStackPlacementZone(BasePlacementZone):
 
-    def __init__(self, provider, zone, region):
+    def __init__(self, provider: OpenStackCloudProvider, zone: Any,
+                 region: Any) -> None:
         super(OpenStackPlacementZone, self).__init__(provider)
         if isinstance(zone, OpenStackPlacementZone):
             # pylint:disable=protected-access
-            self._os_zone = zone._os_zone
+            self._os_zone = cast(Any, zone)._os_zone
             # pylint:disable=protected-access
-            self._os_region = zone._os_region
+            self._os_region = cast(Any, zone)._os_region
         else:
             self._os_zone = zone
             self._os_region = region
 
     @property
-    def id(self):
+    def id(self) -> str:
         """
         Get the zone id
 
@@ -184,7 +209,7 @@ class OpenStackPlacementZone(BasePlacementZone):
         return self._os_zone
 
     @property
-    def name(self):
+    def name(self) -> str:
         """
         Get the zone name.
 
@@ -195,7 +220,7 @@ class OpenStackPlacementZone(BasePlacementZone):
         return self._os_zone
 
     @property
-    def region_name(self):
+    def region_name(self) -> str:
         """
         Get the region that this zone belongs to.
 
@@ -207,49 +232,50 @@ class OpenStackPlacementZone(BasePlacementZone):
 
 class OpenStackVMType(BaseVMType):
 
-    def __init__(self, provider, os_flavor):
+    def __init__(self, provider: OpenStackCloudProvider,
+                 os_flavor: Any) -> None:
         super(OpenStackVMType, self).__init__(provider)
         self._os_flavor = os_flavor
-        self._extra_data = None
+        self._extra_data: dict[str, Any] | None = None
 
     @property
-    def id(self):
+    def id(self) -> str:
         return self._os_flavor.id
 
     @property
-    def name(self):
+    def name(self) -> str:
         return self._os_flavor.name
 
     @property
-    def family(self):
+    def family(self) -> str | None:
         # TODO: This may not be standardised across OpenStack
         # but NeCTAR is using it this way
         return self.extra_data.get('flavor_class:name')
 
     @property
-    def vcpus(self):
+    def vcpus(self) -> int:
         return self._os_flavor.vcpus
 
     @property
-    def ram(self):
+    def ram(self) -> float:
         return int(self._os_flavor.ram) / 1024
 
     @property
-    def size_root_disk(self):
+    def size_root_disk(self) -> int:
         return self._os_flavor.disk
 
     @property
-    def size_ephemeral_disks(self):
+    def size_ephemeral_disks(self) -> int:
         return 0 if self._os_flavor.ephemeral == 'N/A' else \
             self._os_flavor.ephemeral
 
     @property
-    def num_ephemeral_disks(self):
+    def num_ephemeral_disks(self) -> int:
         return 0 if self._os_flavor.ephemeral == 'N/A' else \
             self._os_flavor.ephemeral
 
     @property
-    def extra_data(self):
+    def extra_data(self) -> dict[str, Any]:
         # get_keys() hits Nova's /flavors/<id>/os-extra_specs endpoint.
         # Cache the result so repeat property accesses (and family, which
         # delegates here) don't fan out to N concurrent API calls under
@@ -288,19 +314,20 @@ class OpenStackInstance(BaseInstance):
         'VERIFY_RESIZE': InstanceState.CONFIGURING
     }
 
-    def __init__(self, provider, os_instance):
+    def __init__(self, provider: OpenStackCloudProvider,
+                 os_instance: Any) -> None:
         super(OpenStackInstance, self).__init__(provider)
         self._os_instance = os_instance
 
     @property
-    def id(self):
+    def id(self) -> str:
         """
         Get the instance identifier.
         """
         return self._os_instance.id
 
     @property
-    def name(self):
+    def name(self) -> str:
         """
         Get the instance identifier.
         """
@@ -308,7 +335,7 @@ class OpenStackInstance(BaseInstance):
 
     @property
     # pylint:disable=arguments-differ
-    def label(self):
+    def label(self) -> str | None:
         """
         Get the instance label.
         """
@@ -316,7 +343,7 @@ class OpenStackInstance(BaseInstance):
 
     @label.setter
     # pylint:disable=arguments-differ
-    def label(self, value):
+    def label(self, value: str) -> None:
         """
         Set the instance label.
         """
@@ -325,7 +352,7 @@ class OpenStackInstance(BaseInstance):
         self._os_instance.name = value
         self._os_instance.update(name=value or "cb-inst")
 
-    def _all_addresses(self):
+    def _all_addresses(self) -> set[str]:
         """All IP addresses associated with this instance.
 
         Nova's info_cache (which backs ``server.addresses``) is refreshed
@@ -335,7 +362,7 @@ class OpenStackInstance(BaseInstance):
         Neutron will still appear. So we deliberately read only fixed
         IPs from Nova and ask Neutron live for the current floating IPs.
         """
-        addrs = set()
+        addrs: set[str] = set()
         for _, addr_list in self._os_instance.addresses.items():
             for entry in addr_list:
                 if entry.get('OS-EXT-IPS:type') == 'floating':
@@ -344,10 +371,9 @@ class OpenStackInstance(BaseInstance):
                 if ip:
                     addrs.add(ip)
         try:
-            for port in self._provider.os_conn.network.ports(
-                    device_id=self.id):
-                for fip in self._provider.os_conn.network.ips(
-                        port_id=port.id):
+            os_conn = cast("OpenStackCloudProvider", self._provider).os_conn
+            for port in os_conn.network.ports(device_id=self.id):
+                for fip in os_conn.network.ips(port_id=port.id):
                     if fip.floating_ip_address:
                         addrs.add(fip.floating_ip_address)
         except Exception as e:
@@ -357,7 +383,7 @@ class OpenStackInstance(BaseInstance):
         return addrs
 
     @property
-    def public_ips(self):
+    def public_ips(self) -> list[str]:
         """
         Get all the public IP addresses for this instance.
         """
@@ -369,7 +395,7 @@ class OpenStackInstance(BaseInstance):
                 if not ipaddress.ip_address(a).is_private]
 
     @property
-    def private_ips(self):
+    def private_ips(self) -> list[str]:
         """
         Get all the private IP addresses for this instance.
         """
@@ -377,36 +403,44 @@ class OpenStackInstance(BaseInstance):
                 if ipaddress.ip_address(a).is_private]
 
     @property
-    def vm_type_id(self):
+    def vm_type_id(self) -> str:
         """
         Get the VM type name.
         """
         return self._os_instance.flavor.get('id')
 
     @property
-    def vm_type(self):
+    def vm_type(self) -> VMType:
         """
         Get the VM type object.
         """
-        flavor = self._provider.nova.flavors.get(
-            self._os_instance.flavor.get('id'))
-        return OpenStackVMType(self._provider, flavor)
+        flavor = cast("OpenStackCloudProvider", self._provider).nova \
+            .flavors.get(self._os_instance.flavor.get('id'))
+        return OpenStackVMType(
+            cast("OpenStackCloudProvider", self._provider), flavor)
 
     @property
-    def create_time(self):
+    def create_time(self) -> str | datetime:
         """
         Get the instance creation time
         """
-        return datetime.strptime(self._os_instance.created, '%Y-%m-%dT%H:%M:%SZ')
+        return datetime.strptime(
+            self._os_instance.created, '%Y-%m-%dT%H:%M:%SZ')
 
-    def reboot(self):
+    def start(self) -> None:
+        pass
+
+    def stop(self) -> None:
+        pass
+
+    def reboot(self) -> None:
         """
         Reboot this instance (using the cloud middleware API).
         """
         self._os_instance.reboot()
 
     @property
-    def image_id(self):
+    def image_id(self) -> str:
         """
         Get the image ID for this instance.
         """
@@ -417,14 +451,19 @@ class OpenStackInstance(BaseInstance):
                 if self._os_instance.image else "")
 
     @property
-    def zone_id(self):
+    def zone_id(self) -> str:
         """
         Get the placement zone where this instance is running.
         """
-        return getattr(self._os_instance, 'OS-EXT-AZ:availability_zone', None)
+        zone = getattr(
+            self._os_instance, 'OS-EXT-AZ:availability_zone', None)
+        if zone is None:
+            raise ProviderInternalException(
+                "Instance {0} has no availability zone".format(self.id))
+        return zone
 
     @property
-    def subnet_id(self):
+    def subnet_id(self) -> str:
         """
         Extract (one) subnet id associated with this instance.
 
@@ -438,6 +477,8 @@ class OpenStackInstance(BaseInstance):
         # MAC address can be used to identify a port so extract the MAC
         # address corresponding to the (first) private IP associated with the
         # instance.
+        port = None
+        addr = None
         for net in self._os_instance.to_dict().get('addresses').keys():
             for iface in self._os_instance.to_dict().get('addresses')[net]:
                 if iface.get('OS-EXT-IPS:type') == 'fixed':
@@ -446,34 +487,37 @@ class OpenStackInstance(BaseInstance):
                     break
         # Now get a handle to a port with the given MAC address and get the
         # subnet to which the private IP is connected as the desired id.
-        for prt in self._provider.neutron.list_ports().get('ports'):
+        neutron = cast("OpenStackCloudProvider", self._provider).neutron
+        for prt in neutron.list_ports().get('ports'):
             if prt.get('mac_address') == port:
                 for ip in prt.get('fixed_ips'):
                     if ip.get('ip_address') == addr:
                         return ip.get('subnet_id')
+        raise ProviderInternalException(
+            "Could not determine a subnet for instance {0}".format(self.id))
 
     @property
-    def vm_firewalls(self):
-        return [
+    def vm_firewalls(self) -> list[VMFirewall]:
+        return cast("list[VMFirewall]", [
             self._provider.security.vm_firewalls.get(group.id)
             for group in self._os_instance.list_security_group()
-        ]
+        ])
 
     @property
-    def vm_firewall_ids(self):
+    def vm_firewall_ids(self) -> list[str]:
         """
         Get the VM firewall IDs associated with this instance.
         """
         return [fw.id for fw in self.vm_firewalls]
 
     @property
-    def key_pair_id(self):
+    def key_pair_id(self) -> str:
         """
         Get the id of the key pair associated with this instance.
         """
         return self._os_instance.key_name
 
-    def create_image(self, label):
+    def create_image(self, label: str) -> MachineImage:
         """
         Create a new image based on this instance.
         """
@@ -482,21 +526,27 @@ class OpenStackInstance(BaseInstance):
 
         image_id = self._os_instance.create_image(label)
         img = OpenStackMachineImage(
-            self._provider, self._provider.compute.images.get(image_id))
+            cast("OpenStackCloudProvider", self._provider),
+            self._provider.compute.images.get(image_id))
         return img
 
-    def _get_fip(self, floating_ip):
+    def _get_fip(self, floating_ip: FloatingIP | str) -> Any:
         """Get a floating IP object based on the supplied ID."""
-        return self._provider.networking._floating_ips.get(None, floating_ip)
+        # The OpenStack FloatingIP service looks up by id alone and ignores
+        # the gateway argument, so None is passed deliberately.
+        # pylint:disable=protected-access
+        return self._provider.networking._floating_ips.get(
+            cast(Gateway, None), cast(str, floating_ip))
 
-    def _primary_port(self):
+    def _primary_port(self) -> Any:
         """Return the first Neutron port on this instance, or None."""
         # pylint:disable=protected-access
+        os_conn = cast("OpenStackCloudProvider", self._provider).os_conn
         return next(
-            iter(self._provider.os_conn.network.ports(device_id=self.id)),
+            iter(os_conn.network.ports(device_id=self.id)),
             None)
 
-    def add_floating_ip(self, floating_ip):
+    def add_floating_ip(self, floating_ip: FloatingIP | str) -> None:
         """
         Add a floating IP address to this instance.
 
@@ -513,9 +563,10 @@ class OpenStackInstance(BaseInstance):
                 "Cannot add floating IP: instance {0} has no network port"
                 .format(self.id))
         # pylint:disable=protected-access
-        self._provider.os_conn.network.update_ip(fip._ip, port_id=port.id)
+        cast("OpenStackCloudProvider", self._provider).os_conn.network \
+            .update_ip(fip._ip, port_id=port.id)
 
-    def remove_floating_ip(self, floating_ip):
+    def remove_floating_ip(self, floating_ip: FloatingIP | str) -> None:
         """
         Remove a floating IP address from this instance.
 
@@ -531,17 +582,17 @@ class OpenStackInstance(BaseInstance):
                else self._get_fip(floating_ip))
         if fip is None:
             return
-        self._provider.neutron.update_floatingip(
-            fip.id, {'floatingip': {'port_id': None}})
+        cast("OpenStackCloudProvider", self._provider).neutron \
+            .update_floatingip(fip.id, {'floatingip': {'port_id': None}})
 
-    def add_vm_firewall(self, firewall):
+    def add_vm_firewall(self, firewall: VMFirewall) -> None:
         """
         Add a VM firewall to this instance
         """
         log.debug("Adding firewall: %s", firewall)
         self._os_instance.add_security_group(firewall.id)
 
-    def remove_vm_firewall(self, firewall):
+    def remove_vm_firewall(self, firewall: VMFirewall) -> None:
         """
         Remove a VM firewall from this instance
         """
@@ -549,11 +600,11 @@ class OpenStackInstance(BaseInstance):
         self._os_instance.remove_security_group(firewall.id)
 
     @property
-    def state(self):
+    def state(self) -> str:
         return OpenStackInstance.INSTANCE_STATE_MAP.get(
             self._os_instance.status, InstanceState.UNKNOWN)
 
-    def refresh(self):
+    def refresh(self) -> None:
         """
         Refreshes the state of this instance by re-querying the cloud provider
         for its latest state.
@@ -562,7 +613,7 @@ class OpenStackInstance(BaseInstance):
             self.id)
         if instance:
             # pylint:disable=protected-access
-            self._os_instance = instance._os_instance
+            self._os_instance = cast(Any, instance)._os_instance
         else:
             # The instance no longer exists and cannot be refreshed.
             # set the status to unknown
@@ -571,36 +622,38 @@ class OpenStackInstance(BaseInstance):
 
 class OpenStackRegion(BaseRegion):
 
-    def __init__(self, provider, os_region):
+    def __init__(self, provider: OpenStackCloudProvider,
+                 os_region: Any) -> None:
         super(OpenStackRegion, self).__init__(provider)
         self._os_region = os_region
 
     @property
-    def id(self):
+    def id(self) -> str:
         return (self._os_region.id if type(self._os_region) is Region else
                 self._os_region)
 
     @property
-    def name(self):
+    def name(self) -> str:
         return self.id
 
     @property
-    def zones(self):
+    def zones(self) -> Iterable[OpenStackPlacementZone]:
         # ``detailed`` param must be set to ``False`` because the (default)
         # ``True`` value requires Admin privileges
+        provider = cast("OpenStackCloudProvider", self._provider)
         if self.name == self._provider.region_name:  # optimisation
-            zones = self._provider.nova.availability_zones.list(detailed=False)
+            zones = provider.nova.availability_zones.list(detailed=False)
         else:
             try:
                 # pylint:disable=protected-access
-                region_nova = self._provider._connect_nova_region(self.name)
+                region_nova = provider._connect_nova_region(self.name)
                 zones = region_nova.availability_zones.list(detailed=False)
             except keystoneex.EndpointNotFound:
                 # This region may not have a compute endpoint. If so just
                 # return an empty list
                 zones = []
 
-        return [OpenStackPlacementZone(self._provider, z.zoneName, self.name)
+        return [OpenStackPlacementZone(provider, z.zoneName, self.name)
                 for z in zones]
 
 
@@ -621,21 +674,22 @@ class OpenStackVolume(BaseVolume):
         'error_extending': VolumeState.ERROR
     }
 
-    def __init__(self, provider, volume):
+    def __init__(self, provider: OpenStackCloudProvider,
+                 volume: Any) -> None:
         super(OpenStackVolume, self).__init__(provider)
         self._volume = volume
 
     @property
-    def id(self):
+    def id(self) -> str:
         return self._volume.id
 
     @property
-    def name(self):
+    def name(self) -> str:
         return self.id
 
     @property
     # pylint:disable=arguments-differ
-    def label(self):
+    def label(self) -> str | None:
         """
         Get the volume label.
         """
@@ -643,44 +697,48 @@ class OpenStackVolume(BaseVolume):
 
     @label.setter
     # pylint:disable=arguments-differ
-    def label(self, value):
+    def label(self, value: str) -> None:
         """
         Set the volume label.
         """
         self.assert_valid_resource_label(value)
         self._volume.name = value
-        self._volume.commit(self._provider.os_conn.block_storage)
+        self._volume.commit(
+            cast("OpenStackCloudProvider", self._provider).os_conn
+            .block_storage)
 
     @property
-    def description(self):
+    def description(self) -> str:
         return self._volume.description
 
     @description.setter
-    def description(self, value):
+    def description(self, value: str) -> None:
         self._volume.description = value
-        self._volume.commit(self._provider.os_conn.block_storage)
+        self._volume.commit(
+            cast("OpenStackCloudProvider", self._provider).os_conn
+            .block_storage)
 
     @property
-    def size(self):
+    def size(self) -> int:
         return self._volume.size
 
     @property
-    def create_time(self):
+    def create_time(self) -> str | datetime:
         return self._volume.created_at
 
     @property
-    def zone_id(self):
+    def zone_id(self) -> str:
         return self._volume.availability_zone
 
     @property
-    def source(self):
+    def source(self) -> Snapshot | MachineImage | None:
         if self._volume.snapshot_id:
             return self._provider.storage.snapshots.get(
                 self._volume.snapshot_id)
         return None
 
     @property
-    def attachments(self):
+    def attachments(self) -> AttachmentInfo | None:
         if self._volume.attachments:
             return BaseAttachmentInfo(
                 self,
@@ -689,7 +747,7 @@ class OpenStackVolume(BaseVolume):
         else:
             return None
 
-    def attach(self, instance, device):
+    def attach(self, instance: str | Instance, device: str) -> None:
         """
         Attach this volume to an instance.
         """
@@ -697,18 +755,21 @@ class OpenStackVolume(BaseVolume):
         instance_id = instance.id if isinstance(
             instance,
             OpenStackInstance) else instance
-        self._provider.os_conn.compute.create_volume_attachment(
-            server=instance_id, volume_id=self.id, device=device)
+        cast("OpenStackCloudProvider", self._provider).os_conn.compute \
+            .create_volume_attachment(
+                server=instance_id, volume_id=self.id, device=device)
 
-    def detach(self, force=False):
+    def detach(self, force: bool = False) -> None:
         """
         Detach this volume from an instance.
         """
         for attachment in self._volume.attachments:
-            self._provider.os_conn.compute.delete_volume_attachment(
-                attachment['id'], attachment['server_id'])
+            cast("OpenStackCloudProvider", self._provider).os_conn.compute \
+                .delete_volume_attachment(
+                    attachment['id'], attachment['server_id'])
 
-    def create_snapshot(self, label, description=None):
+    def create_snapshot(self, label: str,
+                        description: str | None = None) -> Snapshot:
         """
         Create a snapshot of this Volume.
         """
@@ -718,11 +779,11 @@ class OpenStackVolume(BaseVolume):
             label, self, description=description)
 
     @property
-    def state(self):
+    def state(self) -> str:
         return OpenStackVolume.VOLUME_STATE_MAP.get(
             self._volume.status, VolumeState.UNKNOWN)
 
-    def refresh(self):
+    def refresh(self) -> None:
         """
         Refreshes the state of this volume by re-querying the cloud provider
         for its latest state.
@@ -731,7 +792,7 @@ class OpenStackVolume(BaseVolume):
             self.id)
         if vol:
             # pylint:disable=protected-access
-            self._volume = vol._volume  # pylint:disable=protected-access
+            self._volume = cast(Any, vol)._volume
         else:
             # The volume no longer exists and cannot be refreshed.
             # set the status to unknown
@@ -749,21 +810,22 @@ class OpenStackSnapshot(BaseSnapshot):
         'error_deleting': SnapshotState.ERROR
     }
 
-    def __init__(self, provider, snapshot):
+    def __init__(self, provider: OpenStackCloudProvider,
+                 snapshot: Any) -> None:
         super(OpenStackSnapshot, self).__init__(provider)
         self._snapshot = snapshot
 
     @property
-    def id(self):
+    def id(self) -> str:
         return self._snapshot.id
 
     @property
-    def name(self):
+    def name(self) -> str:
         return self.id
 
     @property
     # pylint:disable=arguments-differ
-    def label(self):
+    def label(self) -> str | None:
         """
         Get the snapshot label.
         """
@@ -771,41 +833,45 @@ class OpenStackSnapshot(BaseSnapshot):
 
     @label.setter
     # pylint:disable=arguments-differ
-    def label(self, value):
+    def label(self, value: str) -> None:
         """
         Set the snapshot label.
         """
         self.assert_valid_resource_label(value)
         self._snapshot.name = value
-        self._snapshot.commit(self._provider.os_conn.block_storage)
+        self._snapshot.commit(
+            cast("OpenStackCloudProvider", self._provider).os_conn
+            .block_storage)
 
     @property
-    def description(self):
+    def description(self) -> str:
         return self._snapshot.description
 
     @description.setter
-    def description(self, value):
+    def description(self, value: str) -> None:
         self._snapshot.description = value
-        self._snapshot.commit(self._provider.os_conn.block_storage)
+        self._snapshot.commit(
+            cast("OpenStackCloudProvider", self._provider).os_conn
+            .block_storage)
 
     @property
-    def size(self):
+    def size(self) -> int:
         return self._snapshot.size
 
     @property
-    def volume_id(self):
+    def volume_id(self) -> str | None:
         return self._snapshot.volume_id
 
     @property
-    def create_time(self):
+    def create_time(self) -> str | datetime:
         return self._snapshot.created_at
 
     @property
-    def state(self):
+    def state(self) -> str:
         return OpenStackSnapshot.SNAPSHOT_STATE_MAP.get(
             self._snapshot.status, SnapshotState.UNKNOWN)
 
-    def refresh(self):
+    def refresh(self) -> None:
         """
         Refreshes the state of this snapshot by re-querying the cloud provider
         for its latest state.
@@ -814,23 +880,26 @@ class OpenStackSnapshot(BaseSnapshot):
             self.id)
         if snap:
             # pylint:disable=protected-access
-            self._snapshot = snap._snapshot
+            self._snapshot = cast(Any, snap)._snapshot
         else:
             # The snapshot no longer exists and cannot be refreshed.
             # set the status to unknown
             self._snapshot.status = 'unknown'
 
-    def create_volume(self, size=None, volume_type=None, iops=None):
+    def create_volume(self, size: int | None = None,
+                      volume_type: str | None = None,
+                      iops: int | None = None) -> Volume:
         """
         Create a new Volume from this Snapshot.
         """
         vol_label = "from-snap-{0}".format(self.label or self.id)
         self.assert_valid_resource_label(vol_label)
         size = size if size else self._snapshot.size
-        os_vol = self._provider.os_conn.block_storage.create_volume(
+        provider = cast("OpenStackCloudProvider", self._provider)
+        os_vol = provider.os_conn.block_storage.create_volume(
             size=size, name=vol_label, snapshot_id=self._snapshot.id,
-            availability_zone=self._provider.zone_name)
-        cb_vol = OpenStackVolume(self._provider, os_vol)
+            availability_zone=provider.zone_name)
+        cb_vol = OpenStackVolume(provider, os_vol)
         return cb_vol
 
 
@@ -849,112 +918,114 @@ class OpenStackNetwork(BaseNetwork):
         'ACTIVE': NetworkState.AVAILABLE
     }
 
-    def __init__(self, provider, network):
+    def __init__(self, provider: OpenStackCloudProvider,
+                 network: Any) -> None:
         super(OpenStackNetwork, self).__init__(provider)
         self._network = network
         self._gateway_service = OpenStackGatewaySubService(provider, self)
         self._subnet_svc = OpenStackSubnetSubService(provider, self)
 
     @property
-    def id(self):
+    def id(self) -> str:
         return self._network.get('id', None)
 
     @property
-    def name(self):
+    def name(self) -> str:
         return self.id
 
     @property
-    def label(self):
+    def label(self) -> str | None:
         return self._network.get('name', None)
 
     @label.setter
-    def label(self, value):
+    def label(self, value: str) -> None:
         """
         Set the network label.
         """
         self.assert_valid_resource_label(value)
-        self._provider.neutron.update_network(
+        cast("OpenStackCloudProvider", self._provider).neutron.update_network(
             self.id, {'network': {'name': value or ""}})
         self.refresh()
 
     @property
-    def external(self):
+    def external(self) -> bool:
         return self._network.get('router:external', False)
 
     @property
-    def shared(self):
+    def shared(self) -> bool:
         return self._network.get('shared', False)
 
     @property
-    def state(self):
+    def state(self) -> str:
         self.refresh()
         return OpenStackNetwork._NETWORK_STATE_MAP.get(
             self._network.get('status', None),
             NetworkState.UNKNOWN)
 
     @property
-    def cidr_block(self):
+    def cidr_block(self) -> str:
         # OpenStack does not define a CIDR block for networks
         return ''
 
     @property
-    def subnets(self):
+    def subnets(self) -> OpenStackSubnetSubService:
         return self._subnet_svc
 
-    def refresh(self):
+    def refresh(self) -> None:
         """Refresh the state of this network by re-querying the provider."""
         network = self._provider.networking.networks.get(self.id)
         if network:
             # pylint:disable=protected-access
-            self._network = network._network
+            self._network = cast(Any, network)._network
         else:
             # Network no longer exists
             self._network = {}
 
     @property
-    def gateways(self):
+    def gateways(self) -> OpenStackGatewaySubService:
         return self._gateway_service
 
 
 class OpenStackSubnet(BaseSubnet):
 
-    def __init__(self, provider, subnet):
+    def __init__(self, provider: OpenStackCloudProvider,
+                 subnet: Any) -> None:
         super(OpenStackSubnet, self).__init__(provider)
         self._subnet = subnet
-        self._state = None
+        self._state: str | None = None
 
     @property
-    def id(self):
+    def id(self) -> str:
         return self._subnet.get('id', None)
 
     @property
-    def name(self):
+    def name(self) -> str:
         return self.id
 
     @property
-    def label(self):
+    def label(self) -> str | None:
         return self._subnet.get('name', None)
 
     @label.setter
-    def label(self, value):  # pylint:disable=arguments-differ
+    def label(self, value: str) -> None:  # pylint:disable=arguments-differ
         """
         Set the subnet label.
         """
         self.assert_valid_resource_label(value)
-        self._provider.neutron.update_subnet(
+        cast("OpenStackCloudProvider", self._provider).neutron.update_subnet(
             self.id, {'subnet': {'name': value or ""}})
         self._subnet['name'] = value
 
     @property
-    def cidr_block(self):
+    def cidr_block(self) -> str:
         return self._subnet.get('cidr', None)
 
     @property
-    def network_id(self):
+    def network_id(self) -> str:
         return self._subnet.get('network_id', None)
 
     @property
-    def zone(self):
+    def zone(self) -> None:
         """
         OpenStack does not have a notion of placement zone for subnets.
 
@@ -963,15 +1034,15 @@ class OpenStackSubnet(BaseSubnet):
         return None
 
     @property
-    def state(self):
+    def state(self) -> str:
         return SubnetState.UNKNOWN if self._state == SubnetState.UNKNOWN \
              else SubnetState.AVAILABLE
 
-    def refresh(self):
+    def refresh(self) -> None:
         subnet = self._provider.networking.subnets.get(self.id)
         if subnet:
             # pylint:disable=protected-access
-            self._subnet = subnet._subnet
+            self._subnet = cast(Any, subnet)._subnet
             self._state = SubnetState.AVAILABLE
         else:
             # subnet no longer exists
@@ -980,117 +1051,121 @@ class OpenStackSubnet(BaseSubnet):
 
 class OpenStackFloatingIP(BaseFloatingIP):
 
-    def __init__(self, provider, floating_ip):
+    def __init__(self, provider: OpenStackCloudProvider,
+                 floating_ip: Any) -> None:
         super(OpenStackFloatingIP, self).__init__(provider)
         self._ip = floating_ip
 
     @property
-    def id(self):
+    def id(self) -> str:
         return self._ip.id
 
     @property
-    def public_ip(self):
+    def public_ip(self) -> str:
         return self._ip.floating_ip_address
 
     @property
-    def private_ip(self):
+    def private_ip(self) -> str | None:
         return self._ip.fixed_ip_address
 
     @property
-    def in_use(self):
+    def in_use(self) -> bool:
         return bool(self._ip.port_id)
 
-    def refresh(self):
-        net = self._provider.networking.networks.get(
-            self._ip.floating_network_id)
+    def refresh(self) -> None:
+        net = cast("OpenStackNetwork", self._provider.networking.networks.get(
+            self._ip.floating_network_id))
         gw = net.gateways.get_or_create()
         fip = gw.floating_ips.get(self.id)
         # pylint:disable=protected-access
-        self._ip = fip._ip
+        self._ip = cast(Any, fip)._ip
 
     @property
-    def _gateway_id(self):
+    def _gateway_id(self) -> str:
         return self._ip.floating_network_id
 
 
 class OpenStackRouter(BaseRouter):
 
-    def __init__(self, provider, router):
+    def __init__(self, provider: OpenStackCloudProvider,
+                 router: Any) -> None:
         super(OpenStackRouter, self).__init__(provider)
         self._router = router
 
     @property
-    def id(self):
-        return getattr(self._router, 'id', None)
+    def id(self) -> str:
+        router_id = getattr(self._router, 'id', None)
+        if router_id is None:
+            raise ProviderInternalException("Router has no id")
+        return router_id
 
     @property
-    def name(self):
+    def name(self) -> str:
         return self.id
 
     @property
-    def label(self):
+    def label(self) -> str | None:
         return self._router.name
 
     @label.setter
-    def label(self, value):  # pylint:disable=arguments-differ
+    def label(self, value: str) -> None:  # pylint:disable=arguments-differ
         """
         Set the router label.
         """
         self.assert_valid_resource_label(value)
-        self._router = self._provider.os_conn.update_router(self.id, value)
+        self._router = cast("OpenStackCloudProvider", self._provider) \
+            .os_conn.update_router(self.id, value)
 
-    def refresh(self):
-        self._router = self._provider.os_conn.get_router(self.id)
+    def refresh(self) -> None:
+        self._router = cast("OpenStackCloudProvider", self._provider) \
+            .os_conn.get_router(self.id)
 
     @property
-    def state(self):
+    def state(self) -> str:
         if self._router.external_gateway_info:
             return RouterState.ATTACHED
         return RouterState.DETACHED
 
     @property
-    def network_id(self):
-        ports = self._provider.os_conn.list_ports(
-            filters={'device_id': self.id})
+    def network_id(self) -> str | None:
+        ports = cast("OpenStackCloudProvider", self._provider).os_conn \
+            .list_ports(filters={'device_id': self.id})
         if ports:
             return ports[0].network_id
         return None
 
-    def attach_subnet(self, subnet):
-        ret = self._provider.os_conn.add_router_interface(
-            self._router.toDict(), subnet.id)
-        if subnet.id in ret.get('subnet_ids', ""):
-            return True
-        return False
+    def attach_subnet(self, subnet: Subnet | str) -> None:
+        subnet_id = subnet.id if isinstance(subnet, OpenStackSubnet) else subnet
+        cast("OpenStackCloudProvider", self._provider).os_conn \
+            .add_router_interface(self._router.toDict(), subnet_id)
 
-    def detach_subnet(self, subnet):
-        ret = self._provider.os_conn.remove_router_interface(
-            self._router.toDict(), subnet.id)
-        if not ret or subnet.id not in ret.get('subnet_ids', ""):
-            return True
-        return False
+    def detach_subnet(self, subnet: Subnet | str) -> None:
+        subnet_id = subnet.id if isinstance(subnet, OpenStackSubnet) else subnet
+        cast("OpenStackCloudProvider", self._provider).os_conn \
+            .remove_router_interface(self._router.toDict(), subnet_id)
 
     @property
-    def subnets(self):
+    def subnets(self) -> list[Subnet]:
         # A router and a subnet are linked via a port, so traverse ports
         # associated with the current router to find a list of subnets
         # associated with it.
-        subnets = []
-        for port in self._provider.os_conn.list_ports(
-                filters={'device_id': self.id}):
+        subnets: list[Subnet | None] = []
+        os_conn = cast("OpenStackCloudProvider", self._provider).os_conn
+        for port in os_conn.list_ports(filters={'device_id': self.id}):
             for fixed_ip in port.fixed_ips:
                 subnets.append(self._provider.networking.subnets.get(
                     fixed_ip.get('subnet_id')))
-        return subnets
+        return cast("list[Subnet]", subnets)
 
-    def attach_gateway(self, gateway):
-        self._provider.os_conn.update_router(
+    def attach_gateway(self, gateway: Gateway) -> None:
+        cast("OpenStackCloudProvider", self._provider).os_conn.update_router(
             self.id, ext_gateway_net_id=gateway.id)
 
-    def detach_gateway(self, gateway):
+    def detach_gateway(self, gateway: Gateway) -> None:
         # TODO: OpenStack SDK Connection object doesn't appear to have a method
         # for detaching/clearing the external gateway.
-        self._provider.neutron.remove_gateway_router(self.id)
+        cast("OpenStackCloudProvider", self._provider).neutron \
+            .remove_gateway_router(self.id)
 
 
 class OpenStackInternetGateway(BaseInternetGateway):
@@ -1103,7 +1178,8 @@ class OpenStackInternetGateway(BaseInternetGateway):
         NetworkState.UNKNOWN: GatewayState.UNKNOWN
     }
 
-    def __init__(self, provider, gateway_net):
+    def __init__(self, provider: OpenStackCloudProvider,
+                 gateway_net: Any) -> None:
         super(OpenStackInternetGateway, self).__init__(provider)
         if isinstance(gateway_net, OpenStackNetwork):
             # pylint:disable=protected-access
@@ -1112,52 +1188,54 @@ class OpenStackInternetGateway(BaseInternetGateway):
         self._fips_container = OpenStackFloatingIPSubService(provider, self)
 
     @property
-    def id(self):
+    def id(self) -> str:
         return self._gateway_net.get('id', None)
 
     @property
-    def name(self):
+    def name(self) -> str:
         return self._gateway_net.get('name', None)
 
     @property
-    def network_id(self):
+    def network_id(self) -> str:
         return self._gateway_net.get('id')
 
-    def refresh(self):
+    def refresh(self) -> None:
         """Refresh the state of this network by re-querying the provider."""
         network = self._provider.networking.networks.get(self.id)
         if network:
             # pylint:disable=protected-access
-            self._gateway_net = network._network
+            self._gateway_net = cast(Any, network)._network
         else:
             # subnet no longer exists
             self._gateway_net.state = NetworkState.UNKNOWN
 
     @property
-    def state(self):
+    def state(self) -> str:
         return self.GATEWAY_STATE_MAP.get(
             self._gateway_net.state, GatewayState.UNKNOWN)
 
     @property
-    def floating_ips(self):
+    def floating_ips(self) -> OpenStackFloatingIPSubService:
         return self._fips_container
 
 
 class OpenStackKeyPair(BaseKeyPair):
 
-    def __init__(self, provider, key_pair):
+    def __init__(self, provider: OpenStackCloudProvider,
+                 key_pair: Any) -> None:
         super(OpenStackKeyPair, self).__init__(provider, key_pair)
 
 
 class OpenStackVMFirewall(BaseVMFirewall):
     _network_id_tag = "CB-auto-associated-network-id: "
 
-    def __init__(self, provider, vm_firewall):
+    def __init__(self, provider: OpenStackCloudProvider,
+                 vm_firewall: Any) -> None:
         super(OpenStackVMFirewall, self).__init__(provider, vm_firewall)
         self._rule_svc = OpenStackVMFirewallRuleSubService(provider, self)
 
     @property
-    def network_id(self):
+    def network_id(self) -> str | None:
         """
         OpenStack does not associate a fw with a network so extract from desc.
 
@@ -1176,11 +1254,11 @@ class OpenStackVMFirewall(BaseVMFirewall):
             return None
 
     @property
-    def _description(self):
+    def _description(self) -> str:
         return self._vm_firewall.description or ""
 
     @property
-    def description(self):
+    def description(self) -> str | None:
         desc_fragment = " [{}{}]".format(self._network_id_tag,
                                          self.network_id)
         desc = self._description
@@ -1190,43 +1268,44 @@ class OpenStackVMFirewall(BaseVMFirewall):
             return None
 
     @description.setter
-    def description(self, value):
+    def description(self, value: str) -> None:
         if not value:
             value = ""
         value += " [{}{}]".format(self._network_id_tag,
                                   self.network_id)
-        self._provider.os_conn.network.update_security_group(
-            self.id, description=value)
+        cast("OpenStackCloudProvider", self._provider).os_conn.network \
+            .update_security_group(self.id, description=value)
         self.refresh()
 
     @property
-    def name(self):
+    def name(self) -> str:
         """
         Return the name of this VM firewall.
         """
         return self.id
 
     @property
-    def label(self):
+    def label(self) -> str | None:
         return self._vm_firewall.name
 
     @label.setter
     # pylint:disable=arguments-differ
-    def label(self, value):
+    def label(self, value: str) -> None:
         self.assert_valid_resource_label(value)
-        self._provider.os_conn.network.update_security_group(
-            self.id, name=value or "")
+        cast("OpenStackCloudProvider", self._provider).os_conn.network \
+            .update_security_group(self.id, name=value or "")
         self.refresh()
 
     @property
-    def rules(self):
+    def rules(self) -> OpenStackVMFirewallRuleSubService:
         return self._rule_svc
 
-    def refresh(self):
-        self._vm_firewall = self._provider.os_conn.network.get_security_group(
-            self.id)
+    def refresh(self) -> None:
+        self._vm_firewall = cast(
+            "OpenStackCloudProvider", self._provider).os_conn.network \
+            .get_security_group(self.id)
 
-    def to_json(self):
+    def to_json(self) -> dict[str, Any]:
         attr = inspect.getmembers(self, lambda a: not (inspect.isroutine(a)))
         js = {k: v for (k, v) in attr if not k.startswith('_')}
         json_rules = [r.to_json() for r in self.rules]
@@ -1236,48 +1315,48 @@ class OpenStackVMFirewall(BaseVMFirewall):
 
 class OpenStackVMFirewallRule(BaseVMFirewallRule):
 
-    def __init__(self, parent_fw, rule):
+    def __init__(self, parent_fw: VMFirewall, rule: Any) -> None:
         super(OpenStackVMFirewallRule, self).__init__(parent_fw, rule)
 
     @property
-    def id(self):
+    def id(self) -> str:
         return self._rule.get('id')
 
     @property
-    def direction(self):
+    def direction(self) -> TrafficDirection:
         direction = self._rule.get('direction')
         if direction == 'ingress':
             return TrafficDirection.INBOUND
         elif direction == 'egress':
             return TrafficDirection.OUTBOUND
-        else:
-            return None
+        raise ProviderInternalException(
+            "Unknown firewall rule direction: {0}".format(direction))
 
     @property
-    def protocol(self):
+    def protocol(self) -> str:
         return self._rule.get('protocol')
 
     @property
-    def from_port(self):
+    def from_port(self) -> int:
         return self._rule.get('port_range_min')
 
     @property
-    def to_port(self):
+    def to_port(self) -> int:
         return self._rule.get('port_range_max')
 
     @property
-    def cidr(self):
+    def cidr(self) -> str | None:
         return self._rule.get('remote_ip_prefix')
 
     @property
-    def src_dest_fw_id(self):
+    def src_dest_fw_id(self) -> str | None:
         fw = self.src_dest_fw
         if fw:
             return fw.id
         return None
 
     @property
-    def src_dest_fw(self):
+    def src_dest_fw(self) -> VMFirewall | None:
         fw_id = self._rule.get('remote_group_id')
         if fw_id:
             return self._provider.security.vm_firewalls.get(fw_id)
@@ -1286,39 +1365,41 @@ class OpenStackVMFirewallRule(BaseVMFirewallRule):
 
 class OpenStackBucketObject(BaseBucketObject):
 
-    def __init__(self, provider, cbcontainer, obj):
+    def __init__(self, provider: OpenStackCloudProvider,
+                 cbcontainer: Any, obj: Any) -> None:
         super(OpenStackBucketObject, self).__init__(provider)
         self.cbcontainer = cbcontainer
         self._obj = obj
 
     @property
-    def id(self):
+    def id(self) -> str:
         return self._obj.get("name")
 
     @property
-    def name(self):
+    def name(self) -> str:
         """Get this object's name."""
         return self.id
 
     @property
-    def size(self):
+    def size(self) -> int:
         return self._obj.get("bytes")
 
     @property
-    def last_modified(self):
+    def last_modified(self) -> str:
         return self._obj.get("last_modified")
 
-    def iter_content(self):
+    def iter_content(self) -> Iterable[bytes]:
         """Returns this object's content as an iterable."""
-        _, content = self._provider.swift.get_object(
-            self.cbcontainer.name, self.name, resp_chunk_size=65536)
+        _, content = cast("OpenStackCloudProvider", self._provider).swift \
+            .get_object(self.cbcontainer.name, self.name, resp_chunk_size=65536)
         return content
 
     @property
-    def bucket(self):
+    def bucket(self) -> Bucket:
         return self.cbcontainer
 
-    def _upload_single_shot(self, data):
+    def _upload_single_shot(
+            self, data: str | bytes | IO[bytes]) -> BucketObject:
         """
         Set the contents of this object in a single request.
 
@@ -1326,10 +1407,12 @@ class OpenStackBucketObject(BaseBucketObject):
         by the base class via the Static Large Object (SLO) multipart path, so
         this single-request path only runs for smaller payloads.
         """
-        self._provider.swift.put_object(self.cbcontainer.name, self.name,
-                                        data)
+        cast("OpenStackCloudProvider", self._provider).swift.put_object(
+            self.cbcontainer.name, self.name, data)
+        return self
 
-    def upload_from_file(self, path, config=None):
+    def upload_from_file(self, path: str,
+                         config: UploadConfig | None = None) -> BucketObject:
         """
         Stores the contents of the file pointed by the ``path`` variable.
         If the file is bigger than 5 Gig, it will be broken into segments.
@@ -1352,25 +1435,25 @@ class OpenStackBucketObject(BaseBucketObject):
 
         .. seealso:: https://github.com/CloudVE/cloudbridge/issues/35#issuecomment-297629661 # noqa
         """
-        upload_options = {}
+        upload_options: dict[str, Any] = {}
         if 'segment_size' not in upload_options:
             if os.path.getsize(path) >= FIVE_GIG:
                 upload_options['segment_size'] = FIVE_GIG
 
         # remap the swift service's connection factory method
         # pylint:disable=protected-access
-        swiftclient.service.get_conn = self._provider._connect_swift
+        swiftclient.service.get_conn = cast(
+            "OpenStackCloudProvider", self._provider)._connect_swift
 
-        result = True
         with SwiftService() as swift:
             upload_object = SwiftUploadObject(path, object_name=self.name)
             for up_res in swift.upload(self.cbcontainer.name,
                                        [upload_object, ],
                                        options=upload_options):
-                result = result and up_res['success']
-        return result
+                up_res['success']
+        return self
 
-    def delete(self):
+    def delete(self) -> None:
         """
         Delete this object.
 
@@ -1384,107 +1467,111 @@ class OpenStackBucketObject(BaseBucketObject):
 
         # remap the swift service's connection factory method
         # pylint:disable=protected-access
-        swiftclient.service.get_conn = self._provider._connect_swift
+        swiftclient.service.get_conn = cast(
+            "OpenStackCloudProvider", self._provider)._connect_swift
 
-        result = True
         with SwiftService() as swift:
             for del_res in swift.delete(self.cbcontainer.name, [self.name, ]):
-                result = result and del_res['success']
-        return result
+                del_res['success']
 
-    def generate_url(self, expires_in, writable=False):
+    def generate_url(self, expires_in: int, writable: bool = False) -> str:
         http_method = "PUT" if writable else "GET"
         # Set a temp url key on the object (http://bit.ly/2NBiXGD)
         temp_url_key = "cloudbridge-tmp-url-key"
-        self._provider.swift.post_account(
+        swift = cast("OpenStackCloudProvider", self._provider).swift
+        swift.post_account(
             headers={"x-account-meta-temp-url-key": temp_url_key})
-        base_url = urlparse(self._provider.swift.get_service_auth()[0])
+        base_url = urlparse(swift.get_service_auth()[0])
         access_point = "{0}://{1}".format(base_url.scheme, base_url.netloc)
         url_path = "/".join([base_url.path, self.cbcontainer.name, self.name])
         return urljoin(access_point, generate_temp_url(url_path, expires_in,
                                                        temp_url_key, http_method))
 
-    def refresh(self):
+    def refresh(self) -> None:
         self._obj = self.cbcontainer.objects.get(self.id)._obj
 
 
 class OpenStackBucket(BaseBucket):
 
-    def __init__(self, provider, bucket):
+    def __init__(self, provider: OpenStackCloudProvider,
+                 bucket: Any) -> None:
         super(OpenStackBucket, self).__init__(provider)
         self._bucket = bucket
         self._object_container = OpenStackBucketObjectSubService(provider,
                                                                  self)
 
     @property
-    def id(self):
+    def id(self) -> str:
         return self._bucket.get("name")
 
     @property
-    def name(self):
+    def name(self) -> str:
         return self.id
 
     @property
-    def objects(self):
+    def objects(self) -> OpenStackBucketObjectSubService:
         return self._object_container
 
 
 class OpenStackDnsZone(BaseDnsZone):
 
-    def __init__(self, provider, dns_zone):
+    def __init__(self, provider: OpenStackCloudProvider,
+                 dns_zone: Any) -> None:
         super(OpenStackDnsZone, self).__init__(provider)
         self._dns_zone = dns_zone
         self._dns_record_container = OpenStackDnsRecordSubService(
             provider, self)
 
     @property
-    def id(self):
+    def id(self) -> str:
         return self._dns_zone.id
 
     @property
-    def name(self):
+    def name(self) -> str:
         return self._dns_zone.name
 
     @property
-    def admin_email(self):
+    def admin_email(self) -> str | None:
         return self._dns_zone.email
 
     @property
-    def records(self):
+    def records(self) -> OpenStackDnsRecordSubService:
         return self._dns_record_container
 
 
 class OpenStackDnsRecord(BaseDnsRecord):
 
-    def __init__(self, provider, dns_zone, dns_record):
+    def __init__(self, provider: OpenStackCloudProvider, dns_zone: Any,
+                 dns_record: Any) -> None:
         super(OpenStackDnsRecord, self).__init__(provider)
         self._dns_zone = dns_zone
         self._dns_rec = dns_record
 
     @property
-    def id(self):
+    def id(self) -> str:
         return self._dns_rec.id
 
     @property
-    def name(self):
+    def name(self) -> str:
         return self._dns_rec.name
 
     @property
-    def zone_id(self):
+    def zone_id(self) -> str:
         return self._dns_zone.id
 
     @property
-    def type(self):
+    def type(self) -> str:
         return self._dns_rec.type
 
     @property
-    def data(self):
+    def data(self) -> list[str]:
         return self._dns_rec.records
 
     @property
-    def ttl(self):
+    def ttl(self) -> int:
         return self._dns_rec.ttl
 
-    def delete(self):
+    def delete(self) -> None:
         # pylint:disable=protected-access
-        return self._provider.dns._records.delete(self._dns_zone, self)
+        records: Any = self._provider.dns._records
+        records.delete(self._dns_zone, self)

--- a/cloudbridge/providers/openstack/services.py
+++ b/cloudbridge/providers/openstack/services.py
@@ -1,9 +1,16 @@
 """
 Services implemented by the OpenStack provider.
 """
+from __future__ import annotations
+
+import builtins
 import json
 import logging
 import uuid
+from typing import Any
+from typing import IO
+from typing import TYPE_CHECKING
+from typing import cast
 
 from neutronclient.common.exceptions import NeutronClientException
 from neutronclient.common.exceptions import PortNotFoundClient
@@ -52,13 +59,29 @@ from cloudbridge.interfaces.exceptions \
     import DuplicateResourceException
 from cloudbridge.interfaces.exceptions import InvalidParamException
 from cloudbridge.interfaces.exceptions import InvalidValueException
+from cloudbridge.interfaces.exceptions import ProviderInternalException
+from cloudbridge.interfaces.resources import Bucket
+from cloudbridge.interfaces.resources import BucketObject
+from cloudbridge.interfaces.resources import DnsRecord
+from cloudbridge.interfaces.resources import DnsZone
+from cloudbridge.interfaces.resources import FloatingIP
+from cloudbridge.interfaces.resources import Gateway
+from cloudbridge.interfaces.resources import Instance
+from cloudbridge.interfaces.resources import InternetGateway
 from cloudbridge.interfaces.resources import KeyPair
+from cloudbridge.interfaces.resources import LaunchConfig
 from cloudbridge.interfaces.resources import MachineImage
+from cloudbridge.interfaces.resources import MultipartUpload
 from cloudbridge.interfaces.resources import Network
+from cloudbridge.interfaces.resources import Region
+from cloudbridge.interfaces.resources import ResultList
+from cloudbridge.interfaces.resources import Router
 from cloudbridge.interfaces.resources import Snapshot
 from cloudbridge.interfaces.resources import Subnet
 from cloudbridge.interfaces.resources import TrafficDirection
+from cloudbridge.interfaces.resources import UploadPart
 from cloudbridge.interfaces.resources import VMFirewall
+from cloudbridge.interfaces.resources import VMFirewallRule
 from cloudbridge.interfaces.resources import VMType
 from cloudbridge.interfaces.resources import Volume
 
@@ -82,16 +105,21 @@ from .resources import OpenStackVMFirewallRule
 from .resources import OpenStackVMType
 from .resources import OpenStackVolume
 
+if TYPE_CHECKING:
+    from cloudbridge.interfaces.provider import CloudProvider
+    from cloudbridge.providers.openstack.provider import OpenStackCloudProvider
+
 log = logging.getLogger(__name__)
 
 
 class OpenStackSecurityService(BaseSecurityService):
 
-    def __init__(self, provider):
+    def __init__(self, provider: CloudProvider) -> None:
         super(OpenStackSecurityService, self).__init__(provider)
 
         # pylint:disable=protected-access
-        self.service_zone_name = self.provider._get_config_value(
+        os_provider = cast("OpenStackCloudProvider", self.provider)
+        self.service_zone_name = os_provider._get_config_value(
             'os_security_zone_name', cb_helpers.get_env(
                 'OS_SECURITY_ZONE_NAME', self.provider.zone_name))
         # Initialize provider services
@@ -100,23 +128,23 @@ class OpenStackSecurityService(BaseSecurityService):
         self._vm_firewall_rule_svc = OpenStackVMFirewallRuleService(provider)
 
     @property
-    def key_pairs(self):
+    def key_pairs(self) -> OpenStackKeyPairService:
         return self._key_pairs
 
     @property
-    def vm_firewalls(self):
+    def vm_firewalls(self) -> OpenStackVMFirewallService:
         return self._vm_firewalls
 
     @property
-    def _vm_firewall_rules(self):
+    def _vm_firewall_rules(self) -> OpenStackVMFirewallRuleService:
         return self._vm_firewall_rule_svc
 
-    def get_or_create_ec2_credentials(self):
+    def get_or_create_ec2_credentials(self) -> Any:
         """
         A provider specific method than returns the ec2 credentials for the
         current user, or creates a new pair if one doesn't exist.
         """
-        keystone = self.provider.keystone
+        keystone = cast("OpenStackCloudProvider", self.provider).keystone
         if hasattr(keystone, 'ec2'):
             user_id = keystone.session.get_user_id()
             user_creds = [cred for cred in keystone.ec2.list(user_id) if
@@ -129,12 +157,12 @@ class OpenStackSecurityService(BaseSecurityService):
 
         return None
 
-    def get_ec2_endpoints(self):
+    def get_ec2_endpoints(self) -> dict[str, Any]:
         """
         A provider specific method than returns the ec2 endpoints if
         available.
         """
-        keystone = self.provider.keystone
+        keystone = cast("OpenStackCloudProvider", self.provider).keystone
         ec2_url = keystone.session.get_endpoint(service_type='ec2')
         s3_url = keystone.session.get_endpoint(service_type='s3')
 
@@ -144,34 +172,37 @@ class OpenStackSecurityService(BaseSecurityService):
 
 class OpenStackKeyPairService(BaseKeyPairService):
 
-    def __init__(self, provider):
+    def __init__(self, provider: CloudProvider) -> None:
         super(OpenStackKeyPairService, self).__init__(provider)
 
     @dispatch(event="provider.security.key_pairs.get",
               priority=BaseKeyPairService.STANDARD_EVENT_PRIORITY)
-    def get(self, key_pair_id):
+    def get(self, key_pair_id: str) -> KeyPair | None:
         """
         Returns a KeyPair given its id.
         """
         log.debug("Returning KeyPair with the id %s", key_pair_id)
+        provider = cast("OpenStackCloudProvider", self.provider)
         try:
             return OpenStackKeyPair(
-                self.provider, self.provider.nova.keypairs.get(key_pair_id))
+                provider, provider.nova.keypairs.get(key_pair_id))
         except NovaNotFound:
             log.debug("KeyPair %s was not found.", key_pair_id)
             return None
 
     @dispatch(event="provider.security.key_pairs.list",
               priority=BaseKeyPairService.STANDARD_EVENT_PRIORITY)
-    def list(self, limit=None, marker=None):
+    def list(self, limit: int | None = None,
+             marker: str | None = None) -> ResultList[KeyPair]:
         """
         List all key pairs associated with this account.
 
         :rtype: ``list`` of :class:`.KeyPair`
         :return:  list of KeyPair objects
         """
-        keypairs = self.provider.nova.keypairs.list()
-        results = [OpenStackKeyPair(self.provider, kp)
+        provider = cast("OpenStackCloudProvider", self.provider)
+        keypairs = provider.nova.keypairs.list()
+        results = [OpenStackKeyPair(provider, kp)
                    for kp in keypairs]
         log.debug("Listing all key pairs associated with OpenStack "
                   "Account: %s", results)
@@ -180,7 +211,7 @@ class OpenStackKeyPairService(BaseKeyPairService):
 
     @dispatch(event="provider.security.key_pairs.find",
               priority=BaseKeyPairService.STANDARD_EVENT_PRIORITY)
-    def find(self, **kwargs):
+    def find(self, **kwargs: Any) -> ResultList[KeyPair]:
         name = kwargs.pop('name', None)
 
         # All kwargs should have been popped at this time.
@@ -189,15 +220,17 @@ class OpenStackKeyPairService(BaseKeyPairService):
                 "Unrecognised parameters for search: %s. Supported "
                 "attributes: %s" % (kwargs, 'name'))
 
-        keypairs = self.provider.nova.keypairs.findall(name=name)
-        results = [OpenStackKeyPair(self.provider, kp)
+        provider = cast("OpenStackCloudProvider", self.provider)
+        keypairs = provider.nova.keypairs.findall(name=name)
+        results = [OpenStackKeyPair(provider, kp)
                    for kp in keypairs]
         log.debug("Searching for %s in: %s", name, keypairs)
         return ClientPagedResultList(self.provider, results)
 
     @dispatch(event="provider.security.key_pairs.create",
               priority=BaseKeyPairService.STANDARD_EVENT_PRIORITY)
-    def create(self, name, public_key_material=None):
+    def create(self, name: str,
+               public_key_material: str | None = None) -> KeyPair:
         OpenStackKeyPair.assert_valid_resource_name(name)
         existing_kp = self.find(name=name)
         if existing_kp:
@@ -208,15 +241,16 @@ class OpenStackKeyPairService(BaseKeyPairService):
         if not public_key_material:
             public_key_material, private_key = cb_helpers.generate_key_pair()
 
-        kp = self.provider.nova.keypairs.create(name,
-                                                public_key=public_key_material)
-        cb_kp = OpenStackKeyPair(self.provider, kp)
+        provider = cast("OpenStackCloudProvider", self.provider)
+        kp = provider.nova.keypairs.create(name,
+                                           public_key=public_key_material)
+        cb_kp = OpenStackKeyPair(provider, kp)
         cb_kp.material = private_key
         return cb_kp
 
     @dispatch(event="provider.security.key_pairs.delete",
               priority=BaseKeyPairService.STANDARD_EVENT_PRIORITY)
-    def delete(self, key_pair):
+    def delete(self, key_pair: KeyPair | str) -> None:
         keypair = (key_pair if isinstance(key_pair, OpenStackKeyPair)
                    else self.get(key_pair))
         if keypair:
@@ -226,27 +260,30 @@ class OpenStackKeyPairService(BaseKeyPairService):
 
 class OpenStackVMFirewallService(BaseVMFirewallService):
 
-    def __init__(self, provider):
+    def __init__(self, provider: CloudProvider) -> None:
         super(OpenStackVMFirewallService, self).__init__(provider)
 
     @dispatch(event="provider.security.vm_firewalls.get",
               priority=BaseVMFirewallService.STANDARD_EVENT_PRIORITY)
-    def get(self, vm_firewall_id):
+    def get(self, vm_firewall_id: str) -> VMFirewall | None:
+        provider = cast("OpenStackCloudProvider", self.provider)
         try:
             return OpenStackVMFirewall(
-                self.provider,
-                self.provider.os_conn.network
-                    .get_security_group(vm_firewall_id))
+                provider,
+                provider.os_conn.network.get_security_group(
+                    vm_firewall_id))
         except (ResourceNotFound, NotFoundException):
             log.debug("Firewall %s not found.", vm_firewall_id)
             return None
 
     @dispatch(event="provider.security.vm_firewalls.list",
               priority=BaseVMFirewallService.STANDARD_EVENT_PRIORITY)
-    def list(self, limit=None, marker=None):
+    def list(self, limit: int | None = None,
+             marker: str | None = None) -> ResultList[VMFirewall]:
+        provider = cast("OpenStackCloudProvider", self.provider)
         firewalls = [
-            OpenStackVMFirewall(self.provider, fw)
-            for fw in self.provider.os_conn.network.security_groups()]
+            OpenStackVMFirewall(provider, fw)
+            for fw in provider.os_conn.network.security_groups()]
 
         return ClientPagedResultList(self.provider, firewalls,
                                      limit=limit, marker=marker)
@@ -254,7 +291,8 @@ class OpenStackVMFirewallService(BaseVMFirewallService):
     @cb_helpers.deprecated_alias(network_id='network')
     @dispatch(event="provider.security.vm_firewalls.create",
               priority=BaseVMFirewallService.STANDARD_EVENT_PRIORITY)
-    def create(self, label, network, description=None):
+    def create(self, label: str, network: Network | str,
+               description: str | None = None) -> VMFirewall:
         OpenStackVMFirewall.assert_valid_resource_label(label)
         net_id = network.id if isinstance(network, Network) else network
         # We generally simulate a network being associated with a firewall
@@ -267,44 +305,51 @@ class OpenStackVMFirewallService(BaseVMFirewallService):
             description = ""
         description += " [{}{}]".format(OpenStackVMFirewall._network_id_tag,
                                         net_id)
-        sg = self.provider.os_conn.network.create_security_group(
+        provider = cast("OpenStackCloudProvider", self.provider)
+        sg = provider.os_conn.network.create_security_group(
             name=label, description=description)
-        if sg:
-            return OpenStackVMFirewall(self.provider, sg)
-        return None
+        # The interface declares create() -> VMFirewall; the SDK always returns
+        # a security group on success, so a None return is not expected here.
+        return OpenStackVMFirewall(provider, sg)
 
     @dispatch(event="provider.security.vm_firewalls.delete",
               priority=BaseVMFirewallService.STANDARD_EVENT_PRIORITY)
-    def delete(self, vm_firewall):
+    def delete(self, vm_firewall: VMFirewall | str) -> None:
         fw = (vm_firewall if isinstance(vm_firewall, OpenStackVMFirewall)
               else self.get(vm_firewall))
         if fw:
             # pylint:disable=protected-access
-            fw._vm_firewall.delete(self.provider.os_conn.network)
+            provider = cast("OpenStackCloudProvider", self.provider)
+            fw._vm_firewall.delete(provider.os_conn.network)
 
 
 class OpenStackVMFirewallRuleService(BaseVMFirewallRuleService):
 
-    def __init__(self, provider):
+    def __init__(self, provider: CloudProvider) -> None:
         super(OpenStackVMFirewallRuleService, self).__init__(provider)
 
     @dispatch(event="provider.security.vm_firewall_rules.list",
               priority=BaseVMFirewallRuleService.STANDARD_EVENT_PRIORITY)
-    def list(self, firewall, limit=None, marker=None):
+    def list(self, firewall: VMFirewall, limit: int | None = None,
+             marker: str | None = None) -> ResultList[VMFirewallRule]:
         # pylint:disable=protected-access
         rules = [OpenStackVMFirewallRule(firewall, r)
-                 for r in firewall._vm_firewall.security_group_rules]
+                 for r in cast(Any, firewall)._vm_firewall
+                 .security_group_rules]
         return ClientPagedResultList(self.provider, rules,
                                      limit=limit, marker=marker)
 
     @dispatch(event="provider.security.vm_firewall_rules.create",
               priority=BaseVMFirewallRuleService.STANDARD_EVENT_PRIORITY)
-    def create(self, firewall, direction, protocol=None, from_port=None,
-               to_port=None, cidr=None, src_dest_fw=None):
+    def create(self, firewall: VMFirewall, direction: TrafficDirection,
+               protocol: str | None = None, from_port: int | None = None,
+               to_port: int | None = None, cidr: str | None = None,
+               src_dest_fw: VMFirewall | None = None) -> VMFirewallRule:
         src_dest_fw_id = (src_dest_fw.id if isinstance(src_dest_fw,
                                                        OpenStackVMFirewall)
                           else src_dest_fw)
 
+        provider = cast("OpenStackCloudProvider", self.provider)
         try:
             if direction == TrafficDirection.INBOUND:
                 os_direction = 'ingress'
@@ -313,7 +358,7 @@ class OpenStackVMFirewallRuleService(BaseVMFirewallRuleService):
             else:
                 raise InvalidValueException("direction", direction)
             # pylint:disable=protected-access
-            rule = self.provider.os_conn.network.create_security_group_rule(
+            rule = provider.os_conn.network.create_security_group_rule(
                 security_group_id=firewall.id,
                 direction=os_direction,
                 port_range_max=to_port,
@@ -321,10 +366,10 @@ class OpenStackVMFirewallRuleService(BaseVMFirewallRuleService):
                 protocol=protocol,
                 remote_ip_prefix=cidr,
                 remote_group_id=src_dest_fw_id)
-            firewall.refresh()
+            cast(Any, firewall).refresh()
             return OpenStackVMFirewallRule(firewall, rule.to_dict())
         except HttpException as e:
-            firewall.refresh()
+            cast(Any, firewall).refresh()
             # 409=Conflict, raised for duplicate rule
             if e.status_code == 409:
                 existing = self.find(firewall, direction=direction,
@@ -337,20 +382,23 @@ class OpenStackVMFirewallRuleService(BaseVMFirewallRuleService):
 
     @dispatch(event="provider.security.vm_firewall_rules.delete",
               priority=BaseVMFirewallRuleService.STANDARD_EVENT_PRIORITY)
-    def delete(self, firewall, rule):
+    def delete(self, firewall: VMFirewall,
+               rule: VMFirewallRule | str) -> None:
         rule_id = (rule.id if isinstance(rule, OpenStackVMFirewallRule)
                    else rule)
-        self.provider.os_conn.network.delete_security_group_rule(rule_id)
-        firewall.refresh()
+        provider = cast("OpenStackCloudProvider", self.provider)
+        provider.os_conn.network.delete_security_group_rule(rule_id)
+        cast(Any, firewall).refresh()
 
 
 class OpenStackStorageService(BaseStorageService):
 
-    def __init__(self, provider):
+    def __init__(self, provider: CloudProvider) -> None:
         super(OpenStackStorageService, self).__init__(provider)
 
         # pylint:disable=protected-access
-        self.service_zone_name = self.provider._get_config_value(
+        os_provider = cast("OpenStackCloudProvider", self.provider)
+        self.service_zone_name = os_provider._get_config_value(
             'os_storage_zone_name', cb_helpers.get_env(
                 'OS_STORAGE_ZONE_NAME', self.provider.zone_name))
         # Initialize provider services
@@ -360,48 +408,49 @@ class OpenStackStorageService(BaseStorageService):
         self._bucket_obj_svc = OpenStackBucketObjectService(self.provider)
 
     @property
-    def volumes(self):
+    def volumes(self) -> OpenStackVolumeService:
         return self._volume_svc
 
     @property
-    def snapshots(self):
+    def snapshots(self) -> OpenStackSnapshotService:
         return self._snapshot_svc
 
     @property
-    def buckets(self):
+    def buckets(self) -> OpenStackBucketService:
         return self._bucket_svc
 
     @property
-    def _bucket_objects(self):
+    def _bucket_objects(self) -> OpenStackBucketObjectService:
         return self._bucket_obj_svc
 
 
 class OpenStackVolumeService(BaseVolumeService):
 
-    def __init__(self, provider):
+    def __init__(self, provider: CloudProvider) -> None:
         super(OpenStackVolumeService, self).__init__(provider)
 
     @dispatch(event="provider.storage.volumes.get",
               priority=BaseVolumeService.STANDARD_EVENT_PRIORITY)
-    def get(self, volume_id):
+    def get(self, volume_id: str) -> Volume | None:
+        provider = cast("OpenStackCloudProvider", self.provider)
         try:
-            os_vol = self.provider.os_conn.block_storage.get_volume(volume_id)
+            os_vol = provider.os_conn.block_storage.get_volume(volume_id)
         except (NotFoundException, ResourceNotFound):
             log.debug("Volume %s was not found.", volume_id)
             return None
-        if os_vol.availability_zone != self.provider.service_zone_name(self):
+        if os_vol.availability_zone != cast("OpenStackCloudProvider", self.provider).service_zone_name(self):
             log.debug("Volume %s was found in availability zone '%s' while the"
                       " OpenStack provider is in zone '%s'",
                       volume_id,
                       os_vol.availability_zone,
-                      self.provider.service_zone_name(self))
+                      cast("OpenStackCloudProvider", self.provider).service_zone_name(self))
             return None
         else:
-            return OpenStackVolume(self.provider, os_vol)
+            return OpenStackVolume(provider, os_vol)
 
     @dispatch(event="provider.storage.volumes.find",
               priority=BaseVolumeService.STANDARD_EVENT_PRIORITY)
-    def find(self, **kwargs):
+    def find(self, **kwargs: Any) -> ResultList[Volume]:
         label = kwargs.pop('label', None)
 
         # All kwargs should have been popped at this time.
@@ -411,20 +460,23 @@ class OpenStackVolumeService(BaseVolumeService):
                 "attributes: %s" % (kwargs, 'label'))
 
         log.debug("Searching for an OpenStack Volume with the label %s", label)
+        provider = cast("OpenStackCloudProvider", self.provider)
         cb_vols = [
-            OpenStackVolume(self.provider, vol)
-            for vol in self.provider.os_conn.block_storage.volumes(
+            OpenStackVolume(provider, vol)
+            for vol in provider.os_conn.block_storage.volumes(
                 name=label,
                 limit=oshelpers.os_result_limit(self.provider),
                 marker=None)
-            if vol.availability_zone == self.provider.service_zone_name(self)]
+            if vol.availability_zone == cast("OpenStackCloudProvider", self.provider).service_zone_name(self)]
         return oshelpers.to_server_paged_list(self.provider, cb_vols)
 
     @dispatch(event="provider.storage.volumes.list",
               priority=BaseVolumeService.STANDARD_EVENT_PRIORITY)
-    def list(self, limit=None, marker=None):
+    def list(self, limit: int | None = None,
+             marker: str | None = None) -> ResultList[Volume]:
+        provider = cast("OpenStackCloudProvider", self.provider)
         try:
-            os_vols = list(self.provider.os_conn.block_storage.volumes(
+            os_vols = list(provider.os_conn.block_storage.volumes(
                 limit=oshelpers.os_result_limit(self.provider, limit),
                 marker=marker))
         except NotFoundException:
@@ -435,54 +487,60 @@ class OpenStackVolumeService(BaseVolumeService):
             # Fall back to a fresh listing.
             if marker is None:
                 raise
-            os_vols = list(self.provider.os_conn.block_storage.volumes(
+            os_vols = list(provider.os_conn.block_storage.volumes(
                 limit=oshelpers.os_result_limit(self.provider, limit)))
-        cb_vols = [OpenStackVolume(self.provider, vol) for vol in os_vols
-                   if vol.availability_zone == self.provider.service_zone_name(self)]
+        cb_vols = [OpenStackVolume(provider, vol) for vol in os_vols
+                   if vol.availability_zone ==
+                   cast("OpenStackCloudProvider", self.provider).service_zone_name(self)]
         return oshelpers.to_server_paged_list(self.provider, cb_vols, limit)
 
     @dispatch(event="provider.storage.volumes.create",
               priority=BaseVolumeService.STANDARD_EVENT_PRIORITY)
-    def create(self, label, size, snapshot=None, description=None):
+    def create(self, label: str, size: int,
+               snapshot: Snapshot | str | None = None,
+               description: str | None = None) -> Volume:
         OpenStackVolume.assert_valid_resource_label(label)
-        zone_name = self.provider.service_zone_name(self)
+        zone_name = cast("OpenStackCloudProvider", self.provider).service_zone_name(self)
         snapshot_id = snapshot.id if isinstance(
             snapshot, OpenStackSnapshot) and snapshot else snapshot
 
-        os_vol = self.provider.os_conn.block_storage.create_volume(
+        provider = cast("OpenStackCloudProvider", self.provider)
+        os_vol = provider.os_conn.block_storage.create_volume(
             size=size, name=label, description=description,
             availability_zone=zone_name, snapshot_id=snapshot_id)
-        return OpenStackVolume(self.provider, os_vol)
+        return OpenStackVolume(provider, os_vol)
 
     @dispatch(event="provider.storage.volumes.delete",
               priority=BaseVolumeService.STANDARD_EVENT_PRIORITY)
-    def delete(self, volume):
+    def delete(self, volume: Volume | str) -> None:
         vol = (volume if isinstance(volume, OpenStackVolume)
                else self.get(volume))
         if vol:
             # pylint:disable=protected-access
-            self.provider.os_conn.block_storage.delete_volume(vol._volume)
+            provider = cast("OpenStackCloudProvider", self.provider)
+            provider.os_conn.block_storage.delete_volume(vol._volume)
 
 
 class OpenStackSnapshotService(BaseSnapshotService):
 
-    def __init__(self, provider):
+    def __init__(self, provider: CloudProvider) -> None:
         super(OpenStackSnapshotService, self).__init__(provider)
 
     @dispatch(event="provider.storage.snapshots.get",
               priority=BaseSnapshotService.STANDARD_EVENT_PRIORITY)
-    def get(self, snapshot_id):
+    def get(self, snapshot_id: str) -> Snapshot | None:
+        provider = cast("OpenStackCloudProvider", self.provider)
         try:
             return OpenStackSnapshot(
-                self.provider,
-                self.provider.os_conn.block_storage.get_snapshot(snapshot_id))
+                provider,
+                provider.os_conn.block_storage.get_snapshot(snapshot_id))
         except (NotFoundException, ResourceNotFound):
             log.debug("Snapshot %s was not found.", snapshot_id)
             return None
 
     @dispatch(event="provider.storage.snapshots.find",
               priority=BaseSnapshotService.STANDARD_EVENT_PRIORITY)
-    def find(self, **kwargs):
+    def find(self, **kwargs: Any) -> ResultList[Snapshot]:
         label = kwargs.pop('label', None)
 
         # All kwargs should have been popped at this time.
@@ -496,9 +554,10 @@ class OpenStackSnapshotService(BaseSnapshotService):
                        'marker': None}
         log.debug("Searching for an OpenStack snapshot with the following "
                   "params: %s", search_opts)
+        provider = cast("OpenStackCloudProvider", self.provider)
         cb_snaps = [
-            OpenStackSnapshot(self.provider, snap) for
-            snap in self.provider.os_conn.block_storage.snapshots(
+            OpenStackSnapshot(provider, snap) for
+            snap in provider.os_conn.block_storage.snapshots(
                 **search_opts)
             if snap.name == label]
 
@@ -506,10 +565,12 @@ class OpenStackSnapshotService(BaseSnapshotService):
 
     @dispatch(event="provider.storage.snapshots.list",
               priority=BaseSnapshotService.STANDARD_EVENT_PRIORITY)
-    def list(self, limit=None, marker=None):
+    def list(self, limit: int | None = None,
+             marker: str | None = None) -> ResultList[Snapshot]:
+        provider = cast("OpenStackCloudProvider", self.provider)
         cb_snaps = [
-            OpenStackSnapshot(self.provider, snap)
-            for snap in self.provider.os_conn.block_storage.snapshots(
+            OpenStackSnapshot(provider, snap)
+            for snap in provider.os_conn.block_storage.snapshots(
                 limit=oshelpers.os_result_limit(self.provider, limit),
                 marker=marker)
         ]
@@ -517,42 +578,46 @@ class OpenStackSnapshotService(BaseSnapshotService):
 
     @dispatch(event="provider.storage.snapshots.create",
               priority=BaseSnapshotService.STANDARD_EVENT_PRIORITY)
-    def create(self, label, volume, description=None):
+    def create(self, label: str, volume: Volume | str,
+               description: str | None = None) -> Snapshot:
         OpenStackSnapshot.assert_valid_resource_label(label)
         volume_id = (volume.id if isinstance(volume, OpenStackVolume)
                      else volume)
 
-        os_snap = self.provider.os_conn.block_storage.create_snapshot(
+        provider = cast("OpenStackCloudProvider", self.provider)
+        os_snap = provider.os_conn.block_storage.create_snapshot(
             volume_id=volume_id, name=label,
             description=description)
-        return OpenStackSnapshot(self.provider, os_snap)
+        return OpenStackSnapshot(provider, os_snap)
 
     @dispatch(event="provider.storage.snapshots.delete",
               priority=BaseSnapshotService.STANDARD_EVENT_PRIORITY)
-    def delete(self, snapshot):
+    def delete(self, snapshot: Snapshot | str) -> None:
         s = (snapshot if isinstance(snapshot, OpenStackSnapshot) else
              self.get(snapshot))
         if s:
             # pylint:disable=protected-access
-            self.provider.os_conn.block_storage.delete_snapshot(s._snapshot)
+            provider = cast("OpenStackCloudProvider", self.provider)
+            provider.os_conn.block_storage.delete_snapshot(s._snapshot)
 
 
 class OpenStackBucketService(BaseBucketService):
 
-    def __init__(self, provider):
+    def __init__(self, provider: CloudProvider) -> None:
         super(OpenStackBucketService, self).__init__(provider)
 
     @dispatch(event="provider.storage.buckets.get",
               priority=BaseBucketService.STANDARD_EVENT_PRIORITY)
-    def get(self, bucket_id):
+    def get(self, bucket_id: str) -> Bucket | None:
         """
         Returns a bucket given its ID. Returns ``None`` if the bucket
         does not exist.
         """
-        _, container_list = self.provider.swift.get_account(
+        provider = cast("OpenStackCloudProvider", self.provider)
+        _, container_list = provider.swift.get_account(
             prefix=bucket_id)
         if container_list:
-            return OpenStackBucket(self.provider,
+            return OpenStackBucket(provider,
                                    next((c for c in container_list
                                          if c['name'] == bucket_id), None))
         else:
@@ -561,7 +626,7 @@ class OpenStackBucketService(BaseBucketService):
 
     @dispatch(event="provider.storage.buckets.find",
               priority=BaseBucketService.STANDARD_EVENT_PRIORITY)
-    def find(self, **kwargs):
+    def find(self, **kwargs: Any) -> ResultList[Bucket]:
         name = kwargs.pop('name', None)
 
         # All kwargs should have been popped at this time.
@@ -569,153 +634,185 @@ class OpenStackBucketService(BaseBucketService):
             raise InvalidParamException(
                 "Unrecognised parameters for search: %s. Supported "
                 "attributes: %s" % (kwargs, 'name'))
-        _, container_list = self.provider.swift.get_account()
-        cb_buckets = [OpenStackBucket(self.provider, c)
+        provider = cast("OpenStackCloudProvider", self.provider)
+        _, container_list = provider.swift.get_account()
+        cb_buckets = [OpenStackBucket(provider, c)
                       for c in container_list
                       if name in c.get("name")]
         return oshelpers.to_server_paged_list(self.provider, cb_buckets)
 
     @dispatch(event="provider.storage.buckets.list",
               priority=BaseBucketService.STANDARD_EVENT_PRIORITY)
-    def list(self, limit=None, marker=None):
-        _, container_list = self.provider.swift.get_account(
+    def list(self, limit: int | None = None,
+             marker: str | None = None) -> ResultList[Bucket]:
+        provider = cast("OpenStackCloudProvider", self.provider)
+        _, container_list = provider.swift.get_account(
             limit=oshelpers.os_result_limit(self.provider, limit),
             marker=marker)
-        cb_buckets = [OpenStackBucket(self.provider, c)
+        cb_buckets = [OpenStackBucket(provider, c)
                       for c in container_list]
         return oshelpers.to_server_paged_list(self.provider, cb_buckets, limit)
 
     @dispatch(event="provider.storage.buckets.create",
               priority=BaseBucketService.STANDARD_EVENT_PRIORITY)
-    def create(self, name, location=None):
+    def create(self, name: str,
+               location: Region | str | None = None) -> Bucket:
         OpenStackBucket.assert_valid_resource_name(name)
+        provider = cast("OpenStackCloudProvider", self.provider)
         location = location or self.provider.region_name
         try:
-            self.provider.swift.head_container(name)
+            provider.swift.head_container(name)
             raise DuplicateResourceException(
                 'Bucket already exists with name {0}'.format(name))
         except SwiftClientException:
-            self.provider.swift.put_container(name)
-            return self.get(name)
+            provider.swift.put_container(name)
+            # The interface declares create() -> Bucket; the container was just
+            # created above, so get() returns it (not None) here.
+            return cast(Bucket, self.get(name))
 
     @dispatch(event="provider.storage.buckets.delete",
               priority=BaseBucketService.STANDARD_EVENT_PRIORITY)
-    def delete(self, bucket):
+    def delete(self, bucket: Bucket | str) -> None:
         b_id = bucket.id if isinstance(bucket, OpenStackBucket) else bucket
-        self.provider.swift.delete_container(b_id)
+        provider = cast("OpenStackCloudProvider", self.provider)
+        provider.swift.delete_container(b_id)
 
 
 class OpenStackBucketObjectService(BaseBucketObjectService):
 
-    def __init__(self, provider):
+    def __init__(self, provider: CloudProvider) -> None:
         super(OpenStackBucketObjectService, self).__init__(provider)
 
-    def get(self, bucket, name):
+    def get(self, bucket: Bucket | str,
+            name: str) -> BucketObject | None:
         """
         Retrieve a given object from this bucket.
         """
         # Swift always returns a reference for the container first,
         # followed by a list containing references to objects.
-        _, object_list = self.provider.swift.get_container(
-            bucket.name, prefix=name)
+        provider = cast("OpenStackCloudProvider", self.provider)
+        _, object_list = provider.swift.get_container(
+            cast(Any, bucket).name, prefix=name)
         # Loop through list of objects looking for an exact name vs. a prefix
         for obj in object_list:
             if obj.get('name') == name:
-                return OpenStackBucketObject(self.provider,
+                return OpenStackBucketObject(provider,
                                              bucket,
                                              obj)
         return None
 
-    def list(self, bucket, limit=None, marker=None, prefix=None):
+    # The interface declares list(bucket, prefix, limit, marker); this impl
+    # orders the optional parameters as (limit, marker, prefix).
+    def list(self, bucket: Bucket | str,  # type: ignore[override]
+             limit: int | None = None, marker: str | None = None,
+             prefix: str | None = None) -> ResultList[BucketObject]:
         """
         List all objects within this bucket.
 
         :rtype: BucketObject
         :return: List of all available BucketObjects within this bucket.
         """
-        _, object_list = self.provider.swift.get_container(
-            bucket.name,
+        provider = cast("OpenStackCloudProvider", self.provider)
+        _, object_list = provider.swift.get_container(
+            cast(Any, bucket).name,
             limit=oshelpers.os_result_limit(self.provider, limit),
             marker=marker, prefix=prefix)
         cb_objects = [OpenStackBucketObject(
-            self.provider, bucket, obj) for obj in object_list]
+                provider, bucket, obj) for obj in object_list]
 
         return oshelpers.to_server_paged_list(
             self.provider,
             cb_objects,
             limit)
 
-    def find(self, bucket, **kwargs):
-        _, obj_list = self.provider.swift.get_container(bucket.name)
-        cb_objs = [OpenStackBucketObject(self.provider, bucket, obj)
+    def find(self, bucket: Bucket | str,
+             **kwargs: Any) -> ResultList[BucketObject]:
+        provider = cast("OpenStackCloudProvider", self.provider)
+        _, obj_list = provider.swift.get_container(cast(Any, bucket).name)
+        cb_objs = [OpenStackBucketObject(provider, bucket, obj)
                    for obj in obj_list]
         filters = ['name']
         matches = cb_helpers.generic_find(filters, kwargs, cb_objs)
         return ClientPagedResultList(self.provider, list(matches))
 
-    def create(self, bucket, object_name):
-        self.provider.swift.put_object(bucket.name, object_name, None)
-        return self.get(bucket, object_name)
+    def create(self, bucket: Bucket | str,
+               object_name: str) -> BucketObject:
+        provider = cast("OpenStackCloudProvider", self.provider)
+        provider.swift.put_object(cast(Any, bucket).name, object_name, None)
+        # The interface declares create() -> BucketObject; the object was just
+        # uploaded above, so get() returns it (not None) here.
+        return cast(BucketObject, self.get(bucket, object_name))
 
     @staticmethod
-    def _segment_prefix(upload):
+    def _segment_prefix(upload: MultipartUpload) -> str:
         return "{0}/slo/{1}/".format(upload.object_name, upload.id)
 
     @classmethod
-    def _segment_name(cls, upload, part_number):
+    def _segment_name(cls, upload: MultipartUpload, part_number: int) -> str:
         return "{0}{1:08d}".format(cls._segment_prefix(upload), part_number)
 
     @dispatch(event="provider.storage._bucket_objects.create_multipart_upload",
               priority=BaseBucketObjectService.STANDARD_EVENT_PRIORITY)
-    def create_multipart_upload(self, bucket, object_name):
+    def create_multipart_upload(self, bucket: Bucket | str,
+                                object_name: str) -> MultipartUpload:
         # Swift has no server-side initiation; the upload id namespaces this
         # upload's Static Large Object segments.
-        return BaseMultipartUpload(self.provider, bucket, object_name,
-                                   uuid.uuid4().hex)
+        return BaseMultipartUpload(self.provider, cast(Bucket, bucket),
+                                   object_name, uuid.uuid4().hex)
 
     @dispatch(event="provider.storage._bucket_objects.upload_part",
               priority=BaseBucketObjectService.STANDARD_EVENT_PRIORITY)
-    def upload_part(self, bucket, upload, part_number, data):
+    def upload_part(self, bucket: Bucket | str, upload: MultipartUpload,
+                    part_number: int, data: bytes | IO[bytes]) -> UploadPart:
         if isinstance(data, str):
             data = data.encode()
         if not isinstance(data, (bytes, bytearray)):
             data = data.read()
         segment_name = self._segment_name(upload, part_number)
-        etag = self.provider.swift.put_object(
-            bucket.name, segment_name, data)
+        provider = cast("OpenStackCloudProvider", self.provider)
+        etag = provider.swift.put_object(
+            cast(Any, bucket).name, segment_name, data)
         # Retain the manifest entry needed to assemble the SLO on complete.
         return BaseUploadPart(part_number, {
-            'path': "/{0}/{1}".format(bucket.name, segment_name),
+            'path': "/{0}/{1}".format(cast(Any, bucket).name, segment_name),
             'etag': etag,
             'size_bytes': len(data)})
 
     @dispatch(event="provider.storage._bucket_objects."
                     "complete_multipart_upload",
               priority=BaseBucketObjectService.STANDARD_EVENT_PRIORITY)
-    def complete_multipart_upload(self, bucket, upload, parts):
+    def complete_multipart_upload(
+            self, bucket: Bucket | str, upload: MultipartUpload,
+            parts: builtins.list[UploadPart]) -> BucketObject:
         ordered = sorted(parts, key=lambda p: p.part_number)
         manifest = [p.etag for p in ordered]
-        self.provider.swift.put_object(
-            bucket.name, upload.object_name, json.dumps(manifest),
+        provider = cast("OpenStackCloudProvider", self.provider)
+        provider.swift.put_object(
+            cast(Any, bucket).name, upload.object_name, json.dumps(manifest),
             query_string='multipart-manifest=put')
-        return self.get(bucket, upload.object_name)
+        # The interface declares this -> BucketObject; the SLO manifest was just
+        # written above, so get() returns it (not None) here.
+        return cast(BucketObject, self.get(bucket, upload.object_name))
 
     @dispatch(event="provider.storage._bucket_objects.abort_multipart_upload",
               priority=BaseBucketObjectService.STANDARD_EVENT_PRIORITY)
-    def abort_multipart_upload(self, bucket, upload):
+    def abort_multipart_upload(self, bucket: Bucket | str,
+                               upload: MultipartUpload) -> None:
         prefix = self._segment_prefix(upload)
-        _, object_list = self.provider.swift.get_container(
-            bucket.name, prefix=prefix)
+        provider = cast("OpenStackCloudProvider", self.provider)
+        _, object_list = provider.swift.get_container(
+            cast(Any, bucket).name, prefix=prefix)
         for obj in object_list:
             try:
-                self.provider.swift.delete_object(bucket.name, obj.get('name'))
+                provider.swift.delete_object(
+                    cast(Any, bucket).name, obj.get('name'))
             except SwiftClientException:
                 pass  # idempotent: ignore already-deleted segments
 
 
 class OpenStackComputeService(BaseComputeService):
 
-    def __init__(self, provider):
+    def __init__(self, provider: CloudProvider) -> None:
         super(OpenStackComputeService, self).__init__(provider)
         self._vm_type_svc = OpenStackVMTypeService(self.provider)
         self._instance_svc = OpenStackInstanceService(self.provider)
@@ -723,84 +820,94 @@ class OpenStackComputeService(BaseComputeService):
         self._images_svc = OpenStackImageService(self.provider)
         # Region service must be defined before invoking the following
         # pylint:disable=protected-access
-        self.service_zone_name = self.provider._get_config_value(
+        os_provider = cast("OpenStackCloudProvider", self.provider)
+        self.service_zone_name = os_provider._get_config_value(
             'os_compute_zone_name',
             cb_helpers.get_env(
                 'OS_COMPUTE_ZONE_NAME',
-                self.provider._zone_name or
-                self.regions.current.default_zone.name))
+                os_provider._zone_name or
+                cast(Any, self.regions.current).default_zone.name))
 
     @property
-    def images(self):
+    def images(self) -> OpenStackImageService:
         return self._images_svc
 
     @property
-    def vm_types(self):
+    def vm_types(self) -> OpenStackVMTypeService:
         return self._vm_type_svc
 
     @property
-    def instances(self):
+    def instances(self) -> OpenStackInstanceService:
         return self._instance_svc
 
     @property
-    def regions(self):
+    def regions(self) -> OpenStackRegionService:
         return self._region_svc
 
 
 class OpenStackImageService(BaseImageService):
 
-    def __init__(self, provider):
+    def __init__(self, provider: CloudProvider) -> None:
         super(OpenStackImageService, self).__init__(provider)
 
-    def get(self, image_id):
+    def get(self, image_id: str) -> MachineImage | None:
         """
         Returns an Image given its id
         """
         log.debug("Getting OpenStack Image with the id: %s", image_id)
+        provider = cast("OpenStackCloudProvider", self.provider)
         try:
             return OpenStackMachineImage(
-                self.provider, self.provider.os_conn.image.get_image(image_id))
+                provider, provider.os_conn.image.get_image(image_id))
         except (NotFoundException, ResourceNotFound):
             log.debug("Image %s not found", image_id)
             return None
 
-    def find(self, **kwargs):
+    def find(self, **kwargs: Any) -> ResultList[MachineImage]:
         filters = ['label']
-        obj_list = self
-        return cb_helpers.generic_find(filters, kwargs, obj_list)
+        obj_list = list(self)
+        matches = cb_helpers.generic_find(filters, kwargs, obj_list)
+        return ClientPagedResultList(self.provider, list(matches))
 
-    def list(self, filter_by_owner=True, limit=None, marker=None):
+    # Intentionally extends the base list() with a leading filter_by_owner
+    # parameter (matches the interface's documented arguments-differ override).
+    def list(self,  # type: ignore[override]
+             filter_by_owner: bool = True, limit: int | None = None,
+             marker: str | None = None) -> ResultList[MachineImage]:
         """
         List all images.
         """
         project_id = None
+        provider = cast("OpenStackCloudProvider", self.provider)
         if filter_by_owner:
-            project_id = self.provider.os_conn.session.get_project_id()
-        os_images = self.provider.os_conn.image.images(
+            project_id = provider.os_conn.session.get_project_id()
+        os_images = provider.os_conn.image.images(
             owner=project_id,
             limit=oshelpers.os_result_limit(self.provider, limit),
             marker=marker)
 
         cb_images = [
-            OpenStackMachineImage(self.provider, img)
+            OpenStackMachineImage(provider, img)
             for img in os_images]
         return oshelpers.to_server_paged_list(self.provider, cb_images, limit)
 
 
 class OpenStackInstanceService(BaseInstanceService):
 
-    def __init__(self, provider):
+    def __init__(self, provider: CloudProvider) -> None:
         super(OpenStackInstanceService, self).__init__(provider)
 
-    def _to_block_device_mapping(self, launch_config):
+    def _to_block_device_mapping(
+            self, launch_config: LaunchConfig) -> builtins.list[
+                dict[str, Any]]:
         """
         Extracts block device mapping information
         from a launch config and constructs a BlockDeviceMappingV2
         object.
         """
         bdm = []
-        for device in launch_config.block_devices:
-            bdm_dict = dict()
+        for device in cast(Any, launch_config).block_devices:
+            bdm_dict: dict[str, Any] = dict()
 
             if device.is_volume:
                 bdm_dict['destination_type'] = 'volume'
@@ -833,22 +940,27 @@ class OpenStackInstanceService(BaseInstanceService):
             bdm.append(bdm_dict)
         return bdm
 
-    def _has_root_device(self, launch_config):
+    def _has_root_device(self, launch_config: LaunchConfig | None) -> bool:
         if not launch_config:
             return False
-        for device in launch_config.block_devices:
+        for device in cast(Any, launch_config).block_devices:
             if device.is_root:
                 return True
         return False
 
-    def create_launch_config(self):
+    def create_launch_config(self) -> LaunchConfig:
         return BaseLaunchConfig(self.provider)
 
     @dispatch(event="provider.compute.instances.create",
               priority=BaseInstanceService.STANDARD_EVENT_PRIORITY)
-    def create(self, label, image, vm_type, subnet,
-               key_pair=None, vm_firewalls=None, user_data=None,
-               launch_config=None, **kwargs):
+    def create(self, label: str, image: MachineImage | str,
+               vm_type: VMType | str, subnet: Subnet | str,
+               key_pair: KeyPair | str | None = None,
+               vm_firewalls: builtins.list[VMFirewall] |
+               builtins.list[str] | None = None,
+               user_data: str | None = None,
+               launch_config: LaunchConfig | None = None,
+               **kwargs: Any) -> Instance:
         OpenStackInstance.assert_valid_resource_label(label)
         image_id = image.id if isinstance(image, MachineImage) else image
         if isinstance(vm_type, VMType):
@@ -859,32 +971,35 @@ class OpenStackInstanceService(BaseInstanceService):
                 raise CloudBridgeBaseException(
                     "Could not find vm type with name {0}".format(vm_type))
             vm_size = vm_type_obj[0].id
+        net_id: str | None
         if isinstance(subnet, Subnet):
             subnet_id = subnet.id
             net_id = subnet.network_id
         else:
             subnet_id = subnet
-            net_id = (self.provider.networking.subnets
-                      .get(subnet_id).network_id
+            net_id = (cast(Any, self.provider.networking.subnets
+                           .get(subnet_id)).network_id
                       if subnet_id else None)
-        zone_name = self.provider.service_zone_name(self)
+        os_provider = cast("OpenStackCloudProvider", self.provider)
+        zone_name = os_provider.service_zone_name(self)
         key_pair_name = key_pair.name if \
             isinstance(key_pair, KeyPair) else key_pair
         bdm = None
         if launch_config:
             bdm = self._to_block_device_mapping(launch_config)
 
+        provider = cast("OpenStackCloudProvider", self.provider)
         # Security groups must be passed in as a list of IDs and attached to a
         # port if a port is being created. Otherwise, the security groups must
         # be passed in as a list of names to the servers.create() call.
         # OpenStack will respect the port's security groups first and then
         # fall-back to the named security groups.
-        sg_name_list = []
+        sg_name_list: Any = []
         nics = None
         if subnet_id:
             log.debug("Creating network port for %s in subnet: %s",
                       label, subnet_id)
-            sg_list = []
+            sg_list: Any = []
             if vm_firewalls:
                 if isinstance(vm_firewalls, list) and \
                         isinstance(vm_firewalls[0], VMFirewall):
@@ -904,20 +1019,21 @@ class OpenStackInstanceService(BaseInstanceService):
                     "security_groups": sg_id_list
                 }
             }
-            port_id = self.provider.neutron.create_port(port_def)['port']['id']
+            port_id = provider.neutron.create_port(port_def)['port']['id']
             nics = [{'net-id': net_id, 'port-id': port_id}]
         else:
             if vm_firewalls:
                 if isinstance(vm_firewalls, list) and \
                         isinstance(vm_firewalls[0], VMFirewall):
-                    sg_name_list = [sg.name for sg in vm_firewalls]
+                    sg_name_list = [sg.name for sg in
+                                    cast("list[VMFirewall]", vm_firewalls)]
                 else:
                     sg_list = (self.provider.security.vm_firewalls.get(sg)
-                               for sg in vm_firewalls)
+                               for sg in cast("list[str]", vm_firewalls))
                     sg_name_list = (sg[0].name for sg in sg_list if sg)
 
         log.debug("Launching in subnet %s", subnet_id)
-        os_instance = self.provider.nova.servers.create(
+        os_instance = provider.nova.servers.create(
             label,
             None if self._has_root_device(launch_config) else image_id,
             vm_size,
@@ -929,11 +1045,11 @@ class OpenStackInstanceService(BaseInstanceService):
             userdata=str(user_data) or None,
             block_device_mapping_v2=bdm,
             nics=nics)
-        return OpenStackInstance(self.provider, os_instance)
+        return OpenStackInstance(provider, os_instance)
 
     @dispatch(event="provider.compute.instances.find",
               priority=BaseInstanceService.STANDARD_EVENT_PRIORITY)
-    def find(self, **kwargs):
+    def find(self, **kwargs: Any) -> ResultList[Instance]:
         label = kwargs.pop('label', None)
 
         # All kwargs should have been popped at this time.
@@ -942,12 +1058,12 @@ class OpenStackInstanceService(BaseInstanceService):
                 "Unrecognised parameters for search: %s. Supported "
                 "attributes: %s" % (kwargs, 'label'))
 
+        provider = cast("OpenStackCloudProvider", self.provider)
         search_opts = {'name': label,
-                       'availability_zone': self.provider
-                                                .service_zone_name(self)}
+                       'availability_zone': provider.service_zone_name(self)}
         cb_insts = [
-            OpenStackInstance(self.provider, inst)
-            for inst in self.provider.nova.servers.list(
+            OpenStackInstance(provider, inst)
+            for inst in provider.nova.servers.list(
                 search_opts=search_opts,
                 limit=oshelpers.os_result_limit(self.provider),
                 marker=None)]
@@ -955,15 +1071,16 @@ class OpenStackInstanceService(BaseInstanceService):
 
     @dispatch(event="provider.compute.instances.list",
               priority=BaseInstanceService.STANDARD_EVENT_PRIORITY)
-    def list(self, limit=None, marker=None):
+    def list(self, limit: int | None = None,
+             marker: str | None = None) -> ResultList[Instance]:
         """
         List all instances.
         """
-        search_opts = {'availability_zone': self.provider
-                                                .service_zone_name(self)}
+        provider = cast("OpenStackCloudProvider", self.provider)
+        search_opts = {'availability_zone': provider.service_zone_name(self)}
         cb_insts = [
-            OpenStackInstance(self.provider, inst)
-            for inst in self.provider.nova.servers.list(
+            OpenStackInstance(provider, inst)
+            for inst in provider.nova.servers.list(
                 search_opts=search_opts,
                 limit=oshelpers.os_result_limit(self.provider, limit),
                 marker=marker)]
@@ -971,29 +1088,30 @@ class OpenStackInstanceService(BaseInstanceService):
 
     @dispatch(event="provider.compute.instances.get",
               priority=BaseInstanceService.STANDARD_EVENT_PRIORITY)
-    def get(self, instance_id):
+    def get(self, instance_id: str) -> Instance | None:
         """
         Returns an instance given its id.
         """
+        provider = cast("OpenStackCloudProvider", self.provider)
         try:
-            os_instance = self.provider.nova.servers.get(instance_id)
+            os_instance = provider.nova.servers.get(instance_id)
         except NovaNotFound:
             log.debug("Instance %s was not found.", instance_id)
             return None
         if (getattr(os_instance,
                     'OS-EXT-AZ:availability_zone', "")
-                != self.provider.service_zone_name(self)):
+                != cast("OpenStackCloudProvider", self.provider).service_zone_name(self)):
             log.debug("Instance %s was found in availability zone '%s' while "
                       "the OpenStack provider is in zone '%s'",
                       instance_id,
                       getattr(os_instance, 'OS-EXT-AZ:availability_zone', ""),
-                      self.provider.service_zone_name(self))
+                      cast("OpenStackCloudProvider", self.provider).service_zone_name(self))
             return None
-        return OpenStackInstance(self.provider, os_instance)
+        return OpenStackInstance(provider, os_instance)
 
     @dispatch(event="provider.compute.instances.delete",
               priority=BaseInstanceService.STANDARD_EVENT_PRIORITY)
-    def delete(self, instance):
+    def delete(self, instance: Instance | str) -> None:
         ins = (instance if isinstance(instance, OpenStackInstance) else
                self.get(instance))
         if ins:
@@ -1001,10 +1119,11 @@ class OpenStackInstanceService(BaseInstanceService):
             os_instance = ins._os_instance
             # delete the port we created when launching
             # Assumption: it's the first interface in the list
+            provider = cast("OpenStackCloudProvider", self.provider)
             iface_list = os_instance.interface_list()
             if iface_list:
                 with cb_helpers.cleanup_action(
-                        lambda: self.provider.neutron.delete_port(
+                        lambda: provider.neutron.delete_port(
                             iface_list[0].port_id)):
                     # Ignore errors if port can't be deleted
                     pass
@@ -1013,15 +1132,17 @@ class OpenStackInstanceService(BaseInstanceService):
 
 class OpenStackVMTypeService(BaseVMTypeService):
 
-    def __init__(self, provider):
+    def __init__(self, provider: CloudProvider) -> None:
         super(OpenStackVMTypeService, self).__init__(provider)
 
     @dispatch(event="provider.compute.vm_types.list",
               priority=BaseVMTypeService.STANDARD_EVENT_PRIORITY)
-    def list(self, limit=None, marker=None):
+    def list(self, limit: int | None = None,
+             marker: str | None = None) -> ResultList[VMType]:
+        provider = cast("OpenStackCloudProvider", self.provider)
         cb_itypes = [
-            OpenStackVMType(self.provider, obj)
-            for obj in self.provider.nova.flavors.list(
+            OpenStackVMType(provider, obj)
+            for obj in provider.nova.flavors.list(
                 limit=oshelpers.os_result_limit(self.provider, limit),
                 marker=marker)]
 
@@ -1030,23 +1151,25 @@ class OpenStackVMTypeService(BaseVMTypeService):
 
 class OpenStackRegionService(BaseRegionService):
 
-    def __init__(self, provider):
+    def __init__(self, provider: CloudProvider) -> None:
         super(OpenStackRegionService, self).__init__(provider)
 
     @dispatch(event="provider.compute.regions.get",
               priority=BaseRegionService.STANDARD_EVENT_PRIORITY)
-    def get(self, region_id):
+    def get(self, region_id: str) -> Region | None:
         log.debug("Getting OpenStack Region with the id: %s", region_id)
         region = (r for r in self if r.id == region_id)
         return next(region, None)
 
     @dispatch(event="provider.compute.regions.list",
               priority=BaseRegionService.STANDARD_EVENT_PRIORITY)
-    def list(self, limit=None, marker=None):
+    def list(self, limit: int | None = None,
+             marker: str | None = None) -> ResultList[Region]:
         # pylint:disable=protected-access
-        if self.provider._keystone_version == 3:
-            os_regions = [OpenStackRegion(self.provider, region)
-                          for region in self.provider.keystone.regions.list()]
+        provider = cast("OpenStackCloudProvider", self.provider)
+        if provider._keystone_version == 3:
+            os_regions = [OpenStackRegion(provider, region)
+                          for region in provider.keystone.regions.list()]
             return ClientPagedResultList(self.provider, os_regions,
                                          limit=limit, marker=marker)
         else:
@@ -1054,28 +1177,30 @@ class OpenStackRegionService(BaseRegionService):
             # but for v2, this convoluted method is necessary.
             regions = (
                 endpoint.get('region') or endpoint.get('region_id')
-                for svc in self.provider.keystone.service_catalog.get_data()
+                for svc in provider.keystone.service_catalog.get_data()
                 for endpoint in svc.get('endpoints', [])
             )
-            regions = set(region for region in regions if region)
-            os_regions = [OpenStackRegion(self.provider, region)
-                          for region in regions]
+            unique_regions = set(region for region in regions if region)
+            os_regions = [OpenStackRegion(provider, region)
+                          for region in unique_regions]
 
             return ClientPagedResultList(self.provider, os_regions,
                                          limit=limit, marker=marker)
 
     @property
-    def current(self):
-        nova_region = self.provider.nova.client.region_name
+    def current(self) -> Region | None:
+        provider = cast("OpenStackCloudProvider", self.provider)
+        nova_region = provider.nova.client.region_name
         return self.get(nova_region) if nova_region else None
 
 
 class OpenStackNetworkingService(BaseNetworkingService):
 
-    def __init__(self, provider):
+    def __init__(self, provider: CloudProvider) -> None:
         super(OpenStackNetworkingService, self).__init__(provider)
         # pylint:disable=protected-access
-        self.service_zone_name = self.provider._get_config_value(
+        os_provider = cast("OpenStackCloudProvider", self.provider)
+        self.service_zone_name = os_provider._get_config_value(
             'os_networking_zone_name', cb_helpers.get_env(
                 'OS_NETWORKING_ZONE_NAME', self.provider.zone_name))
         self._network_service = OpenStackNetworkService(self.provider)
@@ -1085,147 +1210,163 @@ class OpenStackNetworkingService(BaseNetworkingService):
         self._floating_ip_service = OpenStackFloatingIPService(self.provider)
 
     @property
-    def networks(self):
+    def networks(self) -> OpenStackNetworkService:
         return self._network_service
 
     @property
-    def subnets(self):
+    def subnets(self) -> OpenStackSubnetService:
         return self._subnet_service
 
     @property
-    def routers(self):
+    def routers(self) -> OpenStackRouterService:
         return self._router_service
 
     @property
-    def _gateways(self):
+    def _gateways(self) -> OpenStackGatewayService:
         return self._gateway_service
 
     @property
-    def _floating_ips(self):
+    def _floating_ips(self) -> OpenStackFloatingIPService:
         return self._floating_ip_service
 
 
 class OpenStackNetworkService(BaseNetworkService):
 
-    def __init__(self, provider):
+    def __init__(self, provider: CloudProvider) -> None:
         super(OpenStackNetworkService, self).__init__(provider)
 
     @dispatch(event="provider.networking.networks.get",
               priority=BaseNetworkService.STANDARD_EVENT_PRIORITY)
-    def get(self, network_id):
+    def get(self, network_id: str) -> Network | None:
         network = (n for n in self if n.id == network_id)
         return next(network, None)
 
     @dispatch(event="provider.networking.networks.list",
               priority=BaseNetworkService.STANDARD_EVENT_PRIORITY)
-    def list(self, limit=None, marker=None):
-        networks = [OpenStackNetwork(self.provider, network)
-                    for network in self.provider.neutron.list_networks()
+    def list(self, limit: int | None = None,
+             marker: str | None = None) -> ResultList[Network]:
+        provider = cast("OpenStackCloudProvider", self.provider)
+        networks = [OpenStackNetwork(provider, network)
+                    for network in provider.neutron.list_networks()
                     .get('networks') if network
                     # If there are no availability zones, keep the network
                     # in the results list
                     and (not network.get('availability_zones')
-                         or self.provider.service_zone_name(self)
+                         or cast("OpenStackCloudProvider", self.provider).service_zone_name(self)
                          in network.get('availability_zones'))]
         return ClientPagedResultList(self.provider, networks,
                                      limit=limit, marker=marker)
 
     @dispatch(event="provider.networking.networks.find",
               priority=BaseNetworkService.STANDARD_EVENT_PRIORITY)
-    def find(self, **kwargs):
-        obj_list = self
+    def find(self, **kwargs: Any) -> ResultList[Network]:
+        obj_list = list(self)
         filters = ['label']
         matches = cb_helpers.generic_find(filters, kwargs, obj_list)
         return ClientPagedResultList(self._provider, list(matches))
 
     @dispatch(event="provider.networking.networks.create",
               priority=BaseNetworkService.STANDARD_EVENT_PRIORITY)
-    def create(self, label, cidr_block):
+    def create(self, label: str, cidr_block: str) -> Network:
         OpenStackNetwork.assert_valid_resource_label(label)
         net_info = {'name': label or ""}
-        network = self.provider.neutron.create_network({'network': net_info})
-        cb_net = OpenStackNetwork(self.provider, network.get('network'))
+        provider = cast("OpenStackCloudProvider", self.provider)
+        network = provider.neutron.create_network({'network': net_info})
+        cb_net = OpenStackNetwork(provider, network.get('network'))
         return cb_net
 
     @dispatch(event="provider.networking.networks.delete",
               priority=BaseNetworkService.STANDARD_EVENT_PRIORITY)
-    def delete(self, network):
+    def delete(self, network: Network | str) -> None:
         network = (network if isinstance(network, OpenStackNetwork) else
                    self.get(network))
         if not network:
             return
+        provider = cast("OpenStackCloudProvider", self.provider)
         if not network.external and network.id in str(
-                self.provider.neutron.list_networks()):
+                provider.neutron.list_networks()):
             # If there are ports associated with the network, it won't delete
-            ports = self.provider.neutron.list_ports(
+            ports = provider.neutron.list_ports(
                 network_id=network.id).get('ports', [])
             for port in ports:
                 try:
-                    self.provider.neutron.delete_port(port.get('id'))
+                    provider.neutron.delete_port(port.get('id'))
                 except PortNotFoundClient:
                     # Ports could have already been deleted if instances
                     # are terminated etc. so exceptions can be safely ignored
                     pass
-            self.provider.neutron.delete_network(network.id)
+            provider.neutron.delete_network(network.id)
 
 
 class OpenStackSubnetService(BaseSubnetService):
 
-    def __init__(self, provider):
+    def __init__(self, provider: CloudProvider) -> None:
         super(OpenStackSubnetService, self).__init__(provider)
 
     @dispatch(event="provider.networking.subnets.get",
               priority=BaseSubnetService.STANDARD_EVENT_PRIORITY)
-    def get(self, subnet_id):
+    def get(self, subnet_id: str) -> Subnet | None:
         subnet = (s for s in self if s.id == subnet_id)
         return next(subnet, None)
 
     @dispatch(event="provider.networking.subnets.list",
               priority=BaseSubnetService.STANDARD_EVENT_PRIORITY)
-    def list(self, network=None, limit=None, marker=None):
+    def list(self, network: Network | str | None = None,
+             limit: int | None = None,
+             marker: str | None = None) -> ResultList[Subnet]:
+        provider = cast("OpenStackCloudProvider", self.provider)
         if network:
             network_id = (network.id if isinstance(network, OpenStackNetwork)
                           else network)
             subnets = [subnet for subnet in self if network_id ==
                        subnet.network_id]
         else:
-            subnets = [OpenStackSubnet(self.provider, subnet) for subnet in
-                       self.provider.neutron.list_subnets().get('subnets', [])]
+            subnets = [OpenStackSubnet(provider, subnet) for subnet in
+                       provider.neutron.list_subnets().get('subnets', [])]
         return ClientPagedResultList(self.provider, subnets,
                                      limit=limit, marker=marker)
 
     @dispatch(event="provider.networking.subnets.create",
               priority=BaseSubnetService.STANDARD_EVENT_PRIORITY)
-    def create(self, label, network, cidr_block):
+    def create(self, label: str, network: Network | str,
+               cidr_block: str) -> Subnet:
         OpenStackSubnet.assert_valid_resource_label(label)
         network_id = (network.id if isinstance(network, OpenStackNetwork)
                       else network)
         subnet_info = {'name': label, 'network_id': network_id,
                        'cidr': cidr_block, 'ip_version': 4}
-        subnet = (self.provider.neutron.create_subnet({'subnet': subnet_info})
+        provider = cast("OpenStackCloudProvider", self.provider)
+        subnet = (provider.neutron.create_subnet({'subnet': subnet_info})
                   .get('subnet'))
-        cb_subnet = OpenStackSubnet(self.provider, subnet)
+        cb_subnet = OpenStackSubnet(provider, subnet)
         return cb_subnet
 
     @dispatch(event="provider.networking.subnets.delete",
               priority=BaseSubnetService.STANDARD_EVENT_PRIORITY)
-    def delete(self, subnet):
+    def delete(self, subnet: Subnet | str) -> None:
         sn_id = subnet.id if isinstance(subnet, OpenStackSubnet) else subnet
-        self.provider.neutron.delete_subnet(sn_id)
+        provider = cast("OpenStackCloudProvider", self.provider)
+        provider.neutron.delete_subnet(sn_id)
 
-    def get_or_create_default(self):
+    # The base declares -> Subnet, but this impl can return None when the
+    # default subnet cannot be found or created (NeutronClientException).
+    def get_or_create_default(self) -> Subnet | None:  # type: ignore[override]
         try:
-            sn = self.find(label=OpenStackSubnet.CB_DEFAULT_SUBNET_LABEL)
-            if sn:
-                return sn[0]
+            existing = self.find(
+                label=OpenStackSubnet.CB_DEFAULT_SUBNET_LABEL)
+            if existing:
+                return existing[0]
             # No default subnet look for default network, then create subnet
-            net = self.provider.networking.networks.get_or_create_default()
+            # get_or_create_default is only on the base services, not the
+            # public NetworkService/RouterService interface; access via Any.
+            net = cast(Any, self.provider.networking
+                       .networks).get_or_create_default()
             sn = self.provider.networking.subnets.create(
                 label=OpenStackSubnet.CB_DEFAULT_SUBNET_LABEL,
                 cidr_block=OpenStackSubnet.CB_DEFAULT_SUBNET_IPV4RANGE,
                 network=net)
-            router = self.provider.networking.routers.get_or_create_default(
-                net)
+            router = cast(Any, self.provider.networking
+                          .routers).get_or_create_default(net)
             router.attach_subnet(sn)
             gateway = net.gateways.get_or_create()
             router.attach_gateway(gateway)
@@ -1236,113 +1377,127 @@ class OpenStackSubnetService(BaseSubnetService):
 
 class OpenStackRouterService(BaseRouterService):
 
-    def __init__(self, provider):
+    def __init__(self, provider: CloudProvider) -> None:
         super(OpenStackRouterService, self).__init__(provider)
 
     @dispatch(event="provider.networking.routers.get",
               priority=BaseRouterService.STANDARD_EVENT_PRIORITY)
-    def get(self, router_id):
-        router = self.provider.os_conn.get_router(router_id)
+    def get(self, router_id: str) -> Router | None:
+        provider = cast("OpenStackCloudProvider", self.provider)
+        router = provider.os_conn.get_router(router_id)
         if not router:
             log.debug("Router %s was not found.", router_id)
             return None
-        elif router.availability_zones and self.provider.service_zone_name(self) \
+        elif router.availability_zones and \
+                cast("OpenStackCloudProvider", self.provider).service_zone_name(self) \
                 not in router.availability_zones:
             log.debug("Router %s was found in availability zone '%s' while the"
                       " OpenStack provider is in zone '%s'",
                       router_id,
                       router.availability_zones,
-                      self.provider.service_zone_name(self))
+                      cast("OpenStackCloudProvider", self.provider).service_zone_name(self))
             return None
-        return OpenStackRouter(self.provider, router)
+        return OpenStackRouter(provider, router)
 
     @dispatch(event="provider.networking.routers.list",
               priority=BaseRouterService.STANDARD_EVENT_PRIORITY)
-    def list(self, limit=None, marker=None):
-        routers = self.provider.os_conn.list_routers()
-        os_routers = [OpenStackRouter(self.provider, r) for r in routers
+    def list(self, limit: int | None = None,
+             marker: str | None = None) -> ResultList[Router]:
+        provider = cast("OpenStackCloudProvider", self.provider)
+        routers = provider.os_conn.list_routers()
+        os_routers = [OpenStackRouter(provider, r) for r in routers
                       if not r.availability_zones or
-                      self.provider.service_zone_name(self)
+                      cast("OpenStackCloudProvider", self.provider).service_zone_name(self)
                       in r.availability_zones]
         return ClientPagedResultList(self.provider, os_routers, limit=limit,
                                      marker=marker)
 
     @dispatch(event="provider.networking.routers.find",
               priority=BaseRouterService.STANDARD_EVENT_PRIORITY)
-    def find(self, **kwargs):
-        obj_list = self
+    def find(self, **kwargs: Any) -> ResultList[Router]:
+        obj_list = list(self)
         filters = ['label']
         matches = cb_helpers.generic_find(filters, kwargs, obj_list)
         return ClientPagedResultList(self._provider, list(matches))
 
     @dispatch(event="provider.networking.routers.create",
               priority=BaseRouterService.STANDARD_EVENT_PRIORITY)
-    def create(self, label, network):
+    def create(self, label: str, network: Network | str) -> Router:
         """Parameter ``network`` is not used by OpenStack."""
-        router = self.provider.os_conn.create_router(name=label)
-        return OpenStackRouter(self.provider, router)
+        provider = cast("OpenStackCloudProvider", self.provider)
+        router = provider.os_conn.create_router(name=label)
+        return OpenStackRouter(provider, router)
 
     @dispatch(event="provider.networking.routers.delete",
               priority=BaseRouterService.STANDARD_EVENT_PRIORITY)
-    def delete(self, router):
+    def delete(self, router: Router | str) -> None:
         r_id = router.id if isinstance(router, OpenStackRouter) else router
-        self.provider.os_conn.delete_router(r_id)
+        provider = cast("OpenStackCloudProvider", self.provider)
+        provider.os_conn.delete_router(r_id)
 
 
 class OpenStackGatewayService(BaseGatewayService):
     """For OpenStack, an internet gateway is a just an 'external' network."""
 
-    def __init__(self, provider):
+    def __init__(self, provider: CloudProvider) -> None:
         super(OpenStackGatewayService, self).__init__(provider)
 
     @dispatch(event="provider.networking.gateways.get_or_create",
               priority=BaseGatewayService.STANDARD_EVENT_PRIORITY)
-    def get_or_create(self, network):
+    def get_or_create(self, network: Network | str) -> InternetGateway:
         """For OS, inet gtw is any net that has `external` property set."""
+        provider = cast("OpenStackCloudProvider", self.provider)
         external_nets = (n for n in self._provider.networking.networks
                          if n.external)
         for net in external_nets:
-            if not net.shared:
-                return OpenStackInternetGateway(self._provider, net)
-        return None
+            if not cast(Any, net).shared:
+                return OpenStackInternetGateway(provider, net)
+        raise ProviderInternalException(
+            "No external, non-shared network is available to serve as an "
+            "internet gateway")
 
     @dispatch(event="provider.networking.gateways.delete",
               priority=BaseGatewayService.STANDARD_EVENT_PRIORITY)
-    def delete(self, network, gateway):
+    def delete(self, network: Network | str, gateway: Gateway) -> None:
         pass
 
     @dispatch(event="provider.networking.gateways.list",
               priority=BaseGatewayService.STANDARD_EVENT_PRIORITY)
-    def list(self, network, limit=None, marker=None):
+    def list(self, network: Network | str, limit: int | None = None,
+             marker: str | None = None) -> ResultList[InternetGateway]:
         log.debug("OpenStack listing of all current internet gateways")
-        igl = [OpenStackInternetGateway(self._provider, n)
+        provider = cast("OpenStackCloudProvider", self.provider)
+        igl = [OpenStackInternetGateway(provider, n)
                for n in self._provider.networking.networks
-               if n.external and not n.shared]
+               if n.external and not cast(Any, n).shared]
         return ClientPagedResultList(self._provider, igl, limit=limit,
                                      marker=marker)
 
 
 class OpenStackFloatingIPService(BaseFloatingIPService):
 
-    def __init__(self, provider):
+    def __init__(self, provider: CloudProvider) -> None:
         super(OpenStackFloatingIPService, self).__init__(provider)
 
     @dispatch(event="provider.networking.floating_ips.get",
               priority=BaseFloatingIPService.STANDARD_EVENT_PRIORITY)
-    def get(self, gateway, fip_id):
+    def get(self, gateway: Gateway, fip_id: str) -> FloatingIP | None:
+        provider = cast("OpenStackCloudProvider", self.provider)
         try:
             return OpenStackFloatingIP(
-                self.provider,
-                self.provider.os_conn.network.get_ip(fip_id))
+                provider,
+                provider.os_conn.network.get_ip(fip_id))
         except (ResourceNotFound, NotFoundException):
             log.debug("Floating IP %s not found.", fip_id)
             return None
 
     @dispatch(event="provider.networking.floating_ips.list",
               priority=BaseFloatingIPService.STANDARD_EVENT_PRIORITY)
-    def list(self, gateway, limit=None, marker=None):
-        fips = [OpenStackFloatingIP(self.provider, fip)
-                for fip in self.provider.os_conn.network.ips(
+    def list(self, gateway: Gateway, limit: int | None = None,
+             marker: str | None = None) -> ResultList[FloatingIP]:
+        provider = cast("OpenStackCloudProvider", self.provider)
+        fips = [OpenStackFloatingIP(provider, fip)
+                for fip in provider.os_conn.network.ips(
                     floating_network_id=gateway.id
                 )]
         return ClientPagedResultList(self.provider, fips,
@@ -1350,29 +1505,31 @@ class OpenStackFloatingIPService(BaseFloatingIPService):
 
     @dispatch(event="provider.networking.floating_ips.create",
               priority=BaseFloatingIPService.STANDARD_EVENT_PRIORITY)
-    def create(self, gateway):
+    def create(self, gateway: Gateway) -> FloatingIP:
+        provider = cast("OpenStackCloudProvider", self.provider)
         return OpenStackFloatingIP(
-            self.provider, self.provider.os_conn.network.create_ip(
+            provider, provider.os_conn.network.create_ip(
                 floating_network_id=gateway.id))
 
     @dispatch(event="provider.networking.floating_ips.delete",
               priority=BaseFloatingIPService.STANDARD_EVENT_PRIORITY)
-    def delete(self, gateway, fip):
+    def delete(self, gateway: Gateway, fip: FloatingIP | str) -> None:
+        provider = cast("OpenStackCloudProvider", self.provider)
         if isinstance(fip, OpenStackFloatingIP):
             # pylint:disable=protected-access
             os_ip = fip._ip
         else:
             try:
-                os_ip = self.provider.os_conn.network.get_ip(fip)
+                os_ip = provider.os_conn.network.get_ip(fip)
             except (ResourceNotFound, NotFoundException):
                 log.debug("Floating IP %s not found.", fip)
-                return True
-        os_ip.delete(self._provider.os_conn.network)
+                return
+        os_ip.delete(provider.os_conn.network)
 
 
 class OpenStackDnsService(BaseDnsService):
 
-    def __init__(self, provider):
+    def __init__(self, provider: CloudProvider) -> None:
         super(OpenStackDnsService, self).__init__(provider)
 
         # Initialize provider services
@@ -1380,71 +1537,77 @@ class OpenStackDnsService(BaseDnsService):
         self._record_svc = OpenStackDnsRecordService(self.provider)
 
     @property
-    def host_zones(self):
+    def host_zones(self) -> OpenStackDnsZoneService:
         return self._zone_svc
 
     @property
-    def _records(self):
+    def _records(self) -> OpenStackDnsRecordService:
         return self._record_svc
 
 
 class OpenStackDnsZoneService(BaseDnsZoneService):
 
-    def __init__(self, provider):
+    def __init__(self, provider: CloudProvider) -> None:
         super(OpenStackDnsZoneService, self).__init__(provider)
 
     @dispatch(event="provider.dns.host_zones.get",
               priority=BaseDnsZoneService.STANDARD_EVENT_PRIORITY)
-    def get(self, dns_zone_id):
+    def get(self, dns_zone_id: str) -> DnsZone | None:
+        provider = cast("OpenStackCloudProvider", self.provider)
         try:
             return OpenStackDnsZone(
-                self.provider,
-                self.provider.os_conn.dns.get_zone(dns_zone_id))
+                provider,
+                provider.os_conn.dns.get_zone(dns_zone_id))
         except (ResourceNotFound, NotFoundException, BadRequestException):
             log.debug("Dns Zone %s not found.", dns_zone_id)
             return None
 
     @dispatch(event="provider.dns.host_zones.list",
               priority=BaseDnsZoneService.STANDARD_EVENT_PRIORITY)
-    def list(self, limit=None, marker=None):
-        zones = [OpenStackDnsZone(self.provider, zone)
-                 for zone in self.provider.os_conn.dns.zones()]
+    def list(self, limit: int | None = None,
+             marker: str | None = None) -> ResultList[DnsZone]:
+        provider = cast("OpenStackCloudProvider", self.provider)
+        zones = [OpenStackDnsZone(provider, zone)
+                 for zone in provider.os_conn.dns.zones()]
         return ClientPagedResultList(self.provider, zones,
                                      limit=limit, marker=marker)
 
     @dispatch(event="provider.dns.host_zones.find",
               priority=BaseDnsZoneService.STANDARD_EVENT_PRIORITY)
-    def find(self, **kwargs):
+    def find(self, **kwargs: Any) -> ResultList[DnsZone]:
         filters = ['name']
-        matches = cb_helpers.generic_find(filters, kwargs, self)
+        matches = cb_helpers.generic_find(filters, kwargs, list(self))
         return ClientPagedResultList(self.provider, list(matches),
                                      limit=None, marker=None)
 
     @dispatch(event="provider.dns.host_zones.create",
               priority=BaseDnsZoneService.STANDARD_EVENT_PRIORITY)
-    def create(self, name, admin_email):
+    def create(self, name: str, admin_email: str) -> DnsZone:
         OpenStackDnsZone.assert_valid_resource_name(name)
 
+        provider = cast("OpenStackCloudProvider", self.provider)
         return OpenStackDnsZone(
-            self.provider, self.provider.os_conn.dns.create_zone(
+            provider, provider.os_conn.dns.create_zone(
                 name=self._get_fully_qualified_dns(name),
                 email=admin_email, ttl=3600))
 
     @dispatch(event="provider.dns.host_zones.delete",
               priority=BaseDnsZoneService.STANDARD_EVENT_PRIORITY)
-    def delete(self, dns_zone):
+    def delete(self, dns_zone: DnsZone | str) -> None:
         zone_id = (dns_zone.id if isinstance(dns_zone, OpenStackDnsZone)
                    else dns_zone)
         if zone_id:
-            self.provider.os_conn.dns.delete_zone(zone_id)
+            provider = cast("OpenStackCloudProvider", self.provider)
+            provider.os_conn.dns.delete_zone(zone_id)
 
 
 class OpenStackDnsRecordService(BaseDnsRecordService):
 
-    def __init__(self, provider):
+    def __init__(self, provider: CloudProvider) -> None:
         super(OpenStackDnsRecordService, self).__init__(provider)
 
-    def _to_resource_records(self, data, rec_type):
+    def _to_resource_records(self, data: str | builtins.list[str],
+                             rec_type: str) -> builtins.list[str]:
         """
         Converts a record to what OpenStack expects. For example,
         OpenStack expects a fully qualified name for all CNAME records.
@@ -1455,40 +1618,55 @@ class OpenStackDnsRecordService(BaseDnsRecordService):
             records = [data]
         return [self._standardize_record(r, rec_type) for r in records]
 
-    def get(self, dns_zone, rec_id):
+    def get(self, dns_zone: DnsZone | str,
+            rec_id: str) -> DnsRecord | None:
+        provider = cast("OpenStackCloudProvider", self.provider)
         try:
             return OpenStackDnsRecord(
-                self.provider, dns_zone,
-                self.provider.os_conn.dns.get_recordset(rec_id, dns_zone.id))
+                provider, dns_zone,
+                provider.os_conn.dns.get_recordset(
+                    rec_id, cast(Any, dns_zone).id))
         except (ResourceNotFound, NotFoundException, BadRequestException):
             log.debug("Dns Record %s not found.", rec_id)
             return None
 
-    def list(self, dns_zone, limit=None, marker=None):
-        recs = [OpenStackDnsRecord(self.provider, dns_zone, rec)
-                for rec in self.provider.os_conn.dns.recordsets(dns_zone.id)]
+    # The PageableObjectMixin base declares list(limit, marker); this service
+    # intentionally takes a leading dns_zone parameter.
+    def list(self,  # type: ignore[override]
+             dns_zone: DnsZone | str, limit: int | None = None,
+             marker: str | None = None) -> ResultList[DnsRecord]:
+        provider = cast("OpenStackCloudProvider", self.provider)
+        recs = [OpenStackDnsRecord(provider, dns_zone, rec)
+                for rec in provider.os_conn.dns.recordsets(
+                    cast(Any, dns_zone).id)]
         return ClientPagedResultList(self.provider, recs,
                                      limit=limit, marker=marker)
 
-    def find(self, dns_zone, **kwargs):
+    def find(self, dns_zone: DnsZone | str,
+             **kwargs: Any) -> ResultList[DnsRecord]:
         filters = ['name']
-        matches = cb_helpers.generic_find(filters, kwargs, dns_zone.records)
+        matches = cb_helpers.generic_find(filters, kwargs,
+                                          cast(Any, dns_zone).records)
         return ClientPagedResultList(self.provider, list(matches),
                                      limit=None, marker=None)
 
-    def create(self, dns_zone, name, type, data, ttl=None):
+    def create(self, dns_zone: DnsZone | str, name: str, type: str,
+               data: str, ttl: int | None = None) -> DnsRecord:
         OpenStackDnsRecord.assert_valid_resource_name(name)
 
+        provider = cast("OpenStackCloudProvider", self.provider)
         return OpenStackDnsRecord(
-            self.provider, dns_zone,
-            self.provider.os_conn.dns.create_recordset(
-                zone=dns_zone.id, name=name, type=type,
+            provider, dns_zone,
+            provider.os_conn.dns.create_recordset(
+                zone=cast(Any, dns_zone).id, name=name, type=type,
                 records=self._to_resource_records(data, type),
                 ttl=ttl or 3600))
 
-    def delete(self, dns_zone, record):
+    def delete(self, dns_zone: DnsZone | str,
+               record: DnsRecord | str) -> None:
         rec_id = (record.id if isinstance(record, OpenStackDnsRecord)
                   else record)
         if rec_id:
-            self.provider.os_conn.dns.delete_recordset(
-                rec_id, zone=dns_zone.id)
+            provider = cast("OpenStackCloudProvider", self.provider)
+            provider.os_conn.dns.delete_recordset(
+                rec_id, zone=cast(Any, dns_zone).id)

--- a/cloudbridge/providers/openstack/services.py
+++ b/cloudbridge/providers/openstack/services.py
@@ -1025,11 +1025,10 @@ class OpenStackInstanceService(BaseInstanceService):
             if vm_firewalls:
                 if isinstance(vm_firewalls, list) and \
                         isinstance(vm_firewalls[0], VMFirewall):
-                    sg_name_list = [sg.name for sg in
-                                    cast("list[VMFirewall]", vm_firewalls)]
+                    sg_name_list = [sg.name for sg in vm_firewalls]
                 else:
                     sg_list = (self.provider.security.vm_firewalls.get(sg)
-                               for sg in cast("list[str]", vm_firewalls))
+                               for sg in vm_firewalls)
                     sg_name_list = (sg[0].name for sg in sg_list if sg)
 
         log.debug("Launching in subnet %s", subnet_id)

--- a/cloudbridge/providers/openstack/subservices.py
+++ b/cloudbridge/providers/openstack/subservices.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import logging
 
 from cloudbridge.base.subservices import BaseBucketObjectSubService
@@ -6,6 +8,12 @@ from cloudbridge.base.subservices import BaseFloatingIPSubService
 from cloudbridge.base.subservices import BaseGatewaySubService
 from cloudbridge.base.subservices import BaseSubnetSubService
 from cloudbridge.base.subservices import BaseVMFirewallRuleSubService
+from cloudbridge.interfaces.provider import CloudProvider
+from cloudbridge.interfaces.resources import Bucket
+from cloudbridge.interfaces.resources import DnsZone
+from cloudbridge.interfaces.resources import Gateway
+from cloudbridge.interfaces.resources import Network
+from cloudbridge.interfaces.resources import VMFirewall
 
 
 log = logging.getLogger(__name__)
@@ -13,36 +21,36 @@ log = logging.getLogger(__name__)
 
 class OpenStackBucketObjectSubService(BaseBucketObjectSubService):
 
-    def __init__(self, provider, bucket):
+    def __init__(self, provider: CloudProvider, bucket: Bucket) -> None:
         super(OpenStackBucketObjectSubService, self).__init__(provider, bucket)
 
 
 class OpenStackGatewaySubService(BaseGatewaySubService):
 
-    def __init__(self, provider, network):
+    def __init__(self, provider: CloudProvider, network: Network) -> None:
         super(OpenStackGatewaySubService, self).__init__(provider, network)
 
 
 class OpenStackFloatingIPSubService(BaseFloatingIPSubService):
 
-    def __init__(self, provider, gateway):
+    def __init__(self, provider: CloudProvider, gateway: Gateway) -> None:
         super(OpenStackFloatingIPSubService, self).__init__(provider, gateway)
 
 
 class OpenStackVMFirewallRuleSubService(BaseVMFirewallRuleSubService):
 
-    def __init__(self, provider, firewall):
+    def __init__(self, provider: CloudProvider, firewall: VMFirewall) -> None:
         super(OpenStackVMFirewallRuleSubService, self).__init__(
             provider, firewall)
 
 
 class OpenStackSubnetSubService(BaseSubnetSubService):
 
-    def __init__(self, provider, network):
+    def __init__(self, provider: CloudProvider, network: Network) -> None:
         super(OpenStackSubnetSubService, self).__init__(provider, network)
 
 
 class OpenStackDnsRecordSubService(BaseDnsRecordSubService):
 
-    def __init__(self, provider, dns_zone):
+    def __init__(self, provider: CloudProvider, dns_zone: DnsZone) -> None:
         super(OpenStackDnsRecordSubService, self).__init__(provider, dns_zone)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,7 +91,7 @@ dev = [
     "pydevd",
     "flake8>=3.3.0",
     "flake8-import-order>=0.12",
-    "mypy>=1.11",
+    "mypy>=2.1,<3",
 ]
 
 [tool.setuptools.dynamic]
@@ -153,6 +153,7 @@ module = [
     "cloudbridge.providers.mock.*",
     "cloudbridge.providers.openstack.*",
     "cloudbridge.providers.gcp.*",
+    "cloudbridge.providers.azure.*",
 ]
 ignore_errors = false
 warn_return_any = false

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -135,32 +135,16 @@ implicit_reexport = true
 # `deprecation` library's decorators are untyped; don't fail the build on them.
 disallow_untyped_decorators = false
 
-# Not-yet-typed internal modules: stay exempt until annotated, then move them
-# into the pragmatic tier below (or, if fully strict-clean, delete the entry).
+# Providers (all typed) wrap untyped cloud SDKs, so they get a pragmatic tier:
+# complete annotations are required (disallow_untyped_defs etc. from the strict
+# baseline), but warn_return_any and disallow_untyped_calls are off -- every
+# getter reads an attribute off an Any-typed SDK object, and forcing those
+# through cast()/ignore adds noise without value.
 [[tool.mypy.overrides]]
 module = ["cloudbridge.providers.*"]
-ignore_errors = true
-
-# Typed providers (pragmatic tier). Providers wrap untyped cloud SDKs, so we
-# require complete annotations (disallow_untyped_defs etc. from the strict
-# baseline) but turn off warn_return_any and disallow_untyped_calls: every
-# getter reads an attribute off an Any-typed SDK object, and forcing those
-# through cast()/ignore adds noise without value. A more-specific module pattern
-# here wins over the broad providers.* exemption above.
-[[tool.mypy.overrides]]
-module = [
-    "cloudbridge.providers.aws.*",
-    "cloudbridge.providers.mock.*",
-    "cloudbridge.providers.openstack.*",
-    "cloudbridge.providers.gcp.*",
-    "cloudbridge.providers.azure.*",
-]
-ignore_errors = false
 warn_return_any = false
 disallow_untyped_calls = false
 
 # base/ is held to the FULL strict bar (it orchestrates through the typed
 # interface layer and never touches the cloud SDKs directly), so it falls under
-# the global strict baseline with no override. The providers will get a
-# pragmatic tier (warn_return_any / disallow_untyped_calls off) when they are
-# typed, because they DO read from untyped SDK objects.
+# the global strict baseline with no override.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -141,6 +141,18 @@ disallow_untyped_decorators = false
 module = ["cloudbridge.providers.*"]
 ignore_errors = true
 
+# Typed providers (pragmatic tier). Providers wrap untyped cloud SDKs, so we
+# require complete annotations (disallow_untyped_defs etc. from the strict
+# baseline) but turn off warn_return_any and disallow_untyped_calls: every
+# getter reads an attribute off an Any-typed SDK object, and forcing those
+# through cast()/ignore adds noise without value. A more-specific module pattern
+# here wins over the broad providers.* exemption above.
+[[tool.mypy.overrides]]
+module = ["cloudbridge.providers.aws.*"]
+ignore_errors = false
+warn_return_any = false
+disallow_untyped_calls = false
+
 # base/ is held to the FULL strict bar (it orchestrates through the typed
 # interface layer and never touches the cloud SDKs directly), so it falls under
 # the global strict baseline with no override. The providers will get a

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -148,7 +148,11 @@ ignore_errors = true
 # through cast()/ignore adds noise without value. A more-specific module pattern
 # here wins over the broad providers.* exemption above.
 [[tool.mypy.overrides]]
-module = ["cloudbridge.providers.aws.*", "cloudbridge.providers.mock.*"]
+module = [
+    "cloudbridge.providers.aws.*",
+    "cloudbridge.providers.mock.*",
+    "cloudbridge.providers.openstack.*",
+]
 ignore_errors = false
 warn_return_any = false
 disallow_untyped_calls = false

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,6 +91,7 @@ dev = [
     "pydevd",
     "flake8>=3.3.0",
     "flake8-import-order>=0.12",
+    "mypy>=1.11",
 ]
 
 [tool.setuptools.dynamic]
@@ -100,6 +101,10 @@ version = { attr = "cloudbridge.__version__" }
 include = ["cloudbridge*"]
 exclude = ["tests*"]
 
+[tool.setuptools.package-data]
+# Ship the PEP 561 marker so downstream consumers pick up our type hints.
+cloudbridge = ["py.typed"]
+
 [tool.coverage.run]
 branch = true
 source = ["cloudbridge"]
@@ -108,3 +113,28 @@ omit = [
     "cloudbridge/__init__.py",
 ]
 parallel = true
+
+[tool.mypy]
+# CloudBridge is typed gradually. The public API (the interface layer and the
+# factory) is held to a strict baseline so downstream users get a fully-typed
+# API; the base implementations and providers (which wrap untyped cloud SDKs)
+# are temporarily exempted below and ratcheted to strict module-by-module.
+python_version = "3.13"
+files = ["cloudbridge"]
+ignore_missing_imports = true   # untyped cloud SDKs (boto3, azure-*, ...) -> Any
+namespace_packages = true
+warn_unused_configs = true
+# Strict baseline: applies to every module NOT exempted below.
+disallow_untyped_defs = true
+disallow_incomplete_defs = true
+no_implicit_optional = true
+check_untyped_defs = true
+warn_redundant_casts = true
+warn_unused_ignores = true
+warn_return_any = true
+
+# Gradual-typing exemptions. Remove a module from this list once it is fully
+# annotated; it then falls under the strict baseline above.
+[[tool.mypy.overrides]]
+module = ["cloudbridge.base.*", "cloudbridge.providers.*"]
+ignore_errors = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -152,6 +152,7 @@ module = [
     "cloudbridge.providers.aws.*",
     "cloudbridge.providers.mock.*",
     "cloudbridge.providers.openstack.*",
+    "cloudbridge.providers.gcp.*",
 ]
 ignore_errors = false
 warn_return_any = false

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -148,7 +148,7 @@ ignore_errors = true
 # through cast()/ignore adds noise without value. A more-specific module pattern
 # here wins over the broad providers.* exemption above.
 [[tool.mypy.overrides]]
-module = ["cloudbridge.providers.aws.*"]
+module = ["cloudbridge.providers.aws.*", "cloudbridge.providers.mock.*"]
 ignore_errors = false
 warn_return_any = false
 disallow_untyped_calls = false

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -135,8 +135,14 @@ implicit_reexport = true
 # `deprecation` library's decorators are untyped; don't fail the build on them.
 disallow_untyped_decorators = false
 
-# Gradual-typing exemptions. Remove a module from this list once it is fully
-# annotated; it then falls under the strict baseline above.
+# Not-yet-typed internal modules: stay exempt until annotated, then move them
+# into the pragmatic tier below (or, if fully strict-clean, delete the entry).
 [[tool.mypy.overrides]]
-module = ["cloudbridge.base.*", "cloudbridge.providers.*"]
+module = ["cloudbridge.providers.*"]
 ignore_errors = true
+
+# base/ is held to the FULL strict bar (it orchestrates through the typed
+# interface layer and never touches the cloud SDKs directly), so it falls under
+# the global strict baseline with no override. The providers will get a
+# pragmatic tier (warn_return_any / disallow_untyped_calls off) when they are
+# typed, because they DO read from untyped SDK objects.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -124,14 +124,16 @@ files = ["cloudbridge"]
 ignore_missing_imports = true   # untyped cloud SDKs (boto3, azure-*, ...) -> Any
 namespace_packages = true
 warn_unused_configs = true
-# Strict baseline: applies to every module NOT exempted below.
-disallow_untyped_defs = true
-disallow_incomplete_defs = true
-no_implicit_optional = true
-check_untyped_defs = true
-warn_redundant_casts = true
-warn_unused_ignores = true
-warn_return_any = true
+# Full strict baseline (applies to every module NOT exempted below), with two
+# documented exceptions that don't fit this codebase:
+strict = true
+# interfaces/__init__.py re-exports the public names without an __all__; keep
+# implicit re-export so `from cloudbridge.interfaces import CloudProvider`
+# keeps working for factory.py and downstream consumers.
+implicit_reexport = true
+# Cross-class property setters (@LabeledCloudResource.label.setter) and the
+# `deprecation` library's decorators are untyped; don't fail the build on them.
+disallow_untyped_decorators = false
 
 # Gradual-typing exemptions. Remove a module from this list once it is fully
 # annotated; it then falls under the strict baseline above.

--- a/tests/test_compute_service.py
+++ b/tests/test_compute_service.py
@@ -436,7 +436,7 @@ class CloudComputeServiceTestCase(ProviderTestBase):
                                                   subnet=subnet)
 
             # check whether stopping aws instance works
-            resp = test_inst.stop()
+            test_inst.stop()
             test_inst.wait_for([InstanceState.STOPPED])
             test_inst.refresh()
             self.assertTrue(
@@ -445,11 +445,8 @@ class CloudComputeServiceTestCase(ProviderTestBase):
                 "'stop' operation but got %s"
                 % test_inst.state)
 
-            self.assertTrue(resp, "Response from method was suppose to be"
-                            + " True but got False")
-
             # check whether starting aws instance works
-            resp = test_inst.start()
+            test_inst.start()
             test_inst.wait_for([InstanceState.RUNNING])
             test_inst.refresh()
             self.assertTrue(
@@ -457,6 +454,3 @@ class CloudComputeServiceTestCase(ProviderTestBase):
                 "Instance state must be running when refreshing after a "
                 "'start' operation but got %s"
                 % test_inst.state)
-
-            self.assertTrue(resp, "Response from method was suppose to be"
-                            + " True but got False")

--- a/tox.ini
+++ b/tox.ini
@@ -88,7 +88,9 @@ deps =
 
 [testenv:lint]
 commands = flake8 cloudbridge tests
-deps = flake8
+deps =
+    flake8
+    flake8-import-order
 
 [testenv:mypy]
 # Type-check the codebase (see [tool.mypy] in pyproject.toml). The provider

--- a/tox.ini
+++ b/tox.ini
@@ -6,7 +6,7 @@
 # running the tests.
 
 [tox]
-envlist = py3.13-{aws,azure,gcp,openstack,mock},lint
+envlist = py3.13-{aws,azure,gcp,openstack,mock},lint,mypy
 
 [testenv]
 commands = # see pyproject.toml for coverage options; setup.cfg for flake8
@@ -89,3 +89,11 @@ deps =
 [testenv:lint]
 commands = flake8 cloudbridge tests
 deps = flake8
+
+[testenv:mypy]
+# Type-check the public interface layer (see [tool.mypy] in pyproject.toml).
+# The interfaces import no third-party packages, so the package itself does not
+# need installing here, keeping this env fast.
+skip_install = true
+deps = mypy
+commands = mypy

--- a/tox.ini
+++ b/tox.ini
@@ -91,9 +91,11 @@ commands = flake8 cloudbridge tests
 deps = flake8
 
 [testenv:mypy]
-# Type-check the public interface layer (see [tool.mypy] in pyproject.toml).
-# The interfaces import no third-party packages, so the package itself does not
-# need installing here, keeping this env fast.
-skip_install = true
-deps = mypy
+# Type-check the codebase (see [tool.mypy] in pyproject.toml). The provider
+# layer is typed against the cloud SDKs, so the env installs the full deps
+# (via requirements.txt -> .[dev], which includes mypy) rather than running
+# bare: without the SDKs installed, mypy infers SDK values as Any and reports
+# spurious redundant-cast / unused-ignore errors that don't occur in a real
+# dev environment.
+deps = -rrequirements.txt
 commands = mypy


### PR DESCRIPTION
## What & why

Adds comprehensive type annotations across cloudbridge and an automated
`mypy` check (new tox env + CI), so downstream users get a **strongly-typed
public API** — every object returned through the interface is typed, even
though the underlying cloud SDKs (boto3, azure-*, google-api, openstacksdk)
are not.

The interface layer already expresses the complete return-type web
(`create_provider() -> CloudProvider`, `.compute.instances.list() ->
ResultList[Instance]`, `Instance.reboot() -> bool`, …). Typing that layer and
shipping a PEP 561 `py.typed` marker makes the whole API typed for users
regardless of provider internals.

## Approach

- **Typed tiers.** The `interfaces/` and `base/` layers are held to **full
  mypy strict**. The `providers/` layer runs under a **pragmatic tier**
  (annotations required, but `warn_return_any` / `disallow_untyped_calls`
  relaxed) because it wraps untyped SDK objects.
- **Generics.** `PageableObjectMixin[T]` / `ResultList[T]` with `T` bound to
  `CloudResource`, so services and result lists are typed per-element.
- **`py.typed`** marker shipped via package-data (PEP 561).
- **No public runtime/behaviour change** to the interface contract: existing
  `@abstractproperty` / `__metaclass__ = ABCMeta` are kept as-is.

## Tooling / CI

- New `tox -e mypy` env (installs deps; mypy pinned `>=2.1,<3`).
- `tox -e lint` now also enforces import order (`flake8-import-order`).
- CI lint job runs `tox -e lint` then `tox -e mypy`.

## Behaviour reconciliations

Typing surfaced real cross-provider inconsistencies. Following the guiding
principle that *the interface should be abstract enough to match every
implementation*, providers were conformed to the interface rather than the
interface widened — e.g. `delete`/`attach`/`detach`/`start`/`stop` return
`None` consistently; firewall-rule `direction` returns the `TrafficDirection`
enum; fatal missing-id paths raise `ProviderInternalException` instead of
returning `None`; `Router.subnets` is `Iterable[Subnet]`; GCP `Instance.start`
implemented to mirror `stop`. Provider-internal members (`_bucket_objects`,
`_get_config_value`) are kept off the public interface and accessed through
base-layer types.

## Verification

- `tox -e mypy` (mypy 2.1) green across all 43 typed modules.
- `tox -e lint` clean (flake8 + import order).
- `tox -e py3.13-mock` green (mock subclasses AWS, so this exercises the
  AWS + base behaviour paths).
- Downstream smoke: `reveal_type` on `provider.compute.instances.list()` and
  iterated `Instance` members resolves through the interface types.

## Follow-ups (separate PRs)

- Remove the `deprecation` dependency + deprecated code.
- A handful of latent provider bugs noted during typing (e.g. Azure
  `Volume.source` semantics, GCP `Router.subnets` scope) — tracked for a
  dedicated fix.
