### PR TITLE
Remove the deprecation dependency and long-expired deprecated APIs

### DIFF
--- a/cloudbridge/base/helpers.py
+++ b/cloudbridge/base/helpers.py
@@ -1,5 +1,4 @@
 import fnmatch
-import functools
 import logging
 import os
 import re
@@ -8,23 +7,17 @@ from collections.abc import Iterator
 from contextlib import contextmanager
 from typing import Any
 from typing import TypeVar
-from typing import cast
 from typing import overload
 
 from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives import serialization as crypt_serialization
 from cryptography.hazmat.primitives.asymmetric import rsa
 
-from deprecation import deprecated
-
-import cloudbridge
-
 from ..interfaces.exceptions import InvalidParamException
 
 log = logging.getLogger(__name__)
 
 T = TypeVar("T")
-F = TypeVar("F", bound=Callable[..., Any])
 
 
 def generate_key_pair() -> tuple[str, str]:
@@ -144,36 +137,6 @@ def get_env(varname: str, default_value: object = None) -> object:
              ``default_value`` otherwise.
     """
     return os.environ.get(varname, default_value)
-
-
-# Alias deprecation decorator, following:
-# https://stackoverflow.com/questions/49802412/
-# how-to-implement-deprecation-in-python-with-argument-alias
-def deprecated_alias(**aliases: str) -> Callable[[F], F]:
-    def deco(f: F) -> F:
-        @functools.wraps(f)
-        def wrapper(*args: Any, **kwargs: Any) -> Any:
-            rename_kwargs(f.__name__, kwargs, aliases)
-            return f(*args, **kwargs)
-        return cast(F, wrapper)
-    return deco
-
-
-def rename_kwargs(func_name: str, kwargs: dict[str, Any],
-                  aliases: dict[str, str]) -> None:
-    for alias, new in aliases.items():
-        if alias in kwargs:
-            if new in kwargs:
-                raise InvalidParamException(
-                    '{} received both {} and {}'.format(func_name, alias, new))
-            # Manually invoke the deprecated decorator with an empty lambda
-            # to signal deprecation
-            deprecated(deprecated_in='1.1',
-                       removed_in='2.0',
-                       current_version=cloudbridge.__version__,
-                       details='{} is deprecated, use {} instead'.format(
-                           alias, new))(lambda: None)()
-            kwargs[new] = kwargs.pop(alias)
 
 
 NON_ALPHA_NUM = re.compile(r"[^A-Za-z0-9]+")

--- a/cloudbridge/providers/aws/services.py
+++ b/cloudbridge/providers/aws/services.py
@@ -214,7 +214,6 @@ class AWSVMFirewallService(BaseVMFirewallService):
              marker: str | None = None) -> ResultList[VMFirewall]:
         return self.svc.list(limit=limit, marker=marker)
 
-    @cb_helpers.deprecated_alias(network_id='network')
     @dispatch(event="provider.security.vm_firewalls.create",
               priority=BaseVMFirewallService.STANDARD_EVENT_PRIORITY)
     def create(self, label: str, network: Network | str,

--- a/cloudbridge/providers/azure/provider.py
+++ b/cloudbridge/providers/azure/provider.py
@@ -5,11 +5,8 @@ from typing import Any
 from azure.core.exceptions import HttpResponseError
 from azure.core.exceptions import ResourceNotFoundError
 
-from deprecation import deprecated
-
 import tenacity
 
-import cloudbridge
 from cloudbridge.base import BaseCloudProvider
 from cloudbridge.base.helpers import get_env
 from cloudbridge.interfaces.exceptions import ProviderConnectionException
@@ -74,7 +71,7 @@ class AzureCloudProvider(BaseCloudProvider):
         self.vm_default_user_name = self._get_config_value(
                 'azure_vm_default_username', get_env(
                     'AZURE_VM_DEFAULT_USERNAME')) \
-            or self.__get_deprecated_username('cbuser')
+            or 'cbuser'
 
         self.public_key_storage_table_name = self._get_config_value(
             'azure_public_key_storage_table_name', get_env(
@@ -87,23 +84,6 @@ class AzureCloudProvider(BaseCloudProvider):
         self._compute = AzureComputeService(self)
         self._networking = AzureNetworkingService(self)
         self._dns = AzureDnsService(self)
-
-    def __get_deprecated_username(self, default: str) -> str:
-        username = self._get_config_value(
-            'azure_vm_default_user_name', get_env(
-                'AZURE_VM_DEFAULT_USER_NAME', None))
-        if username:
-            return self.__wrap_deprecated_username(username)
-        else:
-            return default
-
-    @deprecated(deprecated_in='1.1',
-                removed_in='2.0',
-                current_version=cloudbridge.__version__,
-                details='AZURE_VM_DEFAULT_USER_NAME was deprecated in favor '
-                        'of AZURE_VM_DEFAULT_USERNAME')
-    def __wrap_deprecated_username(self, username: str) -> str:
-        return username
 
     @property
     def compute(self) -> ComputeService:

--- a/cloudbridge/providers/azure/services.py
+++ b/cloudbridge/providers/azure/services.py
@@ -161,7 +161,6 @@ class AzureVMFirewallService(BaseVMFirewallService):
                for fw in provider.azure_client.list_vm_firewall()]
         return ClientPagedResultList(self.provider, fws, limit, marker)
 
-    @cb_helpers.deprecated_alias(network_id='network')
     @dispatch(event="provider.security.vm_firewalls.create",
               priority=BaseVMFirewallService.STANDARD_EVENT_PRIORITY)
     def create(self, label: str, network: Network | str,

--- a/cloudbridge/providers/openstack/services.py
+++ b/cloudbridge/providers/openstack/services.py
@@ -288,7 +288,6 @@ class OpenStackVMFirewallService(BaseVMFirewallService):
         return ClientPagedResultList(self.provider, firewalls,
                                      limit=limit, marker=marker)
 
-    @cb_helpers.deprecated_alias(network_id='network')
     @dispatch(event="provider.security.vm_firewalls.create",
               priority=BaseVMFirewallService.STANDARD_EVENT_PRIORITY)
     def create(self, label: str, network: Network | str,

--- a/docs/topics/setup.rst
+++ b/docs/topics/setup.rst
@@ -278,7 +278,7 @@ https://docs.microsoft.com/en-us/azure/role-based-access-control/overview.
 +-------------------------------------+-----------+
 | AZURE_STORAGE_ACCOUNT               |           |
 +-------------------------------------+-----------+
-| AZURE_VM_DEFAULT_USER_NAME          |           |
+| AZURE_VM_DEFAULT_USERNAME           |           |
 +-------------------------------------+-----------+
 
 GCP

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,6 @@ classifiers = [
 ]
 dependencies = [
     "tenacity>=6.0",
-    "deprecation>=2.0.7",
     "pyeventsystem<2",
 ]
 dynamic = ["version"]
@@ -131,8 +130,8 @@ strict = true
 # implicit re-export so `from cloudbridge.interfaces import CloudProvider`
 # keeps working for factory.py and downstream consumers.
 implicit_reexport = true
-# Cross-class property setters (@LabeledCloudResource.label.setter) and the
-# `deprecation` library's decorators are untyped; don't fail the build on them.
+# Cross-class property setters (@LabeledCloudResource.label.setter) are untyped;
+# don't fail the build on them.
 disallow_untyped_decorators = false
 
 # Providers (all typed) wrap untyped cloud SDKs, so they get a pragmatic tier:

--- a/tests/test_base_helpers.py
+++ b/tests/test_base_helpers.py
@@ -1,7 +1,6 @@
 import unittest
 
 from cloudbridge.base import helpers as cb_helpers
-from cloudbridge.interfaces.exceptions import InvalidParamException
 
 
 class BaseHelpersTestCase(unittest.TestCase):
@@ -59,44 +58,3 @@ class BaseHelpersTestCase(unittest.TestCase):
                 invoke_order[0] += "body_"
                 raise CustomException()
         self.assertEqual(invoke_order[0], "body_cleanup")
-
-    def test_deprecated_alias_no_rename(self):
-        param_values = {}
-
-        @cb_helpers.deprecated_alias(old_param='new_param')
-        def custom_func(new_param=None, old_param=None):
-            param_values['new_param'] = new_param
-            param_values['old_param'] = old_param
-
-        custom_func(new_param="hello")
-        self.assertDictEqual(param_values,
-                             {
-                                 'new_param': "hello",
-                                 'old_param': None
-                             })
-
-    def test_deprecated_alias_force_rename(self):
-        param_values = {}
-
-        @cb_helpers.deprecated_alias(old_param='new_param')
-        def custom_func(new_param=None, old_param=None):
-            param_values['new_param'] = new_param
-            param_values['old_param'] = old_param
-
-        custom_func(old_param="hello")
-        self.assertDictEqual(param_values,
-                             {
-                                 'new_param': "hello",
-                                 'old_param': None
-                             })
-
-    def test_deprecated_alias_force_conflict(self):
-        param_values = {}
-
-        @cb_helpers.deprecated_alias(old_param='new_param')
-        def custom_func(new_param=None, old_param=None):
-            param_values['new_param'] = new_param
-            param_values['old_param'] = old_param
-
-        with self.assertRaises(InvalidParamException):
-            custom_func(new_param="world", old_param="hello")


### PR DESCRIPTION
Stacked on #335 (base is `add-typing`; GitHub will retarget to `main`
automatically once #335 merges).

## What & why

Removes the third-party `deprecation` dependency and the long-expired
deprecated APIs that used it. All of these were marked `removed_in='2.0'`
but survived into the 4.x line — they're overdue for removal, and dropping
them lets us delete a runtime dependency.

## Removed

- **`network_id=` kwarg alias** on `security.vm_firewalls.create` (AWS,
  Azure, OpenStack). The parameter has been `network` for years; the alias
  just re-mapped the old name. This also removes the `deprecated_alias` /
  `rename_kwargs` helpers in `base/helpers.py` and their unit tests.
- **`AZURE_VM_DEFAULT_USER_NAME`** config/env alias in the Azure provider.
  Use `AZURE_VM_DEFAULT_USERNAME` (the setup docs are updated to list the
  supported name).
- **`deprecation>=2.0.7`** from dependencies, plus the now-unused imports
  it required.

## ⚠️ Breaking change

Callers passing `network_id=` to firewall creation, or relying on the
`AZURE_VM_DEFAULT_USER_NAME` environment variable, must switch to `network=`
and `AZURE_VM_DEFAULT_USERNAME` respectively. No changelog entry added (this
repo compiles the changelog at release time); flagging here so it's captured
when the next release notes are written — likely warrants a major bump.

## Verification

- `tox -e mypy` (2.1) and `tox -e lint` (flake8 over `cloudbridge` + `tests`)
  clean.
- `tox -e py3.13-mock` passes **with the `deprecation` package uninstalled** —
  tox no longer installs it (`install_package_deps> pip install
  'pyeventsystem<2' 'tenacity>=6.0'`), and all providers import without it.
