### PR TITLE
Lower supported Python floor to 3.10

### DIFF
--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -68,7 +68,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.13']
+        # Lowest and highest supported Python versions
+        python-version: ['3.10', '3.13']
     steps:
       - name: Checkout code
         uses: actions/checkout@v6

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,14 @@
+4.2.1 - unreleased
+------------------
+
+## What's new
+* **Supported Python floor lowered to 3.10.** ``requires-python`` was ``>=3.13``
+  since the PEP 621 packaging migration, but nothing in the codebase or its
+  dependencies needs more than 3.10. CloudBridge now installs on Python
+  3.10–3.13, and CI runs the mock-provider suite on both the lowest and highest
+  supported versions. ``mypy`` type-checks against 3.10 so newer-stdlib usage
+  is caught at lint time.
+
 4.2.0 - July 9, 2026 (sha 60dbe305f0af46a7ce3eadd093756d31b8131b2e)
 -------------------------------------------------------------------
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ description = "A simple layer of abstraction over multiple cloud providers."
 readme = "README.rst"
 license = "MIT"
 license-files = ["LICENSE"]
-requires-python = ">=3.13"
+requires-python = ">=3.10"
 authors = [
     { name = "Galaxy and GVL Projects", email = "help@genome.edu.au" },
 ]
@@ -21,6 +21,9 @@ classifiers = [
     "Operating System :: OS Independent",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
     "Programming Language :: Python :: Implementation :: CPython",
     "Topic :: Software Development :: Libraries :: Python Modules",
@@ -118,7 +121,9 @@ parallel = true
 # factory) is held to a strict baseline so downstream users get a fully-typed
 # API; the base implementations and providers (which wrap untyped cloud SDKs)
 # are temporarily exempted below and ratcheted to strict module-by-module.
-python_version = "3.13"
+# Type-check against the LOWEST supported version so use of newer-stdlib
+# APIs is caught at lint time.
+python_version = "3.10"
 files = ["cloudbridge"]
 ignore_missing_imports = true   # untyped cloud SDKs (boto3, azure-*, ...) -> Any
 namespace_packages = true

--- a/tox.ini
+++ b/tox.ini
@@ -6,7 +6,7 @@
 # running the tests.
 
 [tox]
-envlist = py3.13-{aws,azure,gcp,openstack,mock},lint,mypy
+envlist = py3{.10,.13}-{aws,azure,gcp,openstack,mock},lint,mypy
 
 [testenv]
 commands = # see pyproject.toml for coverage options; setup.cfg for flake8


### PR DESCRIPTION
## Summary

The `requires-python = ">=3.13"` floor was introduced as part of the PEP 621 packaging migration (#PR — setup.py previously declared no floor at all) and reflects the CI matrix rather than any actual language/stdlib requirement: the codebase uses only 3.10-safe constructs (`X | None` unions, builtin generics), and all dependencies (tenacity, pyeventsystem, boto3, azure SDKs, google-api-python-client, openstacksdk, moto 5) support 3.10.

This matters downstream: Galaxy supports Python >=3.10 and currently has to pin cloudbridge 3.2.0 on anything below 3.13, which locks those deployments out of the 4.2.0 multipart upload support.

## Changes
- `requires-python` >=3.13 → >=3.10; added 3.10/3.11/3.12 trove classifiers
- CI mock-provider job now runs on a {lowest, highest} matrix: 3.10 and 3.13 (tox envlist gains `py3.10-*`)
- mypy `python_version` lowered to 3.10 so newer-stdlib usage is caught at lint time
- CHANGELOG: new 4.2.1 (unreleased) section

## Verification
- `tox -e py3.10-mock`: **94 passed, 5 skipped** — identical to the 3.13 run (includes the multipart driver + object store suites under moto)
- `tox -e mypy` (now targeting 3.10): clean, 43 files
- `tox -e lint`: clean

Note: `google.api_core` emits a FutureWarning that new releases will stop supporting 3.10 after its EOL (2026-10) — released versions keep working; worth revisiting the floor when Galaxy moves its own.