### PR TITLE
Create the default network with the configured default CIDR

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -22,6 +22,12 @@ content, and no longer materialises a whole object in memory anywhere.
   which reads in 64 KiB blocks regardless.
 
 ## Fixes
+* **The default network is created with the configured default CIDR.**
+  ``BaseNetworkService.get_or_create_default`` passed a hardcoded
+  ``10.0.0.0/16`` instead of ``BaseNetwork.CB_DEFAULT_IPV4RANGE``, so setting
+  ``CB_DEFAULT_IPV4RANGE`` was silently ignored on Azure and OpenStack, which
+  inherit the base implementation. AWS and GCP override it and were already
+  correct.
 * **Azure no longer splits object content on newlines.** ``iter_content``
   returned an ``io.RawIOBase`` wrapper, and iterating a raw stream calls
   ``readline()`` - so chunks broke at ``b"\n"`` at whatever sizes the content

--- a/cloudbridge/base/services.py
+++ b/cloudbridge/base/services.py
@@ -320,7 +320,8 @@ class BaseNetworkService(
             log.info("Creating a CloudBridge-default network labeled %s",
                      BaseNetwork.CB_DEFAULT_NETWORK_LABEL)
             return self.provider.networking.networks.create(
-                BaseNetwork.CB_DEFAULT_NETWORK_LABEL, '10.0.0.0/16')
+                BaseNetwork.CB_DEFAULT_NETWORK_LABEL,
+                BaseNetwork.CB_DEFAULT_IPV4RANGE)
 
     @dispatch(event="provider.networking.networks.find",
               priority=BaseCloudService.STANDARD_EVENT_PRIORITY)

--- a/tests/test_default_network.py
+++ b/tests/test_default_network.py
@@ -1,0 +1,68 @@
+"""
+Provider-agnostic unit tests for ``BaseNetworkService.get_or_create_default``.
+
+AWS and GCP override this method, and the mock provider used in CI is
+AWS-backed, so the base implementation - the one Azure and OpenStack actually
+inherit - is never executed by the networking service suite. It is exercised
+here directly against in-memory fakes.
+"""
+import unittest
+from unittest import mock
+
+from cloudbridge.base.resources import BaseNetwork
+from cloudbridge.base.services import BaseNetworkService
+
+
+class _NetworkRecorder:
+    """Stands in for provider.networking.networks."""
+
+    def __init__(self, existing=None):
+        self.existing = existing or []
+        self.created = []
+        self.find_labels = []
+
+    def find(self, label=None, **kwargs):
+        self.find_labels.append(label)
+        return list(self.existing)
+
+    def create(self, label, cidr_block, **kwargs):
+        self.created.append((label, cidr_block))
+        return ("network", label, cidr_block)
+
+
+class _FakeProvider:
+    def __init__(self, networks):
+        self.middleware = mock.Mock()
+        self.networking = mock.Mock(networks=networks)
+
+
+class DefaultNetworkTestCase(unittest.TestCase):
+
+    def test_creates_default_network_with_the_default_cidr(self):
+        networks = _NetworkRecorder()
+        service = BaseNetworkService(_FakeProvider(networks))
+
+        # Patched away from the built-in so that a hardcoded 10.0.0.0/16 in
+        # the service cannot pass by coincidence.
+        with mock.patch.object(BaseNetwork, 'CB_DEFAULT_IPV4RANGE',
+                               '192.168.0.0/16'):
+            service.get_or_create_default()
+
+        self.assertEqual(
+            networks.created,
+            [(BaseNetwork.CB_DEFAULT_NETWORK_LABEL, '192.168.0.0/16')],
+            "The default network must be created with the configured default "
+            "CIDR, not a hardcoded one.")
+
+    def test_returns_the_existing_default_network_without_creating(self):
+        networks = _NetworkRecorder(existing=["existing-net"])
+        service = BaseNetworkService(_FakeProvider(networks))
+
+        self.assertEqual(service.get_or_create_default(), "existing-net")
+        self.assertEqual(networks.created, [])
+        self.assertEqual(networks.find_labels,
+                         [BaseNetwork.CB_DEFAULT_NETWORK_LABEL])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Stacked on #343 — targets `iter-content-chunk-size`, so the diff here is the one commit on top. Retarget to `main` once #343 merges.

## Problem

`BaseNetworkService.get_or_create_default` created the default network with a hardcoded CIDR:

```python
return self.provider.networking.networks.create(
    BaseNetwork.CB_DEFAULT_NETWORK_LABEL, '10.0.0.0/16')
```

So `CB_DEFAULT_IPV4RANGE` had no effect on Azure and OpenStack, which inherit this implementation. AWS and GCP override `get_or_create_default` and read the constant, so the setting worked there — which is what made the gap easy to miss.

## Change

Pass `BaseNetwork.CB_DEFAULT_IPV4RANGE`. One line.

## Tests

AWS and GCP overriding the method is also why the existing networking suite cannot catch this: the mock provider used in CI is AWS-backed, so the base implementation never runs. `tests/test_default_network.py` exercises it directly against fakes, covering both branches — the create path asserts against a CIDR patched away from the built-in, so a hardcoded `10.0.0.0/16` cannot pass by coincidence. Confirmed it fails without the fix and passes with it.

---

This PR originally also made the `CB_MULTIPART_*` / `CB_ITER_CHUNK_SIZE` settings resolve their environment variable per call rather than at import. That has been dropped: those settings already resolve through `_get_config_value`, so they were provider-configurable already, and reading the environment once at import is the normal convention for process-start configuration. Making the environment outrank the class attribute only served to make five existing tests environment-dependent, which then needed a shared helper to contain.
