### PR TITLE
Instrument the cloud suites to find where the AWS time goes

### DIFF
--- a/.github/workflows/integration-cloud.yaml
+++ b/.github/workflows/integration-cloud.yaml
@@ -110,6 +110,7 @@ jobs:
           # cell that needs it. Limits blast radius if a single cell is
           # compromised.
           # aws — credentials supplied via the OIDC step above
+          CB_IMAGE_AWS: ${{ matrix.cloud-provider == 'aws' && secrets.CB_IMAGE_AWS || '' }}
           CB_VM_TYPE_AWS: ${{ matrix.cloud-provider == 'aws' && secrets.CB_VM_TYPE_AWS || '' }}
           # azure
           AZURE_CLIENT_ID: ${{ matrix.cloud-provider == 'azure' && secrets.AZURE_CLIENT_ID || '' }}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,6 +9,7 @@ rather than the test as a whole.
 
 Set CB_TEST_TRACE=1 to capture, per xdist worker:
 
+
 * every ``wait_for`` poll, which brackets each wait - the span from a wait's
   first poll to its last is the wait itself, and the gap between consecutive
   polls shows whether the state call is slow (the interval is 1s for real
@@ -22,8 +23,15 @@ captures stderr at file-descriptor level, and captured output is discarded
 for passing tests - which these are. tox prints the files once the run
 finishes.
 
+CB_TEST_TRACE=2 additionally logs one line per boto invocation. Level 1
+answers whether time is going into polling or into throttled retries; when
+the answer is neither - as it was for test_create_and_list_image, where 1184
+of 1400 seconds passed in a single stretch with no polls and no retries at
+all - level 2 is what names the call that blocked, since the gap between two
+consecutive request lines is that request.
+
 Deliberately opt-in: at a 1s poll interval a 30 minute wait is ~1800 lines
-for a single waiting resource.
+for a single waiting resource, and level 2 is roughly 20x that again.
 """
 import logging
 import os
@@ -31,9 +39,19 @@ import os
 TRACE_FILE_PREFIX = 'cb-trace-'
 
 
-def _tracing_requested():
-    return (os.environ.get('CB_TEST_TRACE') or '').lower() in (
-        '1', 'true', 'yes')
+def _trace_level():
+    """
+    0 off; 1 waits and retries; 2 also every provider request.
+
+    Level 1 answers "is the time going into polling, or into throttled
+    retries" - it is cheap enough to leave on. Level 2 additionally logs each
+    boto invocation, so the gap between two consecutive lines names the call
+    that blocked; that is what level 1 cannot show, at perhaps 20x the volume.
+    """
+    raw = (os.environ.get('CB_TEST_TRACE') or '').lower()
+    if raw in ('2', 'requests', 'all'):
+        return 2
+    return 1 if raw in ('1', 'true', 'yes') else 0
 
 
 def _trace_path():
@@ -43,32 +61,41 @@ def _trace_path():
     return '{0}{1}.log'.format(TRACE_FILE_PREFIX, worker)
 
 
-class _WaitAndRetryOnly(logging.Filter):
+class _TraceFilter(logging.Filter):
     """
-    Keep the poll lines, the test markers and the retries; drop the rest.
+    Keep the test markers, the poll lines and genuine retries; at level 2
+    keep the provider request lines too, and drop everything else.
 
-    cloudbridge at DEBUG is far too chatty to keep wholesale - most of the
-    volume is per-request logging from the provider helpers, which says
-    nothing about where a wait went.
+    cloudbridge at DEBUG is far too chatty to keep wholesale - roughly 20x
+    the volume - and most of it says nothing about where the time went.
     """
+
+    def __init__(self, level):
+        super(_TraceFilter, self).__init__()
+        self.level = level
 
     def filter(self, record):
         message = record.getMessage()
         if record.name.startswith('botocore'):
-            # botocore logs a line per request either way; only the ones
-            # where it actually backed off say anything about throttling.
-            return not message.startswith('Not retrying')
+            # botocore logs a line per request whether or not it retried;
+            # only an actual backoff says anything about throttling. The two
+            # retry implementations word the negative case differently.
+            return not (message.startswith('Not retrying')
+                        or message.startswith('No retry needed'))
+        if record.name.startswith('cloudbridge.providers'):
+            return self.level >= 2
         return message.startswith('=== ') or 'Waiting another' in message
 
 
 def pytest_configure(config):
-    if not _tracing_requested():
+    level = _trace_level()
+    if not level:
         return
 
     handler = logging.FileHandler(_trace_path(), mode='w')
     handler.setFormatter(logging.Formatter(
         '%(asctime)s %(name)s %(message)s'))
-    handler.addFilter(_WaitAndRetryOnly())
+    handler.addFilter(_TraceFilter(level))
 
     # wait_for logs one line per poll at DEBUG, naming the object and the
     # state it is waiting on. Scope the level to that module rather than the
@@ -76,14 +103,17 @@ def pytest_configure(config):
     # provider request build a log record that the filter then discards, and
     # those records still propagate to pytest's own capture handler, which
     # holds them for the duration of the test.
-    waits = logging.getLogger('cloudbridge.base.resources')
-    waits.addHandler(handler)
-    waits.setLevel(logging.DEBUG)
+    loggers = ['cloudbridge.base.resources',
+               # Quiet unless a request is actually retried, which is how
+               # throttling shows up client-side. Enabling botocore wholesale
+               # would log every request and response.
+               'botocore.retries', 'botocore.retryhandler']
+    if level >= 2:
+        # One line per boto invocation, so a stretch with no wait_for polling
+        # can still be attributed to the call that blocked.
+        loggers.append('cloudbridge.providers')
 
-    # Quiet unless a request is actually retried, which is how throttling
-    # shows up client-side. Enabling botocore wholesale would log every
-    # request and response.
-    for name in ('botocore.retries', 'botocore.retryhandler'):
+    for name in loggers:
         target = logging.getLogger(name)
         target.addHandler(handler)
         target.setLevel(logging.DEBUG)
@@ -92,12 +122,12 @@ def pytest_configure(config):
 def pytest_runtest_logstart(nodeid, location):
     # Stamps the trace with test boundaries, so a span of polls can be
     # attributed to the test that caused it.
-    if _tracing_requested():
+    if _trace_level():
         logging.getLogger('cloudbridge.base.resources').debug(
             '=== START %s', nodeid)
 
 
 def pytest_runtest_logfinish(nodeid, location):
-    if _tracing_requested():
+    if _trace_level():
         logging.getLogger('cloudbridge.base.resources').debug(
             '=== END %s', nodeid)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,103 @@
+"""
+Opt-in tracing for the cloud integration suites.
+
+The AWS suite's wall time is dominated by one or two tests, and end-to-end
+timings have proved too noisy to attribute - test_create_and_list_image alone
+has measured 26.2, 60.6 and 33.8 minutes across three runs of the same 123
+tests. Answering *where* that time goes needs the individual waits timed
+rather than the test as a whole.
+
+Set CB_TEST_TRACE=1 to capture, per xdist worker:
+
+* every ``wait_for`` poll, which brackets each wait - the span from a wait's
+  first poll to its last is the wait itself, and the gap between consecutive
+  polls shows whether the state call is slow (the interval is 1s for real
+  providers, so a larger gap is the API, not the sleep);
+* botocore retries, which is how throttling appears client-side. Those
+  loggers stay silent unless a request is actually retried, so anything they
+  emit is signal.
+
+Records go to cb-trace-<worker>.log rather than stderr because pytest
+captures stderr at file-descriptor level, and captured output is discarded
+for passing tests - which these are. tox prints the files once the run
+finishes.
+
+Deliberately opt-in: at a 1s poll interval a 30 minute wait is ~1800 lines
+for a single waiting resource.
+"""
+import logging
+import os
+
+TRACE_FILE_PREFIX = 'cb-trace-'
+
+
+def _tracing_requested():
+    return (os.environ.get('CB_TEST_TRACE') or '').lower() in (
+        '1', 'true', 'yes')
+
+
+def _trace_path():
+    # Each xdist worker needs its own file; they run in one directory and
+    # would otherwise interleave mid-line.
+    worker = os.environ.get('PYTEST_XDIST_WORKER', 'main')
+    return '{0}{1}.log'.format(TRACE_FILE_PREFIX, worker)
+
+
+class _WaitAndRetryOnly(logging.Filter):
+    """
+    Keep the poll lines, the test markers and the retries; drop the rest.
+
+    cloudbridge at DEBUG is far too chatty to keep wholesale - most of the
+    volume is per-request logging from the provider helpers, which says
+    nothing about where a wait went.
+    """
+
+    def filter(self, record):
+        message = record.getMessage()
+        if record.name.startswith('botocore'):
+            # botocore logs a line per request either way; only the ones
+            # where it actually backed off say anything about throttling.
+            return not message.startswith('Not retrying')
+        return message.startswith('=== ') or 'Waiting another' in message
+
+
+def pytest_configure(config):
+    if not _tracing_requested():
+        return
+
+    handler = logging.FileHandler(_trace_path(), mode='w')
+    handler.setFormatter(logging.Formatter(
+        '%(asctime)s %(name)s %(message)s'))
+    handler.addFilter(_WaitAndRetryOnly())
+
+    # wait_for logs one line per poll at DEBUG, naming the object and the
+    # state it is waiting on. Scope the level to that module rather than the
+    # cloudbridge tree: raising the whole tree to DEBUG would have every
+    # provider request build a log record that the filter then discards, and
+    # those records still propagate to pytest's own capture handler, which
+    # holds them for the duration of the test.
+    waits = logging.getLogger('cloudbridge.base.resources')
+    waits.addHandler(handler)
+    waits.setLevel(logging.DEBUG)
+
+    # Quiet unless a request is actually retried, which is how throttling
+    # shows up client-side. Enabling botocore wholesale would log every
+    # request and response.
+    for name in ('botocore.retries', 'botocore.retryhandler'):
+        target = logging.getLogger(name)
+        target.addHandler(handler)
+        target.setLevel(logging.DEBUG)
+
+
+def pytest_runtest_logstart(nodeid, location):
+    # Stamps the trace with test boundaries, so a span of polls can be
+    # attributed to the test that caused it.
+    if _tracing_requested():
+        logging.getLogger('cloudbridge.base.resources').debug(
+            '=== START %s', nodeid)
+
+
+def pytest_runtest_logfinish(nodeid, location):
+    if _tracing_requested():
+        logging.getLogger('cloudbridge.base.resources').debug(
+            '=== END %s', nodeid)

--- a/tests/helpers/__init__.py
+++ b/tests/helpers/__init__.py
@@ -95,21 +95,29 @@ def env_or(varname, default_value):
 
 TEST_DATA_CONFIG = {
     "AWSCloudProvider": {
-        # Ubuntu 24.04 LTS, us-east-1, amd64, gp3 (Canonical, 20260714). AMI
-        # ids are per-region, so a run anywhere but us-east-1 has to set
-        # CB_IMAGE_AWS - as does anyone wanting a different distribution.
+        # Canonical's Ubuntu 16.04, built 2017 - a Xen-era HVM image, and an
+        # AMI id is per-region, so anything but us-east-1 must set
+        # CB_IMAGE_AWS. Kept deliberately, not by inertia:
         #
-        # Being Nitro-era matters: the AWS suite's wall time is dominated by
-        # launching an instance, snapshotting it into an AMI, launching a
-        # second instance from that AMI and stop/start cycling, and all of
-        # those are markedly slower on the Xen-era image this replaced
-        # (Ubuntu 16.04, built 2017). Pair it with a Nitro instance type -
-        # t3.micro or larger - via CB_VM_TYPE_AWS; on a t2.* the gain is
-        # mostly lost, and 24.04 is a tight fit in t2.nano's 512 MB.
+        # The comment that used to sit here said moto needed this value to
+        # match an entry in tests/fixtures/custom_amis.json. That has not been
+        # true since 3fbcba2 removed MOTO_AMIS_PATH from tox.ini - nothing
+        # loads that fixture, and moto does not validate instance-launch AMI
+        # ids, so the mock provider is indifferent to this value.
         #
-        # moto does not validate instance-launch AMI ids, so the mock
-        # provider is indifferent to this value.
-        "image": env_or('CB_IMAGE_AWS', 'ami-052355af2a014bd2c'),
+        # With that constraint gone the obvious move was a current image, on
+        # the theory that the suite's wall time - dominated by launching an
+        # instance, snapshotting it into an AMI, launching a second instance
+        # from it, and stop/start cycling - is paying a Xen-era penalty.
+        # Measured against Ubuntu 24.04 (ami-052355af2a014bd2c), it got
+        # worse: test_create_and_list_image went 26.2 -> 33.8 min and
+        # test_instance_start_stop_methods 20.3 -> 29.1 min. Plausibly the
+        # larger image costs more to snapshot while CB_VM_TYPE_AWS stays on a
+        # pre-Nitro type, so there is no launch saving to offset it. Worth
+        # revisiting only alongside a Nitro instance type, and note the same
+        # test has measured 26.2, 60.6 and 33.8 min across three runs, so a
+        # single run cannot resolve a difference this size either way.
+        "image": env_or('CB_IMAGE_AWS', 'ami-aa2ea6d0'),
         "vm_type": env_or('CB_VM_TYPE_AWS', 't2.nano'),
         "placement": env_or('CB_PLACEMENT_AWS', 'us-east-1a'),
         "placement_cfg_key": "aws_zone_name"

--- a/tests/helpers/__init__.py
+++ b/tests/helpers/__init__.py
@@ -81,7 +81,12 @@ def skipIfPython(op, major, minor):
 
 TEST_DATA_CONFIG = {
     "AWSCloudProvider": {
-        # Match the ami value with entry in custom_amis.json for use with moto
+        # This default exists for the mock provider only - it matches an entry
+        # in custom_amis.json so moto can resolve it. It is Ubuntu 16.04 built
+        # in 2017, a Xen-era HVM image, and launching, imaging and stop/start
+        # cycling it against real EC2 is markedly slower than a current
+        # Nitro-compatible image. Runs against real AWS should set
+        # CB_IMAGE_AWS, as the other providers' suites set their CB_IMAGE_*.
         "image": cb_helpers.get_env('CB_IMAGE_AWS', 'ami-aa2ea6d0'),
         "vm_type": cb_helpers.get_env('CB_VM_TYPE_AWS', 't2.nano'),
         "placement": cb_helpers.get_env('CB_PLACEMENT_AWS', 'us-east-1a'),

--- a/tests/helpers/__init__.py
+++ b/tests/helpers/__init__.py
@@ -81,13 +81,21 @@ def skipIfPython(op, major, minor):
 
 TEST_DATA_CONFIG = {
     "AWSCloudProvider": {
-        # This default exists for the mock provider only - it matches an entry
-        # in custom_amis.json so moto can resolve it. It is Ubuntu 16.04 built
-        # in 2017, a Xen-era HVM image, and launching, imaging and stop/start
-        # cycling it against real EC2 is markedly slower than a current
-        # Nitro-compatible image. Runs against real AWS should set
-        # CB_IMAGE_AWS, as the other providers' suites set their CB_IMAGE_*.
-        "image": cb_helpers.get_env('CB_IMAGE_AWS', 'ami-aa2ea6d0'),
+        # Ubuntu 24.04 LTS, us-east-1, amd64, gp3 (Canonical, 20260714). AMI
+        # ids are per-region, so a run anywhere but us-east-1 has to set
+        # CB_IMAGE_AWS - as does anyone wanting a different distribution.
+        #
+        # Being Nitro-era matters: the AWS suite's wall time is dominated by
+        # launching an instance, snapshotting it into an AMI, launching a
+        # second instance from that AMI and stop/start cycling, and all of
+        # those are markedly slower on the Xen-era image this replaced
+        # (Ubuntu 16.04, built 2017). Pair it with a Nitro instance type -
+        # t3.micro or larger - via CB_VM_TYPE_AWS; on a t2.* the gain is
+        # mostly lost, and 24.04 is a tight fit in t2.nano's 512 MB.
+        #
+        # moto does not validate instance-launch AMI ids, so the mock
+        # provider is indifferent to this value.
+        "image": cb_helpers.get_env('CB_IMAGE_AWS', 'ami-052355af2a014bd2c'),
         "vm_type": cb_helpers.get_env('CB_VM_TYPE_AWS', 't2.nano'),
         "placement": cb_helpers.get_env('CB_PLACEMENT_AWS', 'us-east-1a'),
         "placement_cfg_key": "aws_zone_name"

--- a/tests/helpers/__init__.py
+++ b/tests/helpers/__init__.py
@@ -79,6 +79,20 @@ def skipIfPython(op, major, minor):
     return wrap
 
 
+def env_or(varname, default_value):
+    """
+    Environment variable ``varname``, treating unset and empty alike.
+
+    The cloud workflow sets every CB_* variable in every matrix cell, as
+    ``${{ matrix.cloud-provider == '<x>' && secrets.<VAR> || '' }}``, so a
+    variable belonging to another cell - or one whose secret is simply not
+    configured - arrives as an empty string rather than absent. A plain
+    ``os.environ.get`` hands that empty string straight back, silently
+    blanking the test data instead of falling back to the default.
+    """
+    return cb_helpers.get_env(varname) or default_value
+
+
 TEST_DATA_CONFIG = {
     "AWSCloudProvider": {
         # Ubuntu 24.04 LTS, us-east-1, amd64, gp3 (Canonical, 20260714). AMI
@@ -95,33 +109,33 @@ TEST_DATA_CONFIG = {
         #
         # moto does not validate instance-launch AMI ids, so the mock
         # provider is indifferent to this value.
-        "image": cb_helpers.get_env('CB_IMAGE_AWS', 'ami-052355af2a014bd2c'),
-        "vm_type": cb_helpers.get_env('CB_VM_TYPE_AWS', 't2.nano'),
-        "placement": cb_helpers.get_env('CB_PLACEMENT_AWS', 'us-east-1a'),
+        "image": env_or('CB_IMAGE_AWS', 'ami-052355af2a014bd2c'),
+        "vm_type": env_or('CB_VM_TYPE_AWS', 't2.nano'),
+        "placement": env_or('CB_PLACEMENT_AWS', 'us-east-1a'),
         "placement_cfg_key": "aws_zone_name"
     },
     'OpenStackCloudProvider': {
-        'image': cb_helpers.get_env('CB_IMAGE_OS',
-                                    'c66bdfa1-62b1-43be-8964-e9ce208ac6a5'),
-        "vm_type": cb_helpers.get_env('CB_VM_TYPE_OS', 'm1.tiny'),
-        "placement": cb_helpers.get_env('CB_PLACEMENT_OS', 'nova'),
+        'image': env_or('CB_IMAGE_OS',
+                        'c66bdfa1-62b1-43be-8964-e9ce208ac6a5'),
+        "vm_type": env_or('CB_VM_TYPE_OS', 'm1.tiny'),
+        "placement": env_or('CB_PLACEMENT_OS', 'nova'),
         "placement_cfg_key": "os_zone_name"
     },
     'GCPCloudProvider': {
-        'image': cb_helpers.get_env(
+        'image': env_or(
             'CB_IMAGE_GCP',
             'https://www.googleapis.com/compute/v1/projects/ubuntu-os-cloud/'
             'global/images/ubuntu-1804-bionic-v20200908'),
-        'vm_type': cb_helpers.get_env('CB_VM_TYPE_GCP', 'f1-micro'),
-        'placement': cb_helpers.get_env('GCP_ZONE_NAME', 'us-central1-a'),
+        'vm_type': env_or('CB_VM_TYPE_GCP', 'f1-micro'),
+        'placement': env_or('GCP_ZONE_NAME', 'us-central1-a'),
         "placement_cfg_key": "gcp_zone_name"
     },
     "AzureCloudProvider": {
         "image":
-            cb_helpers.get_env('CB_IMAGE_AZURE',
-                               'Canonical:0001-com-ubuntu-minimal-jammy:minimal-22_04-lts-gen2:latest'),
-        "vm_type": cb_helpers.get_env('CB_VM_TYPE_AZURE', 'Standard_DC1ds_v3'),
-        "placement": cb_helpers.get_env('CB_PLACEMENT_AZURE', 'eastus'),
+            env_or('CB_IMAGE_AZURE',
+                   'Canonical:0001-com-ubuntu-minimal-jammy:minimal-22_04-lts-gen2:latest'),
+        "vm_type": env_or('CB_VM_TYPE_AZURE', 'Standard_DC1ds_v3'),
+        "placement": env_or('CB_PLACEMENT_AZURE', 'eastus'),
         "placement_cfg_key": "azure_zone_name"
     }
 }

--- a/tox.ini
+++ b/tox.ini
@@ -28,15 +28,6 @@ setenv =
     # Fix for moto import issue: https://github.com/travis-ci/travis-ci/issues/7940
     BOTO_CONFIG=/dev/null
     aws: CB_TEST_PROVIDER=aws
-    # DIAGNOSTIC - REMOVE BEFORE MERGING. Turns on the wait/retry tracing
-    # described in tests/conftest.py for the AWS suite. It lives here rather
-    # than in the workflow env because the cloud workflow triggers on
-    # pull_request_target, so its definition comes from the base branch and a
-    # PR cannot change it; tox.ini is checked out from the PR head and can.
-    # Level 2 also logs each boto invocation. Level 1 already showed the AWS
-    # image test spends 1184 of its 1400 seconds in one stretch with no
-    # polling and no retries, so the remaining question is which call blocks.
-    aws: CB_TEST_TRACE=2
     azure: CB_TEST_PROVIDER=azure
     gcp: CB_TEST_PROVIDER=gcp
     openstack: CB_TEST_PROVIDER=openstack

--- a/tox.ini
+++ b/tox.ini
@@ -33,7 +33,10 @@ setenv =
     # than in the workflow env because the cloud workflow triggers on
     # pull_request_target, so its definition comes from the base branch and a
     # PR cannot change it; tox.ini is checked out from the PR head and can.
-    aws: CB_TEST_TRACE=1
+    # Level 2 also logs each boto invocation. Level 1 already showed the AWS
+    # image test spends 1184 of its 1400 seconds in one stretch with no
+    # polling and no retries, so the remaining question is which call blocks.
+    aws: CB_TEST_TRACE=2
     azure: CB_TEST_PROVIDER=azure
     gcp: CB_TEST_PROVIDER=gcp
     openstack: CB_TEST_PROVIDER=openstack

--- a/tox.ini
+++ b/tox.ini
@@ -10,7 +10,15 @@ envlist = py3{.10,.13}-{aws,azure,gcp,openstack,mock},lint,mypy
 
 [testenv]
 commands = # see pyproject.toml for coverage options; setup.cfg for flake8
-           coverage run --source=cloudbridge -m pytest -v {posargs:-n 5 tests/}
+           # --durations reports the slowest tests with their setup/teardown.
+           # The cloud suites' wall time is set by one or two long tests, and
+           # this is the authoritative record of which - the alternative is
+           # inferring it from gaps between result lines in the CI log, which
+           # cannot separate a slow test from a worker waiting for work.
+           coverage run --source=cloudbridge -m pytest -v --durations=25 {posargs:-n 5 tests/}
+           # Emit any CB_TEST_TRACE output (see tests/conftest.py). A no-op
+           # when tracing is off, which is the default.
+           python -c "import glob,sys;[sys.stdout.write(open(f).read()) for f in sorted(glob.glob('cb-trace-*.log'))]"
            # Combine parallel-mode data files and emit Cobertura XML for upload
            # by coverallsapp/github-action in CI. Locally this produces
            # coverage.xml in the project root, which IDEs can also consume.
@@ -20,6 +28,12 @@ setenv =
     # Fix for moto import issue: https://github.com/travis-ci/travis-ci/issues/7940
     BOTO_CONFIG=/dev/null
     aws: CB_TEST_PROVIDER=aws
+    # DIAGNOSTIC - REMOVE BEFORE MERGING. Turns on the wait/retry tracing
+    # described in tests/conftest.py for the AWS suite. It lives here rather
+    # than in the workflow env because the cloud workflow triggers on
+    # pull_request_target, so its definition comes from the base branch and a
+    # PR cannot change it; tox.ini is checked out from the PR head and can.
+    aws: CB_TEST_TRACE=1
     azure: CB_TEST_PROVIDER=azure
     gcp: CB_TEST_PROVIDER=gcp
     openstack: CB_TEST_PROVIDER=openstack
@@ -28,6 +42,10 @@ setenv =
     COVERAGE_FILE=.coverage.{envname}
 passenv =
     PYTHONUNBUFFERED
+    # Set to 1 to log every wait_for poll and every botocore retry, for
+    # working out where a slow cloud suite is actually spending its time.
+    # See tests/conftest.py; verbose by design, so opt-in.
+    CB_TEST_TRACE
     aws: CB_IMAGE_AWS
     aws: CB_VM_TYPE_AWS
     aws: CB_PLACEMENT_AWS


### PR DESCRIPTION
Off `main`, independent of #343 and #344.

## What this is now

This started as an attempt to fix the AWS suite's runtime by modernising the test image. **That was measured and it made things worse**, so the image change is reverted and what remains is the instrumentation needed to answer the question properly, plus two real bug fixes found on the way.

## The measurements

Per-test durations from the timestamped Actions logs, same 123 tests each run:

| test | Aug 2 (4.3.1, Ubuntu 16.04) | Aug 20 (#343 run) | Aug 20 (Ubuntu 24.04) |
|---|---|---|---|
| `test_create_and_list_image` | 26.2 min | 60.6 min | **33.8 min** |
| `test_instance_start_stop_methods` | 20.3 min | 1.3 min | **29.1 min** |
| `test_create_wildcard_dns_record` | 0.9 min | 56.6 min | **0.9 min** |
| suite wall | 26.3 min | 60.8 min | 33.9 min |

Three things fall out:

1. **The suite is one or two tests.** `test_create_and_list_image` starts first and runs until the end; three of five workers finish inside 6 minutes and idle. Total work across workers is ~65 min but the longest single test is 26–34, so parallelism is already saturated and no scheduling change can move the floor.
2. **Ubuntu 24.04 was slower.** Plausibly a larger image costs more to snapshot while `CB_VM_TYPE_AWS` stays on a pre-Nitro type (that secret was last set in 2022), so there is no launch saving to offset it. Reverted.
3. **End-to-end timing cannot settle this.** The same test has measured 26.2, 60.6 and 33.8 minutes. A single run cannot resolve a 30% difference in either direction, and the 60.6 outlier was a bad Route53 day, not the image.

The 24.04 run did genuinely exercise the new image, incidentally: the workflow triggers on `pull_request_target`, so its definition comes from the base branch and the `CB_IMAGE_AWS` wiring was inert — but `tests/` is checked out from the PR head, so the default applied.

(The obvious first suspect, VM type listings, was already fixed in #342. That whole file now costs 39.8 s.)

## What this PR does

**Instrumentation.** `--durations=25` in tox, always on — authoritative per-test timings, replacing inference from gaps between result lines in the CI log, which cannot tell a slow test from a worker waiting for work. And `CB_TEST_TRACE=1` (see `tests/conftest.py`) records every `wait_for` poll and every genuine botocore retry, per xdist worker, with tox printing the files afterwards. The span from a wait's first poll to its last is the wait; a gap wider than the 1 s interval means the API call itself is slow, which is what throttling looks like client-side.

Two mechanics worth flagging for review:

- Records go to files, not stderr. pytest captures stderr at fd level and **discards it for passing tests**, so the first attempt at this produced nothing at all.
- The filter is load-bearing. Unfiltered `cloudbridge` at DEBUG was 557 KB from two test files, and `botocore.retries.standard` logs `Not retrying request.` on every single request. Filtered to poll lines, test markers and real retries, the same run produces 453 bytes.
- `CB_TEST_TRACE=1` is set in `tox.ini`, not the workflow env, because `pull_request_target` means a PR cannot change the workflow. **That setenv line is diagnostic and marked for removal before merge.**

**Bug fix: an unset `CB_*` secret arrived as an empty string.** The workflow sets every `CB_*` variable in every matrix cell as `${{ ... || '' }}`, so a variable whose secret is not configured is exported empty rather than absent. `get_env` is `os.environ.get`, which returns that empty string in preference to the default — blanking the test data instead of falling back. Wiring `CB_IMAGE_AWS` in made this reachable, since no such secret exists; the other providers escape it only because their secrets happen to be set.

**`CB_IMAGE_AWS` wiring**, kept so the secret can take effect if you do set one.

**Documentation on the default**, recording what was tried and measured so the next person doesn't repeat it — including that the constraint the old comment cited (moto needing the id to match `tests/fixtures/custom_amis.json`) has not existed since `3fbcba2` removed `MOTO_AMIS_PATH` from tox.ini. Nothing loads that fixture, and moto does not validate instance-launch AMI ids. It is dead weight and a candidate for deletion.

Mock suite unchanged throughout: 117 passed, 6 skipped.

## What the next run should show

If the time is a handful of long AWS-side waits, that is a real floor and the fix is changing what those tests do — most obviously the second instance launch inside `test_create_and_list_image`, which exists to prove the created AMI boots and costs a full instance lifecycle.

If instead it is spread across polls that each take far longer than their 1 s interval, the cause is client-side: five xdist workers each polling `wait_for` every second is a lot of sustained EC2 API traffic, and throttled polls with botocore backoff would stretch waits unevenly depending on how many long waits overlap — which would also explain why the same test swings between 26 and 61 minutes.

## Still open, unrelated to the image

On the #343 run, `test_create_wildcard_dns_record` took **56.6 minutes** against 56 *seconds* at baseline. The Route53 waiter is `{'Delay': 5, 'MaxAttempts': 360}` — a 30 minute ceiling — and that test does two `resource_record_sets_changed` waits, so it burned nearly both and came within ~2 minutes of raising `WaiterError` and failing the job. Same config as the baseline run, and nothing here touches DNS, so it is Route53-side. Worth deciding separately whether a 30 minute ceiling is still the right call, since a bad Route53 day can put the job an hour over or break it outright.
