### PR TITLE
Declare cryptography as a dependency, and guard bare installs

### DIFF
--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -63,6 +63,54 @@ jobs:
       - name: Run mypy
         run: tox -e mypy
 
+  bare-install:
+    name: Bare install imports
+    runs-on: ubuntu-latest
+    # Every test environment installs the [dev] extra, which drags in the
+    # provider SDKs and their transitive dependencies, so the suite passes
+    # happily against a package whose declared dependencies are incomplete.
+    # cloudbridge 4.3.1 and 4.4.0 both shipped unable to import
+    # cloudbridge.base.resources from a plain `pip install cloudbridge`,
+    # because base.helpers imports cryptography at module scope and nothing
+    # declared it. Install the built wheel on its own and import the modules
+    # a user reaches for first.
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - name: Setup Python
+        uses: actions/setup-python@v6
+        with:
+          # The floor, since a missing dependency is likelier to be satisfied
+          # by chance on a newer interpreter's richer wheel set.
+          python-version: '3.10'
+
+      - name: Build the distributions
+        run: |
+          pip install build
+          python -m build
+
+      - name: Install the wheel with no extras
+        run: pip install dist/*.whl
+
+      - name: Import without the repo on sys.path
+        # Run from elsewhere: the working directory is the repo root, and
+        # Python would import the source tree in preference to the wheel,
+        # which hides exactly the failure this job exists to catch.
+        working-directory: /tmp
+        run: |
+          python -c "
+          import cloudbridge
+          from cloudbridge.base.resources import BaseBucketObject
+          from cloudbridge.base.helpers import generate_key_pair
+          from cloudbridge.factory import CloudProviderFactory
+          public, _ = generate_key_pair()
+          assert public.startswith('ssh-rsa'), public[:32]
+          print('cloudbridge', cloudbridge.get_version(), 'imports from a bare install')
+          "
+
   mock:
     name: Mock-provider tests
     runs-on: ubuntu-latest

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,27 @@
+4.4.1 - unreleased
+------------------
+
+## Fixes
+* **``cryptography`` is now declared as a dependency.**
+  ``cloudbridge.base.helpers`` imports it at module scope, and almost
+  everything imports that module, so it was required for the library to
+  import at all - but it appeared nowhere in ``pyproject.toml``. A plain
+  ``pip install cloudbridge`` therefore produced an installation that raised
+  ``ModuleNotFoundError: No module named 'cryptography'`` on
+  ``import cloudbridge.base.resources``, as did ``cloudbridge[aws]``, since
+  boto3 does not depend on it either. Installations that worked did so
+  because something else in the environment happened to provide it. This
+  affected 4.4.0 and earlier; the import has been there since 2019.
+
+## Build and CI
+* **A new ``Bare install imports`` job builds the wheel, installs it with no
+  extras, and imports the modules a user reaches for first.** Every test
+  environment installs the ``[dev]`` extra, which pulls in the provider SDKs
+  and their transitive dependencies, so the suite passed against a package
+  whose declared dependencies were incomplete. The job runs from outside the
+  repository, so the source tree cannot satisfy the import in place of the
+  installed wheel.
+
 4.4.0 - August 21, 2026 (sha 55d925d56eaad247b960ad00e636253637192549)
 ----------------------------------------------------------------------
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,11 @@ classifiers = [
 dependencies = [
     "tenacity>=6.0",
     "pyeventsystem<2",
+    # Imported at module scope by cloudbridge.base.helpers, which almost
+    # everything else imports, so it is required for the library to import at
+    # all - not just for generate_key_pair, which is what actually uses it.
+    # Kept unpinned above the floor, per the general-purpose library policy.
+    "cryptography>=3.4",
 ]
 dynamic = ["version"]
 


### PR DESCRIPTION
Off `main`, for 4.4.1. Found while verifying the 4.4.0 artifact before publishing.

## The bug

`cloudbridge.base.helpers` imports `cryptography` at module scope, and almost everything imports that module — so it is required for the library to import at all. Only `generate_key_pair` actually calls it, but the import runs regardless. It appeared nowhere in `pyproject.toml`.

A plain `pip install cloudbridge` therefore produced an installation that could not import `cloudbridge.base.resources`, and so could not do anything:

```
ModuleNotFoundError: No module named 'cryptography'
```

`cloudbridge[aws]` fails the same way — boto3 does not depend on `cryptography` either. Verified from clean virtualenvs:

| install | result |
|---|---|
| `cloudbridge==4.4.0` | `ModuleNotFoundError` |
| `cloudbridge[aws]==4.4.0` | `ModuleNotFoundError` |
| `cloudbridge[aws]==4.3.1` | `ModuleNotFoundError` |

Installations that work do so because something else in the environment happens to provide it — Galaxy, or an azure/openstack install, which genuinely depend on it. The import has been there since `952e1a2`, in 2019, so this is long-standing rather than new.

## The fix

Declare it. The comment beside the entry records *why* it is a core dependency and not an extra, since only one function uses it and a later tidy-up would otherwise reasonably move it.

Kept unpinned above a floor, per the release guide's policy of keeping general-purpose libraries as unrestricted as possible. `3.4` is the floor rather than something newer because the APIs used — `rsa.generate_private_key`, `PrivateFormat.PKCS8`, `PublicFormat.OpenSSH` — have been stable well below it.

## Why the tests did not catch it, and the guard

**Nothing in the suite could have.** Every test environment installs the `[dev]` extra, which pulls in the provider SDKs and their transitive dependencies, so the suite passes happily against a package that cannot be installed and used. The tests exercise the source tree, never the artifact.

The new `Bare install imports` job builds the wheel, installs it **with no extras**, and imports what a user reaches for first, including generating a key pair so the `cryptography` path is actually executed rather than merely imported.

Two details that matter, both learned the hard way:

- **It runs from outside the repository.** The working directory is the repo root, and Python imports the source tree in preference to the installed wheel — which hides exactly the failure the job exists to catch. My first attempt at reproducing this locally was invalid for that reason, and reported a traceback from the working copy.
- **It runs on 3.10**, the floor, since a missing dependency is likelier to be satisfied by chance on a newer interpreter's richer wheel set.

Confirmed the guard **fails** against the published 4.4.0 wheel and **passes** against this one — a guard that cannot fail would be worse than none.

## Not done here

The version is left at 4.4.0; the release guide bumps it in the release commit.

An alternative fix would be to move the import inside `generate_key_pair`, keeping the core install dependency-light. I did not, because it changes behaviour — a missing `cryptography` would then fail at key-pair creation rather than at import — and declaring what you import at module scope is the more honest fix. Worth a second opinion if you would rather go the other way; the guard is useful either way.
